### PR TITLE
Desktop pet: optional interaction sound

### DIFF
--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -3,8 +3,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 
-from PySide6.QtCore import Qt, QRect, QTimer, Signal
+from PySide6.QtCore import Qt, QRect, QTimer, QUrl, Signal
 from PySide6.QtGui import QAction, QColor, QCursor, QFont, QFontMetrics, QMovie, QPainter, QPixmap, QTransform
+from PySide6.QtMultimedia import QSoundEffect
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
 
 from frontengine.show.base_widget import BaseWidget
@@ -451,10 +452,11 @@ class DesktopPetWidget(BaseWidget):
     clone_requested = Signal()
 
     def __init__(self, image_path: str, size: int = 128, speed: int = 3,
-                 behaviour: str = BEHAVIOUR_FLOOR, climb: bool = True, talk: bool = True):
+                 behaviour: str = BEHAVIOUR_FLOOR, climb: bool = True, talk: bool = True,
+                 sound_path: Optional[str] = None):
         front_engine_logger.info(
             f"[DesktopPetWidget] Init | path={image_path}, size={size}, speed={speed}, "
-            f"behaviour={behaviour}, climb={climb}, talk={talk}"
+            f"behaviour={behaviour}, climb={climb}, talk={talk}, sound={sound_path}"
         )
         super().__init__()
         self.opacity = 1.0
@@ -490,6 +492,8 @@ class DesktopPetWidget(BaseWidget):
         self._chatter_rng = _random_module.SystemRandom()
         self._mood = PetMood(user_setting_dict.get("pet_mood", 60))
         self._messages = self._load_messages()
+        self._sound: Optional[QSoundEffect] = None
+        self._init_sound(sound_path)
         self._bubble = SpeechBubble()
         self._chatter_timer = QTimer(self)
         self._chatter_timer.setSingleShot(True)
@@ -592,6 +596,27 @@ class DesktopPetWidget(BaseWidget):
     def _persist_mood(self) -> None:
         user_setting_dict["pet_mood"] = self._mood.value
 
+    def _init_sound(self, sound_path: Optional[str]) -> None:
+        if not sound_path:
+            return
+        path = Path(sound_path)
+        if not (path.exists() and path.is_file()):
+            return
+        try:
+            self._sound = QSoundEffect(self)
+            self._sound.setSource(QUrl.fromLocalFile(str(path)))
+        except Exception as error:  # pragma: no cover - audio backend guard
+            front_engine_logger.warning(f"[DesktopPetWidget] sound load failed: {error!r}")
+            self._sound = None
+
+    def _play_sound(self) -> None:
+        if self._sound is None:
+            return
+        try:
+            self._sound.play()
+        except Exception as error:  # pragma: no cover - audio backend guard
+            front_engine_logger.warning(f"[DesktopPetWidget] sound play failed: {error!r}")
+
     def _schedule_chatter(self) -> None:
         if self._talk:
             self._chatter_timer.start(self._chatter_rng.randint(15000, 35000))
@@ -636,6 +661,7 @@ class DesktopPetWidget(BaseWidget):
             self.motion.wake()  # interacting wakes a sleeping pet
             self._mood.pet()    # petting cheers it up
             self._persist_mood()
+            self._play_sound()
             self._set_active_sprite(STATE_DRAG)
         super().mousePressEvent(event)
 

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 from frontengine.show.pet.desktop_pet import (
     DesktopPetWidget, BEHAVIOUR_FLOOR, BEHAVIOUR_WANDER, BEHAVIOUR_CHASE, scan_pet_pack,
 )
-from frontengine.ui.dialog.choose_file_dialog import choose_pet
+from frontengine.ui.dialog.choose_file_dialog import choose_pet, choose_wav_sound
 from frontengine.ui.page.utils import (
     build_recent_combobox,
     enable_file_drop,
@@ -32,6 +32,7 @@ class PetSettingUI(QWidget):
         self.pet_list: list = []
         self.ready_to_play = False
         self.pet_image_path: Optional[str] = None
+        self.pet_sound_path: Optional[str] = None
 
         # Choose file
         self.choose_file_button = QPushButton(
@@ -42,6 +43,10 @@ class PetSettingUI(QWidget):
             language_wrapper.language_word_dict.get("pet_choose_pack", "Choose pet pack...")
         )
         self.choose_pack_button.clicked.connect(self.choose_pack)
+        self.choose_sound_button = QPushButton(
+            language_wrapper.language_word_dict.get("pet_choose_sound", "Choose sound (optional)")
+        )
+        self.choose_sound_button.clicked.connect(self.choose_sound)
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
 
         # Size
@@ -88,6 +93,7 @@ class PetSettingUI(QWidget):
         self.grid_layout.addWidget(self.choose_file_button, 0, 0)
         self.grid_layout.addWidget(self.ready_label, 0, 1)
         self.grid_layout.addWidget(self.choose_pack_button, 0, 2)
+        self.grid_layout.addWidget(self.choose_sound_button, 1, 2)
         self.grid_layout.addWidget(self.size_label, 1, 0)
         self.grid_layout.addWidget(self.size_combobox, 1, 1)
         self.grid_layout.addWidget(self.speed_label, 2, 0)
@@ -111,6 +117,7 @@ class PetSettingUI(QWidget):
             behaviour=self.behaviour_combobox.currentData(),
             climb=self.climb_checkbox.isChecked(),
             talk=self.talk_checkbox.isChecked(),
+            sound_path=self.pet_sound_path,
         )
         pet.clone_requested.connect(self._spawn_pet)
         pet.set_pet_window_flag()
@@ -140,6 +147,13 @@ class PetSettingUI(QWidget):
             self.ready_to_play = True
             add_recent_file("pet", self.pet_image_path)
             reload_recent_combobox(self.recent_files_combobox, "pet")
+
+    def choose_sound(self) -> None:
+        """選擇點擊時播放的音效（選填）/ Choose an optional click sound."""
+        front_engine_logger.info("[PetSettingUI] choose_sound")
+        path = choose_wav_sound(self)
+        if path:
+            self.pet_sound_path = path
 
     def choose_pack(self) -> None:
         """選擇動作包資料夾（依 walk/idle/climb/fall/drag 檔名對應狀態）。"""
@@ -188,6 +202,7 @@ class PetSettingUI(QWidget):
             "behaviour": self.behaviour_combobox.currentData(),
             "climb": self.climb_checkbox.isChecked(),
             "talk": self.talk_checkbox.isChecked(),
+            "sound": self.pet_sound_path,
         }
 
     def set_state(self, state: dict) -> None:
@@ -211,3 +226,5 @@ class PetSettingUI(QWidget):
             self.climb_checkbox.setChecked(bool(state["climb"]))
         if "talk" in state:
             self.talk_checkbox.setChecked(bool(state["talk"]))
+        if state.get("sound"):
+            self.pet_sound_path = str(state["sound"])

--- a/frontengine/utils/multi_language/english.py
+++ b/frontengine/utils/multi_language/english.py
@@ -226,6 +226,7 @@ english_word_dict = {
     "pet_climb_label": "Climb walls",
     "pet_clone": "Clone",
     "pet_choose_pack": "Choose pet pack...",
+    "pet_choose_sound": "Choose sound (optional)",
     "pet_pack_empty": "No sprites (walk/idle/sleep/climb/fall/drag) found in that folder.",
     "pet_talk_label": "Speech bubbles",
     "pet_chatter_morning": "Good morning!|Rise and shine!|Ready for the day?",

--- a/frontengine/utils/multi_language/traditional_chinese.py
+++ b/frontengine/utils/multi_language/traditional_chinese.py
@@ -227,6 +227,7 @@ traditional_chinese_word_dict = {
     "pet_climb_label": "攀爬牆壁",
     "pet_clone": "複製",
     "pet_choose_pack": "選擇動作包資料夾...",
+    "pet_choose_sound": "選擇音效（選填）",
     "pet_pack_empty": "該資料夾找不到精靈檔（walk/idle/sleep/climb/fall/drag）。",
     "pet_talk_label": "對話泡泡",
     "pet_chatter_morning": "早安！|新的一天開始囉！|準備好了嗎？",


### PR DESCRIPTION
Adds an optional click/pet sound (Shimeji/eSheep ship sound packs).

- A pet can play a short QSoundEffect when clicked/petted; the sound is optional and chosen on the pet page (persisted in presets).
- Loading and playback are fully guarded, so a missing/invalid/unsupported file never crashes.

Testing: widget loads a real WAV, plays on click without crashing, no-sound and invalid-path paths are no-ops, spawn passes the sound through, and page state round-trips. compileall clean; full regression green.