### PR TITLE
Desktop pet: affection / growth (level up by caring for it)

### DIFF
--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -290,6 +290,34 @@ class PetMood:
         return self.CONTENT
 
 
+class PetGrowth:
+    """
+    親密度累積與等級：互動會累加親密度，跨過門檻即升級。
+    Affection points accrue from interactions; crossing a threshold levels up.
+    """
+
+    THRESHOLDS = (0, 100, 250, 500, 1000, 2000)
+
+    def __init__(self, affection: int = 0) -> None:
+        self.affection = self._clamp(affection)
+
+    @staticmethod
+    def _clamp(value) -> int:
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return 0
+
+    def level(self) -> int:
+        return max(1, sum(1 for threshold in self.THRESHOLDS if self.affection >= threshold))
+
+    def add(self, amount: int) -> bool:
+        """累加親密度；若因此升級回傳 True。"""
+        before = self.level()
+        self.affection = self._clamp(self.affection + int(amount))
+        return self.level() > before
+
+
 class PetHunger:
     """
     寵物飽足值 0~100：餵食上升、隨時間下降；level() 回傳 full/ok/hungry。
@@ -768,6 +796,7 @@ class DesktopPetWidget(BaseWidget):
         self._mood = PetMood(user_setting_dict.get("pet_mood", 60))
         self._hunger = PetHunger(user_setting_dict.get("pet_hunger", 70))
         self._hunger_warned = False
+        self._growth = PetGrowth(user_setting_dict.get("pet_affection", 0))
         self._messages = self._load_messages()
         self._sound: Optional[QSoundEffect] = None
         self._init_sound(sound_path)
@@ -849,6 +878,7 @@ class DesktopPetWidget(BaseWidget):
             self.motion.clear_follow()
             if self._talk and not self._peer_greeted:
                 self._peer_greeted = True
+                self._gain_affection(3)
                 self.motion.vx = abs(self.motion.vx) if peer[0] >= my_center[0] else -abs(self.motion.vx)
                 pool = self._messages.get("meet") or []
                 if pool:
@@ -941,8 +971,18 @@ class DesktopPetWidget(BaseWidget):
             "hungry": lines("pet_chatter_hungry", "I'm hungry...|Got a snack?|Feed me?"),
             "fed": lines("pet_chatter_fed", "Yum!|Thank you!|Delicious!"),
             "away": lines("pet_chatter_away", "Still there?|I'll nap till you're back~|Zzz..."),
+            "levelup": lines("pet_chatter_levelup", "Level up!|I'm growing!|We're getting closer!"),
             "any": lines("pet_chatter_any", "Hi there!|(^_^)|Keep going!"),
         }
+
+    def _gain_affection(self, amount: int) -> None:
+        """互動累加親密度；升級時慶祝一下並保存。"""
+        leveled = self._growth.add(amount)
+        user_setting_dict["pet_affection"] = self._growth.affection
+        if leveled and self._talk:
+            pool = self._messages.get("levelup") or []
+            if pool:
+                self.say(pool[self._chatter_rng.randrange(len(pool))])
 
     def _persist_mood(self) -> None:
         user_setting_dict["pet_mood"] = self._mood.value
@@ -1043,6 +1083,7 @@ class DesktopPetWidget(BaseWidget):
         self._mood.pet()
         self._persist_hunger()
         self._persist_mood()
+        self._gain_affection(5)
         pool = self._messages.get("fed") or []
         if pool:
             self.say(pool[self._chatter_rng.randrange(len(pool))])
@@ -1128,6 +1169,7 @@ class DesktopPetWidget(BaseWidget):
             self.motion.clear_follow()
             self._mood.pet()    # petting cheers it up
             self._persist_mood()
+            self._gain_affection(2)
             self._play_sound()
             self._set_active_sprite(STATE_DRAG)
         super().mousePressEvent(event)

--- a/frontengine/user_setting/user_setting_file.py
+++ b/frontengine/user_setting/user_setting_file.py
@@ -39,6 +39,9 @@ user_setting_dict: Dict[str, Any] = {
     # 桌面寵物飽足值（0~100）
     # Desktop pet fullness (0..100)
     "pet_hunger": 70,
+    # 桌面寵物親密度（累積互動）
+    # Desktop pet affection (accumulated interactions)
+    "pet_affection": 0,
 }
 
 

--- a/frontengine/utils/multi_language/english.py
+++ b/frontengine/utils/multi_language/english.py
@@ -229,6 +229,7 @@ english_word_dict = {
     "pet_chatter_hungry": "I'm hungry...|Got a snack?|Feed me, please?|My tummy's rumbling~",
     "pet_chatter_fed": "Yum!|Thank you!|Delicious!|Nom nom (^o^)",
     "pet_chatter_away": "Still there?|I'll nap till you're back~|Zzz...|Take your time!",
+    "pet_chatter_levelup": "Level up!|I'm growing!|We're getting closer!|Yay, thank you!",
     "pet_set_reminder": "Set reminder...",
     "pet_reminder_prompt": "Remind me to:",
     "pet_reminder_minutes": "In how many minutes?",

--- a/frontengine/utils/multi_language/traditional_chinese.py
+++ b/frontengine/utils/multi_language/traditional_chinese.py
@@ -230,6 +230,7 @@ traditional_chinese_word_dict = {
     "pet_chatter_hungry": "我餓了…|有點心嗎？|餵餵我好嗎？|肚子咕咕叫～",
     "pet_chatter_fed": "好吃！|謝謝你！|真美味！|嗯嗯 (^o^)",
     "pet_chatter_away": "還在嗎？|我先打個盹等你回來～|Zzz…|慢慢來沒關係！",
+    "pet_chatter_levelup": "升級了！|我長大了！|我們更親近了！|耶，謝謝你！",
     "pet_set_reminder": "設定提醒...",
     "pet_reminder_prompt": "提醒我：",
     "pet_reminder_minutes": "幾分鐘後？",


### PR DESCRIPTION
Ties the interactions together into a light "raising" loop.

- Interactions build affection: petting +2, feeding +5, greeting a peer +3. Crossing a threshold levels the pet up and it celebrates with a level-up line.
- PetGrowth (thresholds -> level) is a pure, unit-tested class; affection persists in user settings (pet_affection).

Testing: pure PetGrowth (levels, thresholds, level-up detection, clamp, bad input), and widget wiring (reads settings, click/feed grant + persist, threshold crossing celebrates, no level-up no line, talk-off gains silently). compileall clean; full regression green.