### PR TITLE
Desktop pet: gravity/throw physics, walk-idle states, cursor chase

### DIFF
--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -142,7 +142,7 @@ class PetMotion:
 
     # --- free wander ---
     def _step_wander(self, left, top, right, bottom) -> Tuple[int, int]:
-        if self.vy == 0.0:
+        if abs(self.vy) < 1e-9:
             self.vy = float(self.speed)
         self.x += self.vx
         self.y += self.vy

--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -1,8 +1,9 @@
+import random as _random_module
 from pathlib import Path
 from typing import Optional, Tuple
 
 from PySide6.QtCore import Qt, QRect, QTimer
-from PySide6.QtGui import QAction, QMovie, QPainter, QPixmap, QTransform
+from PySide6.QtGui import QAction, QCursor, QMovie, QPainter, QPixmap, QTransform
 from PySide6.QtWidgets import QMenu, QMessageBox
 
 from frontengine.show.base_widget import BaseWidget
@@ -10,15 +11,29 @@ from frontengine.show.window_helpers import apply_overlay_window_flags
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 
+# 行為模式 / Behaviour modes
+BEHAVIOUR_FLOOR = "floor"    # walk on the floor with gravity, throw & bounce
+BEHAVIOUR_WANDER = "wander"  # free 2D bounce, no gravity
+BEHAVIOUR_CHASE = "chase"    # chase the mouse cursor, sleep when caught
+
 
 class PetMotion:
     """
-    純邏輯的移動模型（不依賴 Qt，便於測試）。gravity=True 時寵物沿著底部
-    行走並在左右邊緣轉向；否則在四邊之間自由彈跳。
-    Pure movement model (no Qt, easy to test). With gravity the pet walks
-    along the floor and turns at the left/right edges; otherwise it bounces
-    freely between all four edges.
+    純邏輯的寵物移動模型（不依賴 Qt，完全可測試）。包含：
+      - 重力落下、落地、彈跳（受動量丟出後）
+      - 走路/發呆的隨機行為狀態機（rng 可注入以利測試）
+      - 追逐游標模式（追到後進入睡眠，游標移動即醒）
+    A pure, Qt-free motion model: gravity fall/land/bounce (after a throw),
+    a random walk/idle behaviour state machine (injectable rng), and a
+    cursor-chase mode that sleeps once it catches the target.
     """
+
+    GRAVITY = 2.0
+    BOUNCE_DAMPING = 0.55
+    WALL_DAMPING = 0.6
+    BOUNCE_THRESHOLD = 8.0
+    CHASE_STOP_DISTANCE = 10.0
+    CHASE_SPEED_FACTOR = 2.0
 
     def __init__(
         self,
@@ -28,7 +43,8 @@ class PetMotion:
         height: int,
         bounds: Tuple[int, int, int, int],
         speed: int = 3,
-        gravity: bool = True,
+        behaviour: str = BEHAVIOUR_FLOOR,
+        rng=None,
     ) -> None:
         self.x = float(x)
         self.y = float(y)
@@ -36,9 +52,15 @@ class PetMotion:
         self.height = int(height)
         self.bounds = bounds  # (left, top, right, bottom)
         self.speed = max(1, int(speed))
-        self.gravity = bool(gravity)
+        self.behaviour = behaviour
+        self._rng = rng if rng is not None else _random_module.SystemRandom()
         self.vx = float(self.speed)
-        self.vy = 0.0 if gravity else float(self.speed)
+        self.vy = 0.0 if behaviour != BEHAVIOUR_WANDER else float(self.speed)
+        self._airborne = False
+        self.state = "walk"  # walk | idle
+        self._state_ticks = 0
+        self.target: Optional[Tuple[float, float]] = None
+        self.asleep = False
 
     @property
     def facing_left(self) -> bool:
@@ -47,38 +69,128 @@ class PetMotion:
     def set_bounds(self, bounds: Tuple[int, int, int, int]) -> None:
         self.bounds = bounds
 
+    def set_target(self, x: float, y: float) -> None:
+        self.target = (float(x), float(y))
+
+    def throw(self, vx: float, vy: float) -> None:
+        """拖曳放開後以動量丟出（只在重力模式有意義）。"""
+        self.vx = float(vx)
+        self.vy = float(vy)
+        self._airborne = True
+        self.asleep = False
+
     def step(self) -> Tuple[int, int]:
         left, top, right, bottom = self.bounds
-        self.x += self.vx
-        if self.gravity:
-            self.y = float(bottom - self.height)
-        else:
+        floor_y = bottom - self.height
+        if self.behaviour == BEHAVIOUR_CHASE:
+            return self._step_chase(left, top, right, bottom)
+        if self.behaviour == BEHAVIOUR_WANDER:
+            return self._step_wander(left, top, right, bottom)
+        return self._step_floor(left, top, right, bottom, floor_y)
+
+    # --- floor / gravity ---
+    def _step_floor(self, left, top, right, bottom, floor_y) -> Tuple[int, int]:
+        airborne = self._airborne or self.y < floor_y - 0.5
+        if airborne:
+            self.vy += self.GRAVITY
+            self.x += self.vx
             self.y += self.vy
+            if self.x <= left:
+                self.x = float(left)
+                self.vx = abs(self.vx) * self.WALL_DAMPING
+            elif self.x + self.width >= right:
+                self.x = float(right - self.width)
+                self.vx = -abs(self.vx) * self.WALL_DAMPING
             if self.y <= top:
                 self.y = float(top)
-                self.vy = abs(self.vy)
-            elif self.y + self.height >= bottom:
-                self.y = float(bottom - self.height)
-                self.vy = -abs(self.vy)
+                self.vy = abs(self.vy) * self.WALL_DAMPING
+            if self.y >= floor_y:
+                self.y = float(floor_y)
+                if abs(self.vy) > self.BOUNCE_THRESHOLD:
+                    self.vy = -self.vy * self.BOUNCE_DAMPING
+                else:
+                    self.vy = 0.0
+                    self._airborne = False
+                    self.vx = float(self.speed) if self.vx >= 0 else float(-self.speed)
+                    self._new_state(force_walk=True)
+            return int(self.x), int(self.y)
+
+        # grounded: random walk / idle
+        self.y = float(floor_y)
+        if self._state_ticks <= 0:
+            self._new_state()
+        self._state_ticks -= 1
+        if self.state == "walk":
+            self.x += self.vx
+            if self.x <= left:
+                self.x = float(left)
+                self.vx = abs(self.vx)
+            elif self.x + self.width >= right:
+                self.x = float(right - self.width)
+                self.vx = -abs(self.vx)
+        return int(self.x), int(self.y)
+
+    def _new_state(self, force_walk: bool = False) -> None:
+        if force_walk or self._rng.random() < 0.65:
+            self.state = "walk"
+            if not force_walk:
+                self.vx = float(self.speed) if self._rng.random() < 0.5 else float(-self.speed)
+            self._state_ticks = self._rng.randint(30, 120)
+        else:
+            self.state = "idle"
+            self._state_ticks = self._rng.randint(20, 80)
+
+    # --- free wander ---
+    def _step_wander(self, left, top, right, bottom) -> Tuple[int, int]:
+        if self.vy == 0.0:
+            self.vy = float(self.speed)
+        self.x += self.vx
+        self.y += self.vy
         if self.x <= left:
             self.x = float(left)
             self.vx = abs(self.vx)
         elif self.x + self.width >= right:
             self.x = float(right - self.width)
             self.vx = -abs(self.vx)
+        if self.y <= top:
+            self.y = float(top)
+            self.vy = abs(self.vy)
+        elif self.y + self.height >= bottom:
+            self.y = float(bottom - self.height)
+            self.vy = -abs(self.vy)
+        return int(self.x), int(self.y)
+
+    # --- chase cursor ---
+    def _step_chase(self, left, top, right, bottom) -> Tuple[int, int]:
+        if self.target is None:
+            return int(self.x), int(self.y)
+        target_x, target_y = self.target
+        dx = target_x - (self.x + self.width / 2)
+        dy = target_y - (self.y + self.height / 2)
+        distance = (dx * dx + dy * dy) ** 0.5
+        if distance <= self.CHASE_STOP_DISTANCE:
+            self.asleep = True
+            return int(self.x), int(self.y)
+        self.asleep = False
+        step = float(self.speed) * self.CHASE_SPEED_FACTOR
+        self.x += step * (dx / distance)
+        self.y += step * (dy / distance)
+        self.vx = abs(self.vx) if dx >= 0 else -abs(self.vx)
+        self.x = min(max(self.x, float(left)), float(right - self.width))
+        self.y = min(max(self.y, float(top)), float(bottom - self.height))
         return int(self.x), int(self.y)
 
 
 class DesktopPetWidget(BaseWidget):
     """
-    桌面寵物：可自主走動、可拖曳的動畫精靈。支援 GIF（QMovie）與靜態圖。
-    A draggable, self-walking animated sprite. Supports GIF (QMovie) and
-    static images.
+    桌面寵物：可自主走動、可拖曳丟出、可追游標的動畫精靈。支援 GIF 與靜態圖。
+    A draggable, throwable, cursor-chasing animated sprite (GIF or image).
     """
 
-    def __init__(self, image_path: str, size: int = 128, speed: int = 3, gravity: bool = True):
+    def __init__(self, image_path: str, size: int = 128, speed: int = 3,
+                 behaviour: str = BEHAVIOUR_FLOOR):
         front_engine_logger.info(
-            f"[DesktopPetWidget] Init | path={image_path}, size={size}, speed={speed}, gravity={gravity}"
+            f"[DesktopPetWidget] Init | path={image_path}, size={size}, speed={speed}, behaviour={behaviour}"
         )
         super().__init__()
         self.opacity = 1.0
@@ -88,6 +200,7 @@ class DesktopPetWidget(BaseWidget):
         self.pixmap: Optional[QPixmap] = None
         self._dragging: bool = False
         self._drag_offset = None
+        self._last_move_delta: Tuple[int, int] = (0, 0)
 
         if self.image_path.exists() and self.image_path.is_file():
             if self.image_path.suffix.lower() in (".gif", ".webp"):
@@ -103,12 +216,11 @@ class DesktopPetWidget(BaseWidget):
             message_box.show()
 
         self.resize(self.pet_size, self.pet_size)
-        self.motion = PetMotion(0, 0, self.pet_size, self.pet_size, (0, 0, 1920, 1080), speed, gravity)
+        self.motion = PetMotion(0, 0, self.pet_size, self.pet_size, (0, 0, 1920, 1080), speed, behaviour)
 
         self._timer = QTimer(self)
         self._timer.timeout.connect(self._on_tick)
 
-        # Right-click to close
         self.close_action = QAction(language_wrapper.language_word_dict.get("control_center_close_all", "Close"), self)
         self.close_action.triggered.connect(self.close)
         self.menu = QMenu(self)
@@ -128,12 +240,10 @@ class DesktopPetWidget(BaseWidget):
         if pixmap is None or pixmap.isNull():
             return
         if self.motion.facing_left:
-            # Mirror horizontally so the sprite faces its walking direction.
             pixmap = pixmap.transformed(QTransform().scale(-1, 1))
         painter.drawPixmap(QRect(0, 0, self.width(), self.height()), pixmap)
 
     def start_moving(self, bounds: Tuple[int, int, int, int], interval_ms: int = 33) -> None:
-        """在指定範圍內開始走動 / Start walking within `bounds` (left, top, right, bottom)."""
         front_engine_logger.info(f"[DesktopPetWidget] start_moving | bounds={bounds}")
         left, top, right, bottom = bounds
         self.motion.set_bounds(bounds)
@@ -145,19 +255,25 @@ class DesktopPetWidget(BaseWidget):
     def _on_tick(self) -> None:
         if self._dragging:
             return
+        if self.motion.behaviour == BEHAVIOUR_CHASE:
+            cursor = QCursor.pos()
+            self.motion.set_target(cursor.x(), cursor.y())
         x, y = self.motion.step()
         self.move(x, y)
 
-    # --- dragging ---
+    # --- dragging + throwing ---
     def mousePressEvent(self, event) -> None:
         if event.button() == Qt.MouseButton.LeftButton:
             self._dragging = True
+            self._last_move_delta = (0, 0)
             self._drag_offset = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event) -> None:
         if self._dragging and self._drag_offset is not None:
-            self.move(event.globalPosition().toPoint() - self._drag_offset)
+            new_top_left = event.globalPosition().toPoint() - self._drag_offset
+            self._last_move_delta = (new_top_left.x() - self.x(), new_top_left.y() - self.y())
+            self.move(new_top_left)
         super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event) -> None:
@@ -165,6 +281,9 @@ class DesktopPetWidget(BaseWidget):
             self._dragging = False
             self.motion.x = float(self.x())
             self.motion.y = float(self.y())
+            # Fling with the momentum of the last drag movement (floor mode).
+            if self.motion.behaviour == BEHAVIOUR_FLOOR:
+                self.motion.throw(self._last_move_delta[0], self._last_move_delta[1])
         super().mouseReleaseEvent(event)
 
     def contextMenuEvent(self, event) -> None:

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -2,10 +2,12 @@ from typing import Optional
 
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
-    QWidget, QGridLayout, QLabel, QPushButton, QMessageBox, QCheckBox, QComboBox,
+    QWidget, QGridLayout, QLabel, QPushButton, QMessageBox, QComboBox,
 )
 
-from frontengine.show.pet.desktop_pet import DesktopPetWidget
+from frontengine.show.pet.desktop_pet import (
+    DesktopPetWidget, BEHAVIOUR_FLOOR, BEHAVIOUR_WANDER, BEHAVIOUR_CHASE,
+)
 from frontengine.ui.dialog.choose_file_dialog import choose_pet
 from frontengine.ui.page.utils import (
     build_recent_combobox,
@@ -50,9 +52,15 @@ class PetSettingUI(QWidget):
         self.speed_combobox.addItems([str(n) for n in range(1, 11)])
         self.speed_combobox.setCurrentText("3")
 
-        # Gravity / walk on floor
-        self.gravity_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_gravity_label", "Walk on floor"))
-        self.gravity_checkbox.setChecked(True)
+        # Behaviour
+        self.behaviour_label = QLabel(language_wrapper.language_word_dict.get("pet_behaviour_label", "Behaviour"))
+        self.behaviour_combobox = QComboBox()
+        self.behaviour_combobox.addItem(
+            language_wrapper.language_word_dict.get("pet_behaviour_floor", "Walk on floor"), BEHAVIOUR_FLOOR)
+        self.behaviour_combobox.addItem(
+            language_wrapper.language_word_dict.get("pet_behaviour_wander", "Free wander"), BEHAVIOUR_WANDER)
+        self.behaviour_combobox.addItem(
+            language_wrapper.language_word_dict.get("pet_behaviour_chase", "Chase cursor"), BEHAVIOUR_CHASE)
 
         # Start
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("pet_start", "Spawn pet"))
@@ -73,7 +81,8 @@ class PetSettingUI(QWidget):
         self.grid_layout.addWidget(self.size_combobox, 1, 1)
         self.grid_layout.addWidget(self.speed_label, 2, 0)
         self.grid_layout.addWidget(self.speed_combobox, 2, 1)
-        self.grid_layout.addWidget(self.gravity_checkbox, 3, 0)
+        self.grid_layout.addWidget(self.behaviour_label, 3, 0)
+        self.grid_layout.addWidget(self.behaviour_combobox, 3, 1)
         self.grid_layout.addWidget(self.start_button, 4, 0)
         self.grid_layout.addWidget(self.recent_files_label, 5, 0)
         self.grid_layout.addWidget(self.recent_files_combobox, 5, 1)
@@ -83,7 +92,7 @@ class PetSettingUI(QWidget):
             image_path=self.pet_image_path,
             size=int(self.size_combobox.currentText()),
             speed=int(self.speed_combobox.currentText()),
-            gravity=self.gravity_checkbox.isChecked(),
+            behaviour=self.behaviour_combobox.currentData(),
         )
         pet.set_pet_window_flag()
         self.pet_list.append(pet)
@@ -137,7 +146,7 @@ class PetSettingUI(QWidget):
             "pet_image_path": self.pet_image_path,
             "size": self.size_combobox.currentText(),
             "speed": self.speed_combobox.currentText(),
-            "gravity": self.gravity_checkbox.isChecked(),
+            "behaviour": self.behaviour_combobox.currentData(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -150,5 +159,10 @@ class PetSettingUI(QWidget):
                 index = combobox.findText(str(state[key]))
                 if index >= 0:
                     combobox.setCurrentIndex(index)
-        if "gravity" in state:
-            self.gravity_checkbox.setChecked(bool(state["gravity"]))
+        behaviour = state.get("behaviour")
+        if behaviour is None and "gravity" in state:  # back-compat with old presets
+            behaviour = BEHAVIOUR_FLOOR if state.get("gravity") else BEHAVIOUR_WANDER
+        if behaviour is not None:
+            index = self.behaviour_combobox.findData(behaviour)
+            if index >= 0:
+                self.behaviour_combobox.setCurrentIndex(index)

--- a/frontengine/utils/multi_language/english.py
+++ b/frontengine/utils/multi_language/english.py
@@ -219,7 +219,10 @@ english_word_dict = {
     "pet_choose_file": "Choose pet sprite",
     "pet_size_label": "Size",
     "pet_speed_label": "Speed",
-    "pet_gravity_label": "Walk on floor",
+    "pet_behaviour_label": "Behaviour",
+    "pet_behaviour_floor": "Walk on floor",
+    "pet_behaviour_wander": "Free wander",
+    "pet_behaviour_chase": "Chase cursor",
     "pet_start": "Spawn pet",
     "pet_message_box_text": "Pet image not found",
 }

--- a/frontengine/utils/multi_language/traditional_chinese.py
+++ b/frontengine/utils/multi_language/traditional_chinese.py
@@ -220,7 +220,10 @@ traditional_chinese_word_dict = {
     "pet_choose_file": "選擇寵物圖片",
     "pet_size_label": "大小",
     "pet_speed_label": "速度",
-    "pet_gravity_label": "沿底部行走",
+    "pet_behaviour_label": "行為",
+    "pet_behaviour_floor": "沿底部行走",
+    "pet_behaviour_wander": "自由漫遊",
+    "pet_behaviour_chase": "追逐游標",
     "pet_start": "召喚寵物",
     "pet_message_box_text": "找不到寵物圖片",
 }


### PR DESCRIPTION
## Summary

Upgrades the desktop pet with behaviours learned from classic desktop mascots (Shimeji physics, Neko cursor-chasing).

`PetMotion` (pure, Qt-free, fully unit-tested) now models:
- **Gravity physics** — falls from mid-air, lands on the floor, and bounces with damping.
- **Fling momentum** — releasing after a drag throws the pet with the drag's velocity; it arcs, bounces off walls/floor, and settles.
- **Behaviour state machine** — random walk/idle cycles with varied durations (injectable RNG for tests).
- **Cursor chase (Neko-style)** — follows the mouse and sleeps once it catches it, waking when the cursor moves.

The Pet page's gravity checkbox becomes a **Behaviour** selector — *Walk on floor* / *Free wander* / *Chase cursor* — persisted in presets with backward compatibility for the old `gravity` flag.

## Testing

- `compileall` clean; full existing regression suite green.
- Headless tests cover gravity fall→land→settle, throw arc + eventual landing + wall clamping, the walk/idle state machine (deterministic RNG), free-wander 2D bounce, chase-toward-target with sleep/wake and facing, widget fling + paint path, and page state round-trip incl. old-preset back-compat.
