### PR TITLE
Add preset system, per-monitor targeting, and global hotkeys

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,3 +7,4 @@ auto-py-to-exe
 PyOpenGL
 PyOpenGL_accelerate
 numpy
+pynput

--- a/frontengine/ui/main_ui.py
+++ b/frontengine/ui/main_ui.py
@@ -25,6 +25,7 @@ from frontengine.ui.page.web.web_setting_ui import WEBSettingUI
 from frontengine.user_setting.user_setting_file import write_user_setting, read_user_setting, user_setting_dict
 from frontengine.utils.critical_exit.critical_exit import CriticalExit
 from frontengine.utils.critical_exit.win32_vk import keyboard_keys_table
+from frontengine.utils.hotkey.hotkey_service import HotkeyService
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
 # 可擴充的外部 Tab 註冊表
@@ -123,6 +124,11 @@ class FrontEngineMainUI(QMainWindow):
         self.critical_ext.set_critical_key(keyboard_keys_table.get("f12"))
         self.critical_ext.init_critical_exit()
 
+        # 全域快速鍵 / Global hotkeys
+        self.hotkey_service = HotkeyService({"<ctrl>+<shift>+<f12>": "close_all"})
+        self.hotkey_service.hotkey_triggered.connect(self._handle_hotkey)
+        self.hotkey_service.start()
+
         # 設定 Icon 與系統托盤
         # Set icon and system tray
         self._setup_icon(show_system_tray_ray)
@@ -189,8 +195,18 @@ class FrontEngineMainUI(QMainWindow):
         else:
             super().closeEvent(event)
 
+    def _handle_hotkey(self, action: str) -> None:
+        """
+        分派全域快速鍵到對應動作。
+        Dispatch global hotkey to the matching action on the UI thread.
+        """
+        if action == "close_all":
+            self.control_center_ui.clear_all()
+
     def close(self) -> None:
         """關閉程式並清理資源 / Close application and clear resources"""
+        if getattr(self, "hotkey_service", None) is not None:
+            self.hotkey_service.stop()
         write_user_setting()
         self.video_setting_ui.video_widget_list.clear()
         self.image_setting_ui.image_widget_list.clear()

--- a/frontengine/ui/main_ui.py
+++ b/frontengine/ui/main_ui.py
@@ -12,6 +12,7 @@ from frontengine.system_tray.extend_system_tray import ExtendSystemTray
 from frontengine.ui.menu.help_menu import build_help_menu
 from frontengine.ui.menu.how_to_menu import build_how_to_menu
 from frontengine.ui.menu.language_menu import build_language_menu
+from frontengine.ui.menu.preset_menu import build_preset_menu
 from frontengine.ui.page.control_center.control_center_ui import ControlCenterUI
 from frontengine.ui.page.gif.gif_setting_ui import GIFSettingUI
 from frontengine.ui.page.image.image_setting_ui import ImageSettingUI
@@ -114,6 +115,7 @@ class FrontEngineMainUI(QMainWindow):
         build_language_menu(self)
         build_help_menu(self)
         build_how_to_menu(self)
+        build_preset_menu(self)
 
         # 致命退出設定
         # Critical exit setting

--- a/frontengine/ui/menu/preset_menu.py
+++ b/frontengine/ui/menu/preset_menu.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QInputDialog, QMessageBox
+
+from frontengine.user_setting.preset_repository import PresetRepository
+from frontengine.utils.logging.loggin_instance import front_engine_logger
+from frontengine.utils.multi_language.language_wrapper import language_wrapper
+
+if TYPE_CHECKING:
+    from frontengine.ui.main_ui import FrontEngineMainUI
+
+
+_PRESET_PAGES = (
+    ("video", "video_setting_ui"),
+    ("image", "image_setting_ui"),
+    ("web", "web_setting_ui"),
+    ("gif", "gif_setting_ui"),
+    ("sound", "sound_player_setting_ui"),
+    ("text", "text_setting_ui"),
+    ("particle", "particle_setting_ui"),
+)
+
+
+def _t(key: str, fallback: str) -> str:
+    return language_wrapper.language_word_dict.get(key, fallback)
+
+
+def _collect_state(ui: "FrontEngineMainUI") -> dict:
+    state: dict = {}
+    for name, attribute in _PRESET_PAGES:
+        page = getattr(ui, attribute, None)
+        if page is not None and hasattr(page, "get_state"):
+            state[name] = page.get_state()
+    return state
+
+
+def _apply_state(ui: "FrontEngineMainUI", state: dict) -> None:
+    for name, attribute in _PRESET_PAGES:
+        page = getattr(ui, attribute, None)
+        section = state.get(name)
+        if page is not None and isinstance(section, dict) and hasattr(page, "set_state"):
+            page.set_state(section)
+
+
+def _pick_preset(ui: "FrontEngineMainUI", title: str) -> str:
+    repository = PresetRepository()
+    presets = repository.list_presets()
+    if not presets:
+        QMessageBox.information(ui, title, _t("preset_no_presets", "No presets saved yet."))
+        return ""
+    preset, ok = QInputDialog.getItem(ui, title, _t("preset_pick_label", "Preset:"), presets, 0, False)
+    if not ok or not preset:
+        return ""
+    return preset
+
+
+def _save_action(ui: "FrontEngineMainUI") -> Callable[[], None]:
+    def handler() -> None:
+        front_engine_logger.info("[PresetMenu] save")
+        name, ok = QInputDialog.getText(
+            ui,
+            _t("preset_save_title", "Save preset"),
+            _t("preset_save_label", "Preset name:"),
+        )
+        if not ok or not name.strip():
+            return
+        try:
+            PresetRepository().save(name.strip(), _collect_state(ui))
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(ui, _t("preset_save_title", "Save preset"), str(error))
+            return
+        QMessageBox.information(
+            ui,
+            _t("preset_save_title", "Save preset"),
+            _t("preset_saved", "Preset saved."),
+        )
+
+    return handler
+
+
+def _load_action(ui: "FrontEngineMainUI") -> Callable[[], None]:
+    def handler() -> None:
+        front_engine_logger.info("[PresetMenu] load")
+        title = _t("preset_load_title", "Load preset")
+        preset = _pick_preset(ui, title)
+        if not preset:
+            return
+        try:
+            data = PresetRepository().load(preset)
+        except (OSError, FileNotFoundError, ValueError) as error:
+            QMessageBox.warning(ui, title, str(error))
+            return
+        _apply_state(ui, data)
+        QMessageBox.information(ui, title, _t("preset_loaded", "Preset loaded."))
+
+    return handler
+
+
+def _delete_action(ui: "FrontEngineMainUI") -> Callable[[], None]:
+    def handler() -> None:
+        front_engine_logger.info("[PresetMenu] delete")
+        title = _t("preset_delete_title", "Delete preset")
+        preset = _pick_preset(ui, title)
+        if not preset:
+            return
+        confirm = QMessageBox.question(
+            ui,
+            title,
+            _t("preset_delete_confirm", "Delete preset '{name}'?").format(name=preset),
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+        try:
+            PresetRepository().delete(preset)
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(ui, title, str(error))
+
+    return handler
+
+
+def build_preset_menu(ui: "FrontEngineMainUI") -> None:
+    """
+    Build the Presets menu with Save / Load / Delete actions.
+    """
+    front_engine_logger.info(f"[PresetMenu] build_preset_menu | ui={ui}")
+    menu = ui.menu_bar.addMenu(_t("menu_bar_presets", "Presets"))
+    ui.preset_menu = menu
+
+    for label_key, fallback, callback_factory in (
+        ("preset_menu_save", "Save preset...", _save_action),
+        ("preset_menu_load", "Load preset...", _load_action),
+        ("preset_menu_delete", "Delete preset...", _delete_action),
+    ):
+        action = QAction(_t(label_key, fallback), menu)
+        action.triggered.connect(callback_factory(ui))
+        menu.addAction(action)

--- a/frontengine/ui/page/gif/gif_setting_ui.py
+++ b/frontengine/ui/page/gif/gif_setting_ui.py
@@ -5,7 +5,13 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QLabel, QSlider, QPushButton
 
 from frontengine.show.gif.paint_gif import GifWidget
 from frontengine.ui.dialog.choose_file_dialog import choose_gif
-from frontengine.ui.page.utils import dispatch_to_monitors, show_on_primary_screen, show_on_selected_monitor
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+    show_on_primary_screen,
+    show_on_selected_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -60,6 +66,12 @@ class GIFSettingUI(QWidget):
 
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -73,6 +85,8 @@ class GIFSettingUI(QWidget):
         self.grid_layout.addWidget(self.start_button, 3, 0)
         self.grid_layout.addWidget(self.show_on_all_screen_checkbox, 3, 1)
         self.grid_layout.addWidget(self.show_on_bottom_checkbox, 3, 2)
+        self.grid_layout.addWidget(self.target_monitor_label, 4, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 4, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[GIFSettingUI] set_show_all_screen")
@@ -103,6 +117,7 @@ class GIFSettingUI(QWidget):
             present_on_monitor=lambda widget, monitor, _idx: show_on_selected_monitor(
                 widget, self.fullscreen_checkbox, monitor
             ),
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )
 
     def choose_and_copy_file_to_cwd_gif_dir_then_play(self) -> None:
@@ -130,6 +145,7 @@ class GIFSettingUI(QWidget):
             "fullscreen": self.fullscreen_checkbox.isChecked(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
             "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -148,3 +164,7 @@ class GIFSettingUI(QWidget):
             self.show_all_screen = bool(state["show_on_all_screen"])
         if "show_on_bottom" in state:
             self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)

--- a/frontengine/ui/page/gif/gif_setting_ui.py
+++ b/frontengine/ui/page/gif/gif_setting_ui.py
@@ -121,3 +121,30 @@ class GIFSettingUI(QWidget):
     def speed_trick(self) -> None:
         front_engine_logger.info("[GIFSettingUI] speed_trick")
         self.speed_slider_value_label.setText(str(self.speed_slider.value()))
+
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "speed": self.speed_slider.value(),
+            "gif_image_path": self.gif_image_path,
+            "fullscreen": self.fullscreen_checkbox.isChecked(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if "speed" in state:
+            self.speed_slider.setValue(int(state["speed"]))
+        if state.get("gif_image_path"):
+            self.gif_image_path = state["gif_image_path"]
+            self.ready_to_play = True
+            self.ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+        if "fullscreen" in state:
+            self.fullscreen_checkbox.setChecked(bool(state["fullscreen"]))
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])
+        if "show_on_bottom" in state:
+            self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))

--- a/frontengine/ui/page/image/image_setting_ui.py
+++ b/frontengine/ui/page/image/image_setting_ui.py
@@ -5,7 +5,13 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QSlider, QLabel, QPushButton
 
 from frontengine.show.image.paint_image import ImageWidget
 from frontengine.ui.dialog.choose_file_dialog import choose_image
-from frontengine.ui.page.utils import dispatch_to_monitors, show_on_primary_screen, show_on_selected_monitor
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+    show_on_primary_screen,
+    show_on_selected_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -52,6 +58,12 @@ class ImageSettingUI(QWidget):
 
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -62,6 +74,8 @@ class ImageSettingUI(QWidget):
         self.grid_layout.addWidget(self.start_button, 2, 0)
         self.grid_layout.addWidget(self.show_on_all_screen_checkbox, 2, 1)
         self.grid_layout.addWidget(self.show_on_bottom_checkbox, 2, 2)
+        self.grid_layout.addWidget(self.target_monitor_label, 3, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 3, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[ImageSettingUI] set_show_all_screen")
@@ -91,6 +105,7 @@ class ImageSettingUI(QWidget):
             present_on_monitor=lambda widget, monitor, _idx: show_on_selected_monitor(
                 widget, self.fullscreen_checkbox, monitor
             ),
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )
 
     def choose_and_copy_file_to_cwd_image_dir_then_play(self) -> None:
@@ -113,6 +128,7 @@ class ImageSettingUI(QWidget):
             "fullscreen": self.fullscreen_checkbox.isChecked(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
             "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -129,3 +145,7 @@ class ImageSettingUI(QWidget):
             self.show_all_screen = bool(state["show_on_all_screen"])
         if "show_on_bottom" in state:
             self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)

--- a/frontengine/ui/page/image/image_setting_ui.py
+++ b/frontengine/ui/page/image/image_setting_ui.py
@@ -105,3 +105,27 @@ class ImageSettingUI(QWidget):
     def opacity_trick(self) -> None:
         front_engine_logger.info("[ImageSettingUI] opacity_trick")
         self.opacity_slider_value_label.setText(str(self.opacity_slider.value()))
+
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "image_path": self.image_path,
+            "fullscreen": self.fullscreen_checkbox.isChecked(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if state.get("image_path"):
+            self.image_path = state["image_path"]
+            self.ready_to_play = True
+            self.ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+        if "fullscreen" in state:
+            self.fullscreen_checkbox.setChecked(bool(state["fullscreen"]))
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])
+        if "show_on_bottom" in state:
+            self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))

--- a/frontengine/ui/page/particle/particle_setting_ui.py
+++ b/frontengine/ui/page/particle/particle_setting_ui.py
@@ -6,7 +6,11 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QSlider, QLabel, QPushButton
 
 from frontengine.show.particle.particle_ui import ParticleOpenGLWidget
 from frontengine.ui.dialog.choose_file_dialog import choose_image
-from frontengine.ui.page.utils import dispatch_to_monitors
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -75,6 +79,12 @@ class ParticleSettingUI(QWidget):
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -91,6 +101,8 @@ class ParticleSettingUI(QWidget):
         self.grid_layout.addWidget(self.particle_speed_combobox, 5, 1)
         self.grid_layout.addWidget(self.start_button, 6, 0)
         self.grid_layout.addWidget(self.show_on_all_screen_checkbox, 6, 1)
+        self.grid_layout.addWidget(self.target_monitor_label, 7, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 7, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[ParticleSettingUI] set_show_all_screen")
@@ -136,6 +148,7 @@ class ParticleSettingUI(QWidget):
             factory=factory,
             present_primary=lambda widget: widget.showMaximized(),
             present_on_monitor=present_on_monitor,
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )
 
     def choose_and_copy_file_to_cwd_image_dir_then_play(self) -> None:
@@ -160,6 +173,7 @@ class ParticleSettingUI(QWidget):
             "count": self.particle_count_combobox.currentText(),
             "speed": self.particle_speed_combobox.currentText(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -182,3 +196,7 @@ class ParticleSettingUI(QWidget):
         if "show_on_all_screen" in state:
             self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
             self.show_all_screen = bool(state["show_on_all_screen"])
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)

--- a/frontengine/ui/page/particle/particle_setting_ui.py
+++ b/frontengine/ui/page/particle/particle_setting_ui.py
@@ -150,3 +150,35 @@ class ParticleSettingUI(QWidget):
     def opacity_trick(self) -> None:
         front_engine_logger.info("[ParticleSettingUI] opacity_trick")
         self.opacity_slider_value_label.setText(str(self.opacity_slider.value()))
+
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "image_path": self.image_path,
+            "direction": self.choose_direction_combobox.currentText(),
+            "size": self.particle_size_combobox.currentText(),
+            "count": self.particle_count_combobox.currentText(),
+            "speed": self.particle_speed_combobox.currentText(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if state.get("image_path"):
+            self.image_path = state["image_path"]
+            self.ready_to_play = True
+            self.ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+        for combobox, key in (
+            (self.choose_direction_combobox, "direction"),
+            (self.particle_size_combobox, "size"),
+            (self.particle_count_combobox, "count"),
+            (self.particle_speed_combobox, "speed"),
+        ):
+            if state.get(key) is not None:
+                index = combobox.findText(str(state[key]))
+                if index >= 0:
+                    combobox.setCurrentIndex(index)
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])

--- a/frontengine/ui/page/sound_player/sound_player_setting_ui.py
+++ b/frontengine/ui/page/sound_player/sound_player_setting_ui.py
@@ -109,3 +109,21 @@ class SoundPlayerSettingUI(QWidget):
     def volume_trick(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] volume_trick")
         self.volume_slider_value_label.setText(str(self.volume_slider.value()))
+
+    def get_state(self) -> dict:
+        return {
+            "volume": self.volume_slider.value(),
+            "wav_sound_path": self.wav_sound_path,
+            "player_sound_path": self.player_sound_path,
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "volume" in state:
+            self.volume_slider.setValue(int(state["volume"]))
+        if state.get("wav_sound_path"):
+            self.wav_sound_path = state["wav_sound_path"]
+            self.ready_to_play = True
+            self.wav_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+        if state.get("player_sound_path"):
+            self.player_sound_path = state["player_sound_path"]
+            self.player_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -3,7 +3,11 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QSlider, QLabel, QLineEdit, 
     QMessageBox
 
 from frontengine.show.text.draw_text import TextWidget
-from frontengine.ui.page.utils import dispatch_to_monitors
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -54,6 +58,12 @@ class TextSettingUI(QWidget):
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -67,6 +77,8 @@ class TextSettingUI(QWidget):
         self.grid_layout.addWidget(self.text_position_combobox, 3, 1)
         self.grid_layout.addWidget(self.start_button, 4, 0)
         self.grid_layout.addWidget(self.line_edit, 4, 1)
+        self.grid_layout.addWidget(self.target_monitor_label, 5, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 5, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[TextSettingUI] set_show_all_screen")
@@ -100,6 +112,7 @@ class TextSettingUI(QWidget):
             "alignment": self.text_position_combobox.currentText(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
             "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -118,6 +131,10 @@ class TextSettingUI(QWidget):
             self.show_all_screen = bool(state["show_on_all_screen"])
         if "show_on_bottom" in state:
             self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)
 
     def start_draw_text_on_screen(self) -> None:
         front_engine_logger.info("[TextSettingUI] start_draw_text_on_screen")
@@ -137,4 +154,5 @@ class TextSettingUI(QWidget):
             factory=lambda _monitor: self._create_text_widget(),
             present_primary=lambda widget: widget.showFullScreen(),
             present_on_monitor=present_on_monitor,
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -92,6 +92,33 @@ class TextSettingUI(QWidget):
         front_engine_logger.info("[TextSettingUI] font_size_trick")
         self.font_size_slider_value_label.setText(str(self.font_size_slider.value()))
 
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "font_size": self.font_size_slider.value(),
+            "text": self.line_edit.text(),
+            "alignment": self.text_position_combobox.currentText(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if "font_size" in state:
+            self.font_size_slider.setValue(int(state["font_size"]))
+        if "text" in state:
+            self.line_edit.setText(str(state.get("text") or ""))
+        if "alignment" in state:
+            index = self.text_position_combobox.findText(str(state["alignment"]))
+            if index >= 0:
+                self.text_position_combobox.setCurrentIndex(index)
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])
+        if "show_on_bottom" in state:
+            self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+
     def start_draw_text_on_screen(self) -> None:
         front_engine_logger.info("[TextSettingUI] start_draw_text_on_screen")
 

--- a/frontengine/ui/page/utils.py
+++ b/frontengine/ui/page/utils.py
@@ -92,6 +92,7 @@ def dispatch_to_monitors(
     factory: Callable[[Optional[QScreen]], QWidget],
     present_primary: Callable[[QWidget], None],
     present_on_monitor: Callable[[QWidget, QScreen, int], None],
+    preferred_monitor_index: Optional[int] = None,
 ) -> None:
     """
     Run the canonical monitor-dispatch flow the setting pages share:
@@ -100,12 +101,21 @@ def dispatch_to_monitors(
 
     `factory` receives the target monitor (or None for the primary path)
     so callers can pass monitor geometry into widget construction if
-    needed.
+    needed. `preferred_monitor_index` lets callers pre-select a specific
+    monitor so the user is not prompted; out-of-range values fall back
+    to the prompt flow.
     """
     monitors = QGuiApplication.screens()
     if not show_all_screen and len(monitors) <= 1:
         widget = factory(None)
         present_primary(widget)
+        return
+
+    if not show_all_screen and preferred_monitor_index is not None and \
+            0 <= preferred_monitor_index < len(monitors):
+        monitor = monitors[preferred_monitor_index]
+        widget = factory(monitor)
+        present_on_monitor(widget, monitor, preferred_monitor_index)
         return
 
     if not show_all_screen and len(monitors) >= 2:
@@ -123,3 +133,24 @@ def dispatch_to_monitors(
     for index, monitor in enumerate(monitors):
         widget = factory(monitor)
         present_on_monitor(widget, monitor, index)
+
+
+def build_target_monitor_combobox() -> QComboBox:
+    """
+    Build a combobox listing the current monitors plus an initial "Ask"
+    entry. Selection "Ask" (data=None) preserves today's prompt flow;
+    selecting a monitor index pre-selects that screen.
+    """
+    combobox = QComboBox()
+    combobox.addItem(language_wrapper.language_word_dict.get("target_monitor_ask", "Ask"), None)
+    for index, _ in enumerate(QGuiApplication.screens()):
+        combobox.addItem(str(index), index)
+    return combobox
+
+
+def resolve_preferred_monitor(combobox: Optional[QComboBox]) -> Optional[int]:
+    """Return the selected monitor index, or None for the Ask entry."""
+    if combobox is None:
+        return None
+    data = combobox.currentData()
+    return int(data) if isinstance(data, int) else None

--- a/frontengine/ui/page/video/video_setting_ui.py
+++ b/frontengine/ui/page/video/video_setting_ui.py
@@ -5,7 +5,13 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QSlider, QLabel, QPushButton
 
 from frontengine.show.video.video_player import VideoWidget
 from frontengine.ui.dialog.choose_file_dialog import choose_video
-from frontengine.ui.page.utils import dispatch_to_monitors, show_on_primary_screen, show_on_selected_monitor
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+    show_on_primary_screen,
+    show_on_selected_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -69,6 +75,12 @@ class VideoSettingUI(QWidget):
         # Show on bottom
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -85,6 +97,8 @@ class VideoSettingUI(QWidget):
         self.grid_layout.addWidget(self.fullscreen_checkbox, 4, 2)
         self.grid_layout.addWidget(self.start_button, 5, 0)
         self.grid_layout.addWidget(self.ready_label, 5, 1)
+        self.grid_layout.addWidget(self.target_monitor_label, 6, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 6, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[VideoSettingUI] set_show_all_screen")
@@ -124,6 +138,7 @@ class VideoSettingUI(QWidget):
             factory=lambda _monitor: self._create_video_widget(),
             present_primary=lambda widget: show_on_primary_screen(widget, self.fullscreen_checkbox),
             present_on_monitor=present_on_monitor,
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )
 
     def choose_and_copy_file_to_cwd_video_dir_then_play(self) -> None:
@@ -156,6 +171,7 @@ class VideoSettingUI(QWidget):
             "fullscreen": self.fullscreen_checkbox.isChecked(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
             "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -176,3 +192,7 @@ class VideoSettingUI(QWidget):
             self.show_all_screen = bool(state["show_on_all_screen"])
         if "show_on_bottom" in state:
             self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)

--- a/frontengine/ui/page/video/video_setting_ui.py
+++ b/frontengine/ui/page/video/video_setting_ui.py
@@ -146,3 +146,33 @@ class VideoSettingUI(QWidget):
     def volume_trick(self) -> None:
         front_engine_logger.info("[VideoSettingUI] volume_trick")
         self.volume_slider_value_label.setText(str(self.volume_slider.value()))
+
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "play_rate": self.play_rate_slider.value(),
+            "volume": self.volume_slider.value(),
+            "video_path": self.video_path,
+            "fullscreen": self.fullscreen_checkbox.isChecked(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if "play_rate" in state:
+            self.play_rate_slider.setValue(int(state["play_rate"]))
+        if "volume" in state:
+            self.volume_slider.setValue(int(state["volume"]))
+        if state.get("video_path"):
+            self.video_path = state["video_path"]
+            self.ready_to_play = True
+            self.ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+        if "fullscreen" in state:
+            self.fullscreen_checkbox.setChecked(bool(state["fullscreen"]))
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])
+        if "show_on_bottom" in state:
+            self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -2,7 +2,11 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QWidget, QGridLayout, QLabel, QSlider, QLineEdit, QPushButton, QCheckBox
 
 from frontengine.show.web.webview import WebWidget
-from frontengine.ui.page.utils import dispatch_to_monitors
+from frontengine.ui.page.utils import (
+    build_target_monitor_combobox,
+    dispatch_to_monitors,
+    resolve_preferred_monitor,
+)
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
@@ -51,6 +55,12 @@ class WEBSettingUI(QWidget):
         # Show on bottom
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
 
+        # Target monitor selector
+        self.target_monitor_label = QLabel(
+            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
+        )
+        self.target_monitor_combobox = build_target_monitor_combobox()
+
         # Layout
         self.grid_layout.addWidget(self.opacity_label, 0, 0)
         self.grid_layout.addWidget(self.opacity_slider_value_label, 0, 1)
@@ -61,6 +71,8 @@ class WEBSettingUI(QWidget):
         self.grid_layout.addWidget(self.show_on_bottom_checkbox, 2, 1)
         self.grid_layout.addWidget(self.start_button, 3, 0)
         self.grid_layout.addWidget(self.web_url_input, 3, 2)
+        self.grid_layout.addWidget(self.target_monitor_label, 4, 0)
+        self.grid_layout.addWidget(self.target_monitor_combobox, 4, 1)
 
     def set_show_all_screen(self) -> None:
         front_engine_logger.info("[WEBSettingUI] set_show_all_screen")
@@ -97,6 +109,7 @@ class WEBSettingUI(QWidget):
             "enable_input": self.enable_input_checkbox.isChecked(),
             "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
             "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+            "target_monitor": self.target_monitor_combobox.currentText(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -115,6 +128,10 @@ class WEBSettingUI(QWidget):
             self.show_all_screen = bool(state["show_on_all_screen"])
         if "show_on_bottom" in state:
             self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+        if state.get("target_monitor") is not None:
+            index = self.target_monitor_combobox.findText(str(state["target_monitor"]))
+            if index >= 0:
+                self.target_monitor_combobox.setCurrentIndex(index)
 
     def start_open_web_with_url(self) -> None:
         front_engine_logger.info("[WEBSettingUI] start_open_web_with_url")
@@ -130,4 +147,5 @@ class WEBSettingUI(QWidget):
             factory=lambda _monitor: self._create_web_widget(),
             present_primary=lambda widget: widget.showFullScreen(),
             present_on_monitor=present_on_monitor,
+            preferred_monitor_index=resolve_preferred_monitor(self.target_monitor_combobox),
         )

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -89,6 +89,33 @@ class WEBSettingUI(QWidget):
         front_engine_logger.info("[WEBSettingUI] opacity_trick")
         self.opacity_slider_value_label.setText(str(self.opacity_slider.value()))
 
+    def get_state(self) -> dict:
+        return {
+            "opacity": self.opacity_slider.value(),
+            "url": self.web_url_input.text(),
+            "open_file": self.open_local_html_checkbox.isChecked(),
+            "enable_input": self.enable_input_checkbox.isChecked(),
+            "show_on_all_screen": self.show_on_all_screen_checkbox.isChecked(),
+            "show_on_bottom": self.show_on_bottom_checkbox.isChecked(),
+        }
+
+    def set_state(self, state: dict) -> None:
+        if "opacity" in state:
+            self.opacity_slider.setValue(int(state["opacity"]))
+        if "url" in state:
+            self.web_url_input.setText(str(state.get("url") or ""))
+        if "open_file" in state:
+            self.open_local_html_checkbox.setChecked(bool(state["open_file"]))
+            self.open_file = bool(state["open_file"])
+        if "enable_input" in state:
+            self.enable_input_checkbox.setChecked(bool(state["enable_input"]))
+            self.enable_input = bool(state["enable_input"])
+        if "show_on_all_screen" in state:
+            self.show_on_all_screen_checkbox.setChecked(bool(state["show_on_all_screen"]))
+            self.show_all_screen = bool(state["show_on_all_screen"])
+        if "show_on_bottom" in state:
+            self.show_on_bottom_checkbox.setChecked(bool(state["show_on_bottom"]))
+
     def start_open_web_with_url(self) -> None:
         front_engine_logger.info("[WEBSettingUI] start_open_web_with_url")
 

--- a/frontengine/user_setting/preset_repository.py
+++ b/frontengine/user_setting/preset_repository.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from os import getcwd
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from frontengine.utils.json.json_repository import JsonRepository
+
+_FILENAME_SAFE = re.compile(r"[^A-Za-z0-9_\- ]+")
+
+
+def _default_dir() -> Path:
+    return Path(getcwd()) / "presets"
+
+
+def _sanitize(name: str) -> str:
+    sanitized = _FILENAME_SAFE.sub("_", name).strip().strip("_")
+    if not sanitized:
+        raise ValueError("Preset name must contain at least one safe character")
+    return sanitized
+
+
+class PresetRepository:
+    """
+    One JSON file per preset under `<cwd>/presets/`. Each document is a
+    flat mapping of setting-page key -> page state dict, with the preset
+    name itself stored under the reserved "__preset_name__" key.
+    """
+
+    def __init__(self, directory: Optional[Path] = None) -> None:
+        self._dir: Path = directory or _default_dir()
+
+    @property
+    def directory(self) -> Path:
+        return self._dir
+
+    def list_presets(self) -> List[str]:
+        if not self._dir.exists():
+            return []
+        return sorted(path.stem for path in self._dir.glob("*.json"))
+
+    def _path_for(self, name: str) -> Path:
+        return self._dir / f"{_sanitize(name)}.json"
+
+    def save(self, name: str, data: Dict[str, Any]) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        payload: Dict[str, Any] = {"__preset_name__": name}
+        payload.update(data)
+        return JsonRepository(self._path_for(name)).save(payload)
+
+    def load(self, name: str) -> Dict[str, Any]:
+        repo = JsonRepository(self._path_for(name))
+        if not repo.exists():
+            raise FileNotFoundError(f"Preset not found: {name}")
+        data = repo.load()
+        if not isinstance(data, dict):
+            return {}
+        return {key: value for key, value in data.items() if key != "__preset_name__"}
+
+    def delete(self, name: str) -> bool:
+        path = self._path_for(name)
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/frontengine/utils/hotkey/hotkey_service.py
+++ b/frontengine/utils/hotkey/hotkey_service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from PySide6.QtCore import QObject, Signal
+
+from frontengine.utils.logging.loggin_instance import front_engine_logger
+
+try:  # pynput ships native backends that may not load on every platform
+    from pynput import keyboard as _pynput_keyboard  # type: ignore
+except Exception as _import_error:  # pragma: no cover - environment guard
+    _pynput_keyboard = None
+    _PYNPUT_ERROR: Optional[BaseException] = _import_error
+else:
+    _PYNPUT_ERROR = None
+
+
+class HotkeyService(QObject):
+    """
+    Thin wrapper around pynput.keyboard.GlobalHotKeys that re-emits every
+    hotkey press as a Qt signal so slots run on the UI thread. Bindings
+    are a mapping of pynput hotkey strings to action names, e.g.
+    ``{"<ctrl>+<shift>+<f12>": "close_all"}``.
+
+    If pynput is missing or fails to import (headless CI, unsupported
+    backend), the service degrades to a no-op and logs the reason.
+    """
+
+    hotkey_triggered = Signal(str)
+
+    def __init__(self, bindings: Dict[str, str], parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._bindings: Dict[str, str] = dict(bindings)
+        self._listener: Optional[Any] = None
+
+    def start(self) -> bool:
+        if self._listener is not None:
+            return True
+        if _pynput_keyboard is None:
+            front_engine_logger.warning(
+                f"[HotkeyService] pynput unavailable, hotkeys disabled ({_PYNPUT_ERROR!r})"
+            )
+            return False
+        if not self._bindings:
+            return False
+        try:
+            dispatch = {
+                combo: (lambda name=action: self.hotkey_triggered.emit(name))
+                for combo, action in self._bindings.items()
+            }
+            self._listener = _pynput_keyboard.GlobalHotKeys(dispatch)
+            self._listener.daemon = True
+            self._listener.start()
+            front_engine_logger.info(
+                f"[HotkeyService] Started with bindings {list(self._bindings)}"
+            )
+            return True
+        except Exception as error:
+            front_engine_logger.warning(f"[HotkeyService] Failed to start: {error!r}")
+            self._listener = None
+            return False
+
+    def stop(self) -> None:
+        listener = self._listener
+        self._listener = None
+        if listener is not None:
+            try:
+                listener.stop()
+            except Exception as error:
+                front_engine_logger.warning(f"[HotkeyService] Stop error: {error!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "JE-Chen", email = "jechenmailman@gmail.com" },
 ]
 dependencies = [
-    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy"
+    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
 ]
 description = "FrontEngine is use-define frontview or only use like screen saver"
 requires-python = ">=3.10"

--- a/stable.toml
+++ b/stable.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "JE-Chen", email = "jechenmailman@gmail.com" },
 ]
 dependencies = [
-    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy"
+    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
 ]
 description = "FrontEngine is use-define frontview or only use like screen saver"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Three new user-facing features on top of the refactor currently in PR #131:

- **Preset system** — a `Presets` top-level menu with Save / Load / Delete actions, backed by `PresetRepository` (one JSON per preset under `<cwd>/presets/`). Each setting page now implements a `get_state()` / `set_state()` contract so the whole UI round-trips through JSON.
- **Per-monitor target selector** — a `Target monitor` combobox on every dispatching setting page (gif, image, video, web, text, particle). `Ask` keeps today's prompt behavior, selecting a specific monitor index pre-selects that screen and bypasses the prompt. Threaded through `dispatch_to_monitors` via a new `preferred_monitor_index` parameter, and persisted in presets.
- **Global hotkeys** — new `HotkeyService` built on pynput that re-emits hotkey presses as Qt signals so slots run on the UI thread. Ships one default binding: `Ctrl+Shift+F12` triggers `ControlCenterUI.clear_all`. Degrades to a no-op (with a log warning) if pynput is unavailable, so headless environments keep working.

`pynput` was added to `dev_requirements.txt`, `pyproject.toml`, and `stable.toml`.

## Test plan

- [ ] Launch the app, Save a preset with a GIF configured, reset UI, Load the same preset — settings round-trip correctly
- [ ] Delete a preset from the menu — entry disappears from subsequent Load dialogs
- [ ] With 2+ monitors, pick `Monitor 1` in a setting page and start — widget appears on monitor 1 without the prompt
- [ ] With 2+ monitors and `Ask` selected — prompt still appears (unchanged behavior)
- [ ] Press `Ctrl+Shift+F12` while overlays are running — all overlays close
- [ ] Uninstall pynput in a test env — app still starts, warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)