### PR TITLE
Tag in every behaviour mode, and keep the nightly cron from disabling CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,20 @@
 name: CI
 
+# 注意：本檔刻意不放 schedule 觸發。GitHub 會在專案閒置約 60 天後自動停用「含排程的
+# workflow」，那會連 push / pull_request 的檢查一起停掉（曾實際發生）。排程改放在
+# nightly.yml，它再呼叫本 workflow；就算 nightly 被停用，PR 與 push 的 CI 仍會照跑。
+#
+# NOTE: no `schedule:` trigger here on purpose. GitHub disables workflows that
+# contain a schedule after ~60 days of repository inactivity, which takes the
+# push/pull_request checks down with it (this happened). The cron lives in
+# nightly.yml and calls this workflow instead, so PR and push CI keep running
+# even if the nightly one is disabled.
 on:
   push:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
-  schedule:
-    - cron: "0 9 * * *"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: Nightly
+
+# 這裡只放排程，實際檢查沿用 ci.yml。GitHub 會在專案閒置約 60 天後停用「含排程的
+# workflow」，把排程隔離在這個檔案，被停用時也只損失每日檢查，PR 與 push 的 CI 照跑。
+# 若發現本 workflow 被停用：`gh workflow enable Nightly`（狀態用 `gh workflow list --all` 查）。
+#
+# Schedule-only wrapper around the CI workflow. GitHub disables workflows that
+# contain a schedule after ~60 days of repository inactivity; keeping the cron
+# here means only the daily run is lost, while push and pull request CI keeps
+# working. Re-enable with `gh workflow enable Nightly` (check the state with
+# `gh workflow list --all`).
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml

--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -403,14 +403,28 @@ class PetTagGame:
         return self._roles(positions, prey)
 
     def _roles(self, positions: dict, prey) -> dict:
-        """依目前的鬼與獵物組出每個人的角色與要走向的 x。"""
-        it_x, _it_y = positions[self.it]
-        roles = {self.it: (TAG_CHASE, positions[prey][0] if prey is not None else it_x)}
-        for participant, (x, _y) in positions.items():
+        """
+        依目前的鬼與獵物組出每個人的 (角色, 目標 x, 目標 y)。逃跑方向取兩點連線的反向，
+        讓地板模式（只用 x）與飄移／追游標模式（用整個點）都有合理目標。
+        Build each participant's (role, target_x, target_y). Runners head along
+        the line away from "it", which suits floor pets (x only) and wander or
+        chase pets (the whole point) alike.
+        """
+        it_x, it_y = positions[self.it]
+        prey_position = positions[prey] if prey is not None else (it_x, it_y)
+        roles = {self.it: (TAG_CHASE, float(prey_position[0]), float(prey_position[1]))}
+        for participant, (x, y) in positions.items():
             if participant == self.it:
                 continue
-            away = self.flee_distance if x >= it_x else -self.flee_distance
-            roles[participant] = (TAG_FLEE, x + away)
+            dx, dy = x - it_x, y - it_y
+            length = (dx * dx + dy * dy) ** 0.5
+            if length < 1e-9:  # standing on each other: just pick a direction
+                dx, dy, length = 1.0, 0.0, 1.0
+            roles[participant] = (
+                TAG_FLEE,
+                x + self.flee_distance * dx / length,
+                y + self.flee_distance * dy / length,
+            )
         return roles
 
 
@@ -666,6 +680,10 @@ class PetMotion:
         self.ground_feet = 0.0
         # 追向某個 x（用於朝同伴走過去玩耍）/ Horizontal target to walk toward (play).
         self.follow_target_x: Optional[float] = None
+        # 引導目標 (x, y)：三種行為模式都會朝它移動（鬼抓人用），優先於各自的預設動線。
+        # Guidance point (x, y) honoured by every behaviour (used by the tag
+        # game); it takes precedence over each mode's own default movement.
+        self.guidance: Optional[Tuple[float, float]] = None
 
     @property
     def facing_left(self) -> bool:
@@ -712,6 +730,43 @@ class PetMotion:
 
     def set_target(self, x: float, y: float) -> None:
         self.target = (float(x), float(y))
+
+    def set_guidance(self, x: float, y: Optional[float] = None) -> None:
+        """
+        設定引導目標；地板模式走向該 x，飄移／追游標模式則朝該點移動。
+        Set the guidance point: floor pets walk toward its x, wander and chase
+        pets steer toward the point itself.
+        """
+        centre_y = self.y + self.height / 2.0
+        self.guidance = (float(x), centre_y if y is None else float(y))
+        if self.behaviour == BEHAVIOUR_FLOOR:
+            self.follow_target_x = self.guidance[0]
+
+    def clear_guidance(self) -> None:
+        """取消引導，回到該模式原本的動線 / Drop the guidance and resume normal movement."""
+        self.guidance = None
+        self.follow_target_x = None
+
+    STEER_BLEND = 0.4
+
+    def _steer_toward(self, point: Tuple[float, float]) -> None:
+        """把速度往目標點轉一些（保持速率），轉彎自然而不是瞬間轉向。"""
+        target_x, target_y = point
+        dx = target_x - (self.x + self.width / 2.0)
+        dy = target_y - (self.y + self.height / 2.0)
+        distance = (dx * dx + dy * dy) ** 0.5
+        if distance < 1e-9:
+            return
+        desired_x = self.speed * dx / distance
+        desired_y = self.speed * dy / distance
+        blended_x = self.vx + self.STEER_BLEND * (desired_x - self.vx)
+        blended_y = self.vy + self.STEER_BLEND * (desired_y - self.vy)
+        magnitude = (blended_x * blended_x + blended_y * blended_y) ** 0.5
+        if magnitude < 1e-9:
+            self.vx, self.vy = desired_x, desired_y
+            return
+        self.vx = self.speed * blended_x / magnitude
+        self.vy = self.speed * blended_y / magnitude
 
     def throw(self, vx: float, vy: float) -> None:
         """拖曳放開後以動量丟出（只在重力模式有意義）。"""
@@ -945,6 +1000,8 @@ class PetMotion:
     def _step_wander(self, left, top, right, bottom) -> Tuple[int, int]:
         if abs(self.vy) < 1e-9:
             self.vy = float(self.speed)
+        if self.guidance is not None:
+            self._steer_toward(self.guidance)
         self.x += self.vx
         self.y += self.vy
         if self.x <= left:
@@ -963,14 +1020,19 @@ class PetMotion:
 
     # --- chase cursor ---
     def _step_chase(self, left, top, right, bottom) -> Tuple[int, int]:
-        if self.target is None:
+        # 被引導時（鬼抓人）以引導目標為準，而不是游標
+        # While guided (tag game) the guidance point wins over the cursor.
+        chase_target = self.guidance if self.guidance is not None else self.target
+        if chase_target is None:
             return int(self.x), int(self.y)
-        target_x, target_y = self.target
+        target_x, target_y = chase_target
         dx = target_x - (self.x + self.width / 2)
         dy = target_y - (self.y + self.height / 2)
         distance = (dx * dx + dy * dy) ** 0.5
         if distance <= self.CHASE_STOP_DISTANCE:
-            self.asleep = True
+            # 追到游標會睡著；玩鬼抓人時只是站在對方身上，不睡。
+            # Catching the cursor means a nap; catching a playmate does not.
+            self.asleep = self.guidance is None
             return int(self.x), int(self.y)
         self.asleep = False
         step = float(self.speed) * self.CHASE_SPEED_FACTOR
@@ -1111,17 +1173,17 @@ class DesktopPetWidget(BaseWidget):
 
     def apply_tag_role(self, role) -> None:
         """
-        套用鬼抓人角色 (角色, 目標 x)；None 代表沒在玩，恢復平常的同伴互動。
+        套用鬼抓人角色 (角色, 目標 x, 目標 y)；None 代表沒在玩，恢復平常的同伴互動。
         Apply a tag role; None means the game is off and normal peer play resumes.
         """
         if role is None:
             if self._tag_role is not None:
                 self._tag_role = None
-                self.motion.clear_follow()
+                self.motion.clear_guidance()
             return
-        self._tag_role, target_x = role
+        self._tag_role, target_x, target_y = role
         self.motion.wake()
-        self.motion.set_follow(target_x)
+        self.motion.set_guidance(target_x, target_y)
 
     def on_tagged(self) -> None:
         """換自己當鬼時喊一句 / Shout when the tag lands on this pet."""

--- a/tests/unit_test/test_pet_guidance.py
+++ b/tests/unit_test/test_pet_guidance.py
@@ -1,0 +1,117 @@
+"""
+PetMotion 的引導目標測試：三種行為模式都要能被導向指定點（鬼抓人用）。
+Tests for PetMotion guidance — every behaviour must steer toward a given point,
+which is what lets the tag game work outside floor mode.
+"""
+import random
+
+from frontengine.show.pet.desktop_pet import (
+    BEHAVIOUR_CHASE, BEHAVIOUR_FLOOR, BEHAVIOUR_WANDER, PetMotion,
+)
+
+BOUNDS = (0, 0, 800, 600)
+
+
+def _motion(**kwargs) -> PetMotion:
+    options = dict(x=0, y=0, width=64, height=64, bounds=BOUNDS, speed=4, rng=random.Random(1))
+    options.update(kwargs)
+    return PetMotion(**options)
+
+
+def _centre(motion: PetMotion):
+    return (motion.x + motion.width / 2.0, motion.y + motion.height / 2.0)
+
+
+def _distance_to(motion: PetMotion, point) -> float:
+    centre_x, centre_y = _centre(motion)
+    return ((point[0] - centre_x) ** 2 + (point[1] - centre_y) ** 2) ** 0.5
+
+
+def test_guidance_starts_unset() -> None:
+    assert _motion().guidance is None
+
+
+def test_floor_guidance_walks_toward_the_x() -> None:
+    motion = _motion(x=100, y=536, behaviour=BEHAVIOUR_FLOOR)
+    motion.set_guidance(600.0, 0.0)
+    assert motion.follow_target_x == 600.0
+    for _ in range(200):
+        motion.step()
+        if motion.follow_target_x is None:
+            break
+    assert motion.x + motion.width / 2 > 500
+
+
+def test_guidance_defaults_its_y_to_the_current_centre() -> None:
+    motion = _motion(x=0, y=200, behaviour=BEHAVIOUR_WANDER)
+    motion.set_guidance(500.0)
+    assert motion.guidance == (500.0, 232.0)
+
+
+def test_wander_steers_toward_the_guidance_point() -> None:
+    motion = _motion(x=0, y=0, behaviour=BEHAVIOUR_WANDER)
+    target = (600.0, 400.0)
+    motion.set_guidance(*target)
+    before = _distance_to(motion, target)
+    for _ in range(200):
+        motion.step()
+    assert _distance_to(motion, target) < before / 2
+
+
+def test_wander_keeps_its_speed_while_steering() -> None:
+    motion = _motion(x=0, y=0, behaviour=BEHAVIOUR_WANDER)
+    motion.set_guidance(600.0, 400.0)
+    for _ in range(50):
+        motion.step()
+        speed = (motion.vx ** 2 + motion.vy ** 2) ** 0.5
+        assert abs(speed - motion.speed) < 1e-6
+
+
+def test_wander_stays_inside_the_bounds_while_guided() -> None:
+    motion = _motion(x=0, y=0, behaviour=BEHAVIOUR_WANDER)
+    motion.set_guidance(5000.0, -5000.0)  # far outside the screen
+    for _ in range(300):
+        x, y = motion.step()
+        assert BOUNDS[0] <= x <= BOUNDS[2] - motion.width
+        assert BOUNDS[1] <= y <= BOUNDS[3] - motion.height
+
+
+def test_unguided_wander_is_unchanged() -> None:
+    motion = _motion(x=100, y=100, behaviour=BEHAVIOUR_WANDER)
+    velocity = (motion.vx, motion.vy)
+    motion.step()
+    assert (motion.vx, motion.vy) == velocity, "no guidance means no steering"
+
+
+def test_chase_guidance_wins_over_the_cursor() -> None:
+    motion = _motion(x=0, y=0, behaviour=BEHAVIOUR_CHASE)
+    motion.set_target(10.0, 10.0)        # the cursor, right next to the pet
+    motion.set_guidance(700.0, 500.0)    # the playmate, far away
+    for _ in range(200):
+        motion.step()
+    assert _distance_to(motion, (700.0, 500.0)) < 20
+    assert motion.asleep is False, "reaching a playmate is not a nap"
+
+
+def test_chase_without_guidance_still_naps_on_the_cursor() -> None:
+    motion = _motion(x=0, y=0, behaviour=BEHAVIOUR_CHASE)
+    motion.set_target(60.0, 60.0)
+    for _ in range(60):
+        motion.step()
+    assert motion.asleep is True
+
+
+def test_clearing_guidance_releases_the_pet() -> None:
+    motion = _motion(behaviour=BEHAVIOUR_FLOOR)
+    motion.set_guidance(600.0, 0.0)
+    motion.clear_guidance()
+    assert motion.guidance is None
+    assert motion.follow_target_x is None
+
+
+def test_guidance_is_accepted_for_every_behaviour() -> None:
+    for behaviour in (BEHAVIOUR_FLOOR, BEHAVIOUR_WANDER, BEHAVIOUR_CHASE):
+        motion = _motion(behaviour=behaviour)
+        motion.set_guidance(300.0, 300.0)
+        assert motion.guidance == (300.0, 300.0)
+        motion.step()  # must not raise in any mode

--- a/tests/unit_test/test_pet_tag.py
+++ b/tests/unit_test/test_pet_tag.py
@@ -26,7 +26,7 @@ def test_the_chaser_heads_for_its_nearest_peer() -> None:
     game = PetTagGame()
     game.it = "a"
     roles = game.update({"a": (0, 0), "b": (700, 0), "c": (300, 0)})
-    assert roles["a"] == (TAG_CHASE, 300)
+    assert roles["a"] == (TAG_CHASE, 300.0, 0.0)
 
 
 def test_runners_head_away_from_the_chaser() -> None:
@@ -35,6 +35,24 @@ def test_runners_head_away_from_the_chaser() -> None:
     roles = game.update({"a": (400, 0), "b": (600, 0), "c": (200, 0)})
     assert roles["b"][1] > 600, "a peer on the right runs further right"
     assert roles["c"][1] < 200, "a peer on the left runs further left"
+
+
+def test_runners_flee_diagonally_when_they_are_not_in_line() -> None:
+    game = PetTagGame(flee_distance=100.0)
+    game.it = "a"
+    roles = game.update({"a": (0, 0), "b": (60, 80)})  # 3-4-5 triangle, out of reach
+    _role, target_x, target_y = roles["b"]
+    assert round(target_x) == 120, "runs 100 further along the same direction"
+    assert round(target_y) == 160
+
+
+def test_overlapping_runners_still_get_a_direction() -> None:
+    # Seeded by update() so the opening cooldown holds the tag off, leaving two
+    # pets standing on exactly the same spot with no direction to flee along.
+    game = PetTagGame(flee_distance=50.0, cooldown_ticks=99)
+    roles = game.update({"a": (100, 100), "b": (100, 100)})
+    assert game.it == "a"
+    assert roles["b"] == (TAG_FLEE, 150.0, 100.0)
 
 
 def test_catching_passes_the_tag_on() -> None:
@@ -112,7 +130,7 @@ def test_the_chase_converges_when_the_chaser_is_faster() -> None:
         if game.just_tagged is not None:
             tagged = True
             break
-        for key, (role, target_x) in roles.items():
+        for key, (role, target_x, _target_y) in roles.items():
             speed = 6.0 if role == TAG_CHASE else 3.0
             step = speed if target_x > positions[key][0] else -speed
             positions[key][0] += step


### PR DESCRIPTION
## Summary

**Tag now works in every behaviour mode.** The game steered pets through the
floor-mode "walk toward this x" target, so free-wander and chase-cursor pets
ignored it. `PetMotion` gains a guidance point that all three modes honour:

- *floor* — walks toward its x, exactly as before;
- *wander* — steers its velocity toward the point, keeping its speed and its
  bouncing off the screen edges, so an off-screen flee target never carries it
  outside the bounds;
- *chase cursor* — follows the point instead of the cursor while guided, and
  reaching a playmate no longer counts as catching the cursor, so pets stop
  falling asleep on top of each other. Clearing the role hands it back to the
  cursor.

Tag roles now carry a 2D target, and runners flee along the line away from "it"
rather than only left or right, which is what makes the diagonal modes look
right.

**The nightly cron no longer risks taking CI down.** GitHub disables workflows
containing a `schedule:` after ~60 days of repository inactivity — and that
disabled the whole CI workflow, push and pull request checks included, which is
why PR #160 originally ran with no CI at all. CI is now push/pull_request plus
`workflow_call`, and a thin `Nightly` workflow owns the cron and calls it. If
inactivity disables anything in future, it is only the nightly run; PR and push
CI keep working.

## Testing

- `python -m pytest tests/ -q` → **235 passed** (222 before), including a new
  `test_pet_guidance.py`: guidance defaults, floor walk-to-x, wander steering
  and speed preservation, staying inside the bounds with an off-screen target,
  unguided wander being untouched, guidance beating the cursor, and naps only
  happening for the cursor.
- 48 headless widget/page tests green, including a new one that runs a mixed
  floor + wander + chase game through the settings page: every pet gets a role,
  exactly one chaser, and opting out releases all three.
- `python -m compileall -q frontengine` clean.
- Both workflow files parse; `Nightly` reuses the CI job rather than copying it.
