### PR TITLE
Desktop pet: audio-reactive pulse (audio visualization)

### DIFF
--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -369,6 +369,15 @@ def format_status(level: int, mood_level: str, hunger_level: str, labels: dict) 
     return f"{level_label}{level} · {mood_text} · {hunger_text}"
 
 
+def audio_pulse_scale(level, base: float = 0.7, amplitude: float = 0.3) -> float:
+    """把音訊音量 (0~1) 轉成脈動縮放比例 / Map an audio level (0..1) to a pulse scale."""
+    try:
+        clamped = max(0.0, min(1.0, float(level)))
+    except (TypeError, ValueError):
+        return 1.0
+    return base + amplitude * clamped
+
+
 def size_for_level(base_size: int, level: int) -> int:
     """依等級放大基礎尺寸（每級 +8%，上限 +50%）/ Grow base size by level (cap +50%)."""
     factor = min(1.5, 1.0 + 0.08 * max(0, int(level) - 1))
@@ -838,7 +847,7 @@ class DesktopPetWidget(BaseWidget):
     def __init__(self, image_path: str, size: int = 128, speed: int = 3,
                  behaviour: str = BEHAVIOUR_FLOOR, climb: bool = True, talk: bool = True,
                  sound_path: Optional[str] = None, sit_on_windows: bool = True,
-                 volume: float = 1.0):
+                 volume: float = 1.0, audio_react: bool = False):
         front_engine_logger.info(
             f"[DesktopPetWidget] Init | path={image_path}, size={size}, speed={speed}, "
             f"behaviour={behaviour}, climb={climb}, talk={talk}, sound={sound_path}, "
@@ -888,6 +897,10 @@ class DesktopPetWidget(BaseWidget):
         self._init_sound(sound_path)
         self._sit_on_windows = bool(sit_on_windows)
         self._platform_tick = 0
+        # 音訊視覺化：依可注入的音量 provider 脈動 / Audio-reactive pulse
+        self._audio_react = bool(audio_react)
+        self._audio_level_provider = None  # callable -> level 0..1 or None
+        self._audio_scale = 1.0
         # 多寵物互動 / Multi-pet interaction
         self._peers_provider = None
         self._peer_greeted = False
@@ -1026,13 +1039,35 @@ class DesktopPetWidget(BaseWidget):
         kind, obj = self._active
         return obj.currentPixmap() if kind == "movie" else obj
 
+    def set_audio_level_provider(self, provider) -> None:
+        """設定回傳目前音量 (0~1 或 None) 的函式 / Provider of the current audio level."""
+        self._audio_level_provider = provider
+
+    def _update_audio_scale(self) -> None:
+        if not self._audio_react or self._audio_level_provider is None:
+            self._audio_scale = 1.0
+            return
+        try:
+            level = self._audio_level_provider()
+        except Exception:  # pragma: no cover - defensive
+            level = None
+        self._audio_scale = 1.0 if level is None else audio_pulse_scale(level)
+
     def draw_content(self, painter: QPainter) -> None:
         pixmap = self._current_pixmap()
         if pixmap is None or pixmap.isNull():
             return
         if self.motion.facing_left:
             pixmap = pixmap.transformed(QTransform().scale(-1, 1))
-        painter.drawPixmap(QRect(0, 0, self.width(), self.height()), pixmap)
+        scale = self._audio_scale if self._audio_react else 1.0
+        if scale >= 0.999:
+            painter.drawPixmap(QRect(0, 0, self.width(), self.height()), pixmap)
+        else:
+            # Anchor to the bottom so the feet stay on the ground while it pulses.
+            width = int(self.width() * scale)
+            height = int(self.height() * scale)
+            painter.drawPixmap(
+                QRect((self.width() - width) // 2, self.height() - height, width, height), pixmap)
 
     def start_moving(self, bounds: Tuple[int, int, int, int], interval_ms: int = 33) -> None:
         front_engine_logger.info(f"[DesktopPetWidget] start_moving | bounds={bounds}")
@@ -1306,6 +1341,9 @@ class DesktopPetWidget(BaseWidget):
         x, y = self.motion.step()
         self.move(x, y)
         self._set_active_sprite(self._visual_state())
+        if self._audio_react:
+            self._update_audio_scale()
+            self.update()
         self._peer_tick += 1
         if self._peer_tick >= 5:
             self._peer_tick = 0

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -90,6 +90,8 @@ class PetSettingUI(QWidget):
         for label, value in (("0%", 0), ("25%", 25), ("50%", 50), ("75%", 75), ("100%", 100)):
             self.volume_combobox.addItem(label, value)
         self.volume_combobox.setCurrentText("100%")
+        self.audio_react_checkbox = QCheckBox(
+            language_wrapper.language_word_dict.get("pet_audio_label", "React to audio"))
 
         # Start
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("pet_start", "Spawn pet"))
@@ -124,6 +126,7 @@ class PetSettingUI(QWidget):
         self.grid_layout.addWidget(self.target_monitor_combobox, 6, 1)
         self.grid_layout.addWidget(self.volume_label, 6, 2)
         self.grid_layout.addWidget(self.volume_combobox, 7, 2)
+        self.grid_layout.addWidget(self.audio_react_checkbox, 7, 0)
 
     def _spawn_pet(self) -> None:
         """建立、顯示並開始移動一隻寵物（供 Start 與右鍵複製共用）。"""
@@ -139,6 +142,7 @@ class PetSettingUI(QWidget):
             sound_path=self.pet_sound_path,
             sit_on_windows=self.sit_checkbox.isChecked(),
             volume=int(self.volume_combobox.currentData()) / 100.0,
+            audio_react=self.audio_react_checkbox.isChecked(),
         )
         pet.clone_requested.connect(self._spawn_pet)
         pet.set_peers_provider(lambda me=pet: self._peer_centers(me))
@@ -253,6 +257,7 @@ class PetSettingUI(QWidget):
             "sit": self.sit_checkbox.isChecked(),
             "target_monitor": self.target_monitor_combobox.currentText(),
             "volume": self.volume_combobox.currentText(),
+            "audio_react": self.audio_react_checkbox.isChecked(),
         }
 
     def set_state(self, state: dict) -> None:
@@ -288,3 +293,5 @@ class PetSettingUI(QWidget):
             index = self.volume_combobox.findText(str(state["volume"]))
             if index >= 0:
                 self.volume_combobox.setCurrentIndex(index)
+        if "audio_react" in state:
+            self.audio_react_checkbox.setChecked(bool(state["audio_react"]))

--- a/frontengine/utils/multi_language/english.py
+++ b/frontengine/utils/multi_language/english.py
@@ -247,6 +247,7 @@ english_word_dict = {
     "pet_talk_label": "Speech bubbles",
     "pet_sit_label": "Sit on windows",
     "pet_volume_label": "Volume",
+    "pet_audio_label": "React to audio",
     "pet_chatter_morning": "Good morning!|Rise and shine!|Ready for the day?",
     "pet_chatter_afternoon": "Good afternoon!|Taking a break?|Keep it up!",
     "pet_chatter_evening": "Good evening!|How was your day?|Almost done?",

--- a/frontengine/utils/multi_language/traditional_chinese.py
+++ b/frontengine/utils/multi_language/traditional_chinese.py
@@ -248,6 +248,7 @@ traditional_chinese_word_dict = {
     "pet_talk_label": "對話泡泡",
     "pet_sit_label": "站在視窗上",
     "pet_volume_label": "音量",
+    "pet_audio_label": "隨音訊律動",
     "pet_chatter_morning": "早安！|新的一天開始囉！|準備好了嗎？",
     "pet_chatter_afternoon": "午安！|要不要休息一下？|繼續加油！",
     "pet_chatter_evening": "晚上好！|今天過得如何？|快完成了嗎？",


### PR DESCRIPTION
Brings audio visualization to the pet.

- With **React to audio** enabled and a level provider set, the pet breathes/pulses with the audio level. audio_pulse_scale maps a 0..1 level to a bottom-anchored draw scale (feet stay on the ground).
- The level source is pluggable via set_audio_level_provider and defaults to none (no visible effect until a real level source is supplied), so it is safe by default.

Testing: pure audio_pulse_scale (base/max/mid/clamp/bad input), widget scale updates from an injected provider (silent/loud/None/error), safe pulsed + non-react paint paths, and page toggle + spawn + state round-trip. compileall clean; full regression green.