### PR TITLE
Fix the test suite so pytest can run again

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,10 @@
+---
+# 測試碼不納入靜態分析：pytest 本來就以 assert 斷言（Bandit B101）、
+# 用 random 產生可重現的測試資料（B311），並以動態匯入巡覽套件模組，
+# 這些在測試情境下都是預期用法，掃描只會產生誤報。
+#
+# Exclude test code from static analysis: pytest asserts by design (Bandit
+# B101), uses random for reproducible fixtures (B311) and imports modules
+# dynamically to walk the package — all expected in tests, and only noise here.
+exclude_paths:
+  - 'tests/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Compile package
         run: python -m compileall -q frontengine
 
+      - name: Run unit tests
+        run: python -m pytest tests/ -q
+
       - name: Start FrontEngine
         run: python ./tests/unit_test/start/start_front_engine.py
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,7 @@
 PySide6==6.10.2
 qt-material
 frontengine
+pytest
 twine
 build
 auto-py-to-exe

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""
+測試共用設定：強制 Qt 使用 offscreen 平台，並把工作目錄移到暫存區，
+避免匯入 frontengine 時產生的日誌檔落在專案目錄。
+
+Shared test setup: force Qt's offscreen platform and run from a temporary
+working directory so the log file created on import does not land in the repo.
+"""
+import os
+import tempfile
+
+import pytest
+
+# 必須在匯入任何 Qt 模組前設定 / Must be set before any Qt module is imported.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _run_from_temporary_directory():
+    """整個測試 session 在暫存目錄下執行 / Run the session from a temp directory."""
+    original = os.getcwd()
+    with tempfile.TemporaryDirectory() as directory:
+        os.chdir(directory)
+        try:
+            yield directory
+        finally:
+            os.chdir(original)

--- a/tests/unit_test/start_manual/quick_test.py
+++ b/tests/unit_test/start_manual/quick_test.py
@@ -1,4 +1,0 @@
-from frontengine import ChatSceneUI
-
-a = ChatSceneUI()
-

--- a/tests/unit_test/test_pet_logic.py
+++ b/tests/unit_test/test_pet_logic.py
@@ -1,0 +1,233 @@
+"""
+桌面寵物的純邏輯測試（不建立任何 widget，因此不需要 QApplication）：
+移動模型、心情／飽足／成長、台詞挑選、動作包掃描與音訊脈動換算。
+
+Pure-logic tests for the desktop pet — no widgets are created, so no
+QApplication is needed: the motion model, mood/hunger/growth, chatter picking,
+pet-pack scanning and the audio pulse mapping.
+"""
+import random
+
+from frontengine.show.pet.desktop_pet import (
+    BEHAVIOUR_FLOOR, BEHAVIOUR_WANDER, PetGrowth, PetHunger, PetMood, PetMotion, PetTimeline,
+    STATE_CLIMB, STATE_DRAG, STATE_FALL, STATE_IDLE, STATE_SLEEP, STATE_WALK, SURFACE_CEILING,
+    SURFACE_FLOOR, SURFACE_LEFT, audio_pulse_scale, derive_visual_state, format_status,
+    message_bucket, nearest_peer, parse_timeline, pick_message, pop_due_reminders, scan_pet_pack,
+    size_for_level,
+)
+
+BOUNDS = (0, 0, 800, 600)
+
+
+def _motion(**kwargs) -> PetMotion:
+    options = dict(x=0, y=0, width=64, height=64, bounds=BOUNDS, speed=4, rng=random.Random(1))
+    options.update(kwargs)
+    return PetMotion(**options)
+
+
+# --- motion ---------------------------------------------------------------
+def test_gravity_lands_on_the_floor() -> None:
+    motion = _motion(y=0, behaviour=BEHAVIOUR_FLOOR)
+    for _ in range(200):
+        motion.step()
+    assert motion.y + motion.height <= BOUNDS[3]
+    assert not motion._airborne
+
+
+def test_walking_stays_inside_the_bounds() -> None:
+    motion = _motion(behaviour=BEHAVIOUR_FLOOR, climb=False)
+    for _ in range(500):
+        x, _y = motion.step()
+        assert BOUNDS[0] <= x <= BOUNDS[2] - motion.width
+
+
+def test_wander_bounces_off_every_edge() -> None:
+    motion = _motion(behaviour=BEHAVIOUR_WANDER)
+    for _ in range(500):
+        x, y = motion.step()
+        assert BOUNDS[0] <= x <= BOUNDS[2] - motion.width
+        assert BOUNDS[1] <= y <= BOUNDS[3] - motion.height
+
+
+def test_throw_makes_it_airborne_then_it_settles() -> None:
+    motion = _motion(behaviour=BEHAVIOUR_FLOOR)
+    motion.throw(6.0, -12.0)
+    assert motion._airborne
+    for _ in range(400):
+        motion.step()
+    assert not motion._airborne
+
+
+def test_grab_nearest_wall_only_near_an_edge() -> None:
+    middle = _motion(x=400)
+    assert middle.grab_nearest_wall() is False
+    edge = _motion(x=5)
+    assert edge.grab_nearest_wall() is True
+    assert edge.surface == SURFACE_LEFT
+
+
+def test_climbing_is_opt_out() -> None:
+    motion = _motion(x=5, climb=False)
+    assert motion.grab_nearest_wall() is False
+
+
+def test_follow_target_walks_toward_it_then_clears() -> None:
+    motion = _motion(x=100)
+    motion.set_follow(300.0)
+    for _ in range(200):
+        motion.step()
+        if motion.follow_target_x is None:
+            break
+    assert motion.follow_target_x is None
+    assert 200 < motion.x + motion.width / 2 < 400
+
+
+def test_platform_walking_turns_at_the_span_edges() -> None:
+    motion = _motion(x=200, y=236)
+    motion.set_platforms([(200.0, 400.0, 300.0)])
+    motion.on_platform = True
+    motion.ground_feet = 300.0
+    motion.surface = SURFACE_FLOOR
+    for _ in range(300):
+        motion.step()
+        assert 200.0 <= motion.x <= 400.0 - motion.width
+
+
+def test_platform_vanishing_drops_the_pet() -> None:
+    motion = _motion(x=200, y=236)
+    motion.on_platform = True
+    motion.ground_feet = 300.0
+    motion.set_platforms([])
+    motion.step()
+    assert motion.on_platform is False
+
+
+def test_sleep_and_wake() -> None:
+    motion = _motion()
+    motion.sleep()
+    assert motion.state == STATE_SLEEP
+    motion.wake()
+    assert motion.state == STATE_WALK
+
+
+# --- visual state ---------------------------------------------------------
+def test_derive_visual_state_priority() -> None:
+    assert derive_visual_state(True, True, SURFACE_FLOOR, STATE_WALK) == STATE_DRAG
+    assert derive_visual_state(False, True, SURFACE_FLOOR, STATE_WALK) == STATE_FALL
+    assert derive_visual_state(False, False, SURFACE_CEILING, STATE_WALK) == STATE_CLIMB
+    assert derive_visual_state(False, False, SURFACE_FLOOR, STATE_SLEEP) == STATE_SLEEP
+    assert derive_visual_state(False, False, SURFACE_FLOOR, "idle") == STATE_IDLE
+    assert derive_visual_state(False, False, SURFACE_FLOOR, STATE_WALK) == STATE_WALK
+
+
+# --- mood / hunger / growth ----------------------------------------------
+def test_mood_buckets_and_clamps() -> None:
+    assert PetMood(200).value == 100
+    assert PetMood(-5).value == 0
+    assert PetMood("bad").value == 60
+    assert PetMood(90).level() == PetMood.HAPPY
+    assert PetMood(50).level() == PetMood.CONTENT
+    assert PetMood(10).level() == PetMood.SAD
+
+
+def test_hunger_feeding_and_decay() -> None:
+    hunger = PetHunger(20)
+    assert hunger.level() == PetHunger.HUNGRY
+    hunger.feed()
+    assert hunger.value == 50
+    assert hunger.level() == PetHunger.OK
+    hunger.feed()
+    assert hunger.level() == PetHunger.FULL
+    for _ in range(200):
+        hunger.decay()
+    assert hunger.value == 0
+
+
+def test_growth_levels_up_on_thresholds() -> None:
+    growth = PetGrowth(0)
+    assert growth.level() == 1
+    assert growth.add(100) is True
+    assert growth.level() == 2
+    assert growth.add(1) is False
+    assert PetGrowth(-10).affection == 0
+
+
+def test_size_grows_with_level_but_is_capped() -> None:
+    assert size_for_level(100, 1) == 100
+    assert size_for_level(100, 2) == 108
+    assert size_for_level(100, 99) == 150
+    assert size_for_level(1, 1) >= 16
+
+
+def test_format_status_uses_labels() -> None:
+    labels = {"level": "Lv.", PetMood.HAPPY: "happy", PetHunger.FULL: "full"}
+    assert format_status(3, PetMood.HAPPY, PetHunger.FULL, labels) == "Lv.3 · happy · full"
+
+
+# --- chatter --------------------------------------------------------------
+def test_message_bucket_covers_the_clock() -> None:
+    assert message_bucket(8) == "morning"
+    assert message_bucket(14) == "afternoon"
+    assert message_bucket(20) == "evening"
+    assert message_bucket(2) == "night"
+    assert message_bucket(26) == "night"  # 26 wraps to 02:00
+
+
+def test_pick_message_prefers_mood_then_time_then_generic() -> None:
+    messages = {"happy": ["mood"], "morning": ["time"], "any": ["generic"]}
+    assert pick_message(8, random.Random(0), messages, mood="happy") in ("mood", "time", "generic")
+    assert pick_message(8, random.Random(0), {"morning": ["time"]}) == "time"
+    assert pick_message(8, random.Random(0), {"any": ["generic"]}) == "generic"
+    assert pick_message(8, random.Random(0), {}) == ""
+
+
+# --- timeline / reminders / peers ----------------------------------------
+def test_parse_timeline_skips_malformed_entries() -> None:
+    events = parse_timeline([{"at": 1, "say": "hi"}, {"say": "no at"}, "junk", {"at": "x"}])
+    assert len(events) == 1
+
+
+def test_timeline_pops_events_in_order_once() -> None:
+    timeline = PetTimeline([(2, {"say": "b"}), (1, {"say": "a"})])
+    assert [event["say"] for event in timeline.pop_due(1.5)] == ["a"]
+    assert [event["say"] for event in timeline.pop_due(3)] == ["b"]
+    assert timeline.pop_due(9) == []
+    timeline.reset()
+    assert len(timeline.pop_due(9)) == 2
+
+
+def test_pop_due_reminders_splits_on_now() -> None:
+    due, remaining = pop_due_reminders(10, [(5, "past"), (15, "future")])
+    assert [text for _when, text in due] == ["past"]
+    assert [text for _when, text in remaining] == ["future"]
+
+
+def test_nearest_peer_picks_the_closest() -> None:
+    peer, distance = nearest_peer((0, 0), [(30, 40), (3, 4)])
+    assert peer == (3, 4)
+    assert distance == 5
+    assert nearest_peer((0, 0), []) == (None, float("inf"))
+
+
+# --- pet packs ------------------------------------------------------------
+def test_scan_pet_pack_maps_aliases(tmp_path) -> None:
+    (tmp_path / "run.png").write_bytes(b"x")
+    (tmp_path / "sit.gif").write_bytes(b"x")
+    (tmp_path / "notes.txt").write_bytes(b"x")
+    pack = scan_pet_pack(str(tmp_path))
+    assert set(pack) == {STATE_WALK, STATE_IDLE}
+
+
+def test_scan_pet_pack_tolerates_bad_input(tmp_path) -> None:
+    assert scan_pet_pack(str(tmp_path / "missing")) == {}
+    assert scan_pet_pack(str(tmp_path / "file.png")) == {}
+
+
+# --- audio pulse ----------------------------------------------------------
+def test_audio_pulse_scale_maps_and_clamps() -> None:
+    assert audio_pulse_scale(0.0) == 0.7
+    assert audio_pulse_scale(1.0) == 1.0
+    assert audio_pulse_scale(0.5) == 0.85
+    assert audio_pulse_scale(9.0) == 1.0
+    assert audio_pulse_scale(-9.0) == 0.7
+    assert audio_pulse_scale("loud") == 1.0

--- a/tests/unit_test/test_public_api.py
+++ b/tests/unit_test/test_public_api.py
@@ -1,0 +1,41 @@
+"""
+守住公開匯入介面：`frontengine.__all__` 的每個名稱都要存在，且套件內每個模組
+都要能單獨匯入。移除功能卻留下舊匯入的情況（例如已刪除的 ChatSceneUI）會在此被抓到。
+
+Guard the public import surface: every name in ``frontengine.__all__`` must
+resolve, and every module in the package must import on its own. This catches
+imports left behind by removed features (e.g. the deleted ChatSceneUI).
+"""
+import importlib
+import pkgutil
+
+import pytest
+
+import frontengine
+
+
+def test_all_is_declared() -> None:
+    assert isinstance(frontengine.__all__, list)
+    assert frontengine.__all__, "__all__ must not be empty"
+
+
+@pytest.mark.parametrize("name", frontengine.__all__)
+def test_exported_name_resolves(name: str) -> None:
+    assert hasattr(frontengine, name), f"{name} is exported but missing"
+
+
+def test_exported_names_are_unique() -> None:
+    assert len(frontengine.__all__) == len(set(frontengine.__all__))
+
+
+def _module_names() -> list:
+    """列出 frontengine 底下所有子模組 / Every submodule under frontengine."""
+    return [
+        module.name
+        for module in pkgutil.walk_packages(frontengine.__path__, prefix="frontengine.")
+    ]
+
+
+@pytest.mark.parametrize("module_name", _module_names())
+def test_module_imports(module_name: str) -> None:
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

`python -m pytest tests/` — the command documented in the README and CLAUDE.md —
has been failing at collection since the chat feature was removed in 7ace791:
`tests/unit_test/start_manual/quick_test.py` still imported `ChatSceneUI`, which
no longer exists. Nothing in the repo ran it, so it went unnoticed.

- Drop the leftover script (it drove a feature deleted in Jan 2024).
- Give the documented command real work:
  - `test_public_api.py` imports **every** module in the package and checks
    every name in `__all__` — the same class of breakage that caused this, so it
    now fails loudly and locally.
  - `test_pet_logic.py` covers the pet's pure logic with no widgets and no
    `QApplication`: motion (gravity/landing, bounds, throw, wall grab, follow,
    window platforms, sleep/wake), visual-state derivation, mood/hunger/growth,
    chatter selection, timeline/reminders/peers, pet-pack scanning and the audio
    pulse mapping.
- `tests/conftest.py` forces Qt's offscreen platform and runs the session from a
  temp directory, so the log file created on import stays out of the tree.
- CI runs the suite (`pytest tests/ -q`) after the compile step, and `pytest` is
  added to `dev_requirements.txt` so the runner actually has it.

## Testing

- `python -m pytest tests/ -q` → **177 passed** locally (Windows, Python 3.14).
- `python -m compileall -q frontengine` clean.

## Note

The **CI workflow itself was disabled** (`disabled_inactivity`) after the repo's
quiet stretch, so no CI has run on recent pushes or PRs — including #160, which
only got the external Codacy/SonarCloud checks. I re-enabled it, so this PR
should be the first to exercise the workflow again.
