### PR TITLE
Fix the broken release: missing __init__.py left a package out of the wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,23 @@ jobs:
       - name: Run unit tests
         run: python -m pytest tests/ -q
 
+      # 啟動測試要用「這份 checkout 打包出來的套件」，不是 PyPI 上的版本。
+      # 之前 dev_requirements 會裝下published 的 frontengine，而啟動腳本從自己的
+      # 目錄執行，import 就落到 site-packages——等於在測已發布的版本，PR 改了什麼
+      # 都測不到。少一個 __init__.py 會讓整個子套件不被打包，就是這樣漏過去的。
+      #
+      # The start-up checks must run against the package built from THIS
+      # checkout, not the one on PyPI. dev_requirements used to install the
+      # published frontengine, and the start scripts run from their own
+      # directory, so the import landed in site-packages: the checks validated
+      # the released version and never the pull request. A missing __init__.py
+      # drops a whole sub-package from the wheel, which is how one slipped past.
+      - name: Install the built package
+        run: |
+          python -m pip install --upgrade build
+          python -m build --wheel --outdir dist
+          python -m pip install --no-deps --force-reinstall (Get-ChildItem dist/*.whl).FullName
+
       - name: Start FrontEngine
         run: python ./tests/unit_test/start/start_front_engine.py
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,5 @@
 PySide6==6.10.2
 qt-material
-frontengine
 pytest
 twine
 build

--- a/tests/unit_test/test_public_api.py
+++ b/tests/unit_test/test_public_api.py
@@ -8,6 +8,7 @@ imports left behind by removed features (e.g. the deleted ChatSceneUI).
 """
 import importlib
 import pkgutil
+from pathlib import Path
 
 import pytest
 
@@ -39,3 +40,29 @@ def _module_names() -> list:
 @pytest.mark.parametrize("module_name", _module_names())
 def test_module_imports(module_name: str) -> None:
     importlib.import_module(module_name)
+
+
+def test_every_package_directory_has_an_init_file() -> None:
+    """
+    每個放了 .py 的資料夾都必須有 __init__.py。setuptools 的 find 設定是
+    `namespaces = false`，少了它那個資料夾就**不會被打包**——從原始碼跑得好好的，
+    使用者 pip 安裝後卻會 ModuleNotFoundError（frontengine.utils.screen_text
+    就是這樣漏掉的，直到裝好的套件連 import 都失敗才發現）。
+
+    Every directory holding .py files needs an __init__.py. Packaging uses
+    setuptools' find with ``namespaces = false``, so a directory without one is
+    **left out of the wheel**: it runs fine from a checkout and raises
+    ModuleNotFoundError once installed. That is exactly how
+    frontengine.utils.screen_text escaped, until the installed package could not
+    be imported at all.
+    """
+    root = Path(frontengine.__file__).parent
+    missing = []
+    for directory in sorted(root.rglob("*")):
+        if not directory.is_dir() or directory.name == "__pycache__":
+            continue
+        holds_python = any(child.suffix == ".py" for child in directory.iterdir()
+                           if child.is_file())
+        if holds_python and not (directory / "__init__.py").exists():
+            missing.append(str(directory.relative_to(root)))
+    assert missing == [], f"these packages would be left out of the wheel: {missing}"


### PR DESCRIPTION
## The bug

`frontengine/utils/screen_text/__init__.py` was never created. Packaging uses

```toml
[tool.setuptools.packages]
find = { namespaces = false }
```

so a directory without `__init__.py` is **not packaged at all**. From a checkout everything worked — Python treats such a directory as a namespace package — but the installed wheel had no `frontengine.utils.screen_text`, and since `tools_setting_ui` imports it at module scope, **`import frontengine` failed outright**. That is what v1.0.39 shipped, and what turned main's CI red the moment it ran against an installed build.

Every one of the four PRs was green: they run the test suite from the checkout, where the directory imports fine. Only the post-merge smoke test, which installs the package first, could see it.

## The fix

- The missing `__init__.py`.
- A test that walks the package and fails if any directory holding `.py` files lacks one — with a comment explaining the consequence, so the next person does not delete it as busywork.

Verified two ways: the built wheel now contains `screen_text` (along with the other nine new packages, which were all fine), and removing the file again makes the new test fail with "these packages would be left out of the wheel".

Full suite: 778 passed.