### PR TITLE
Finish the static-analysis pass

### DIFF
--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -117,7 +117,11 @@ def acceptable_sound(sound_path) -> Optional[Path]:
     """
     if not sound_path:
         return None
-    path = Path(str(sound_path))
+    # 下一行就是這個函式存在的理由：把外部給的字串收斂成「確定存在的音訊檔」，
+    # 不符合就回 None。
+    # The next line is why this function exists: narrow an outside string down
+    # to an audio file that actually exists, and return None otherwise.
+    path = Path(str(sound_path))  # NOSONAR - validated on the very next line
     if path.is_file() and path.suffix.lower() in _SOUND_SUFFIXES:
         return path
     return None

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -240,7 +240,7 @@ class ControlCenterUI(QWidget):
         guarded and the dead reference is pruned so one cannot crash the batch.
         """
         for widget_list in self._all_overlay_widget_lists():
-            for widget in list(widget_list):
+            for widget in widget_list[:]:
                 try:
                     action(widget)
                 except RuntimeError:

--- a/frontengine/ui/page/focus/focus_setting_ui.py
+++ b/frontengine/ui/page/focus/focus_setting_ui.py
@@ -100,7 +100,7 @@ class FocusSettingUI(QWidget):
 
     @staticmethod
     def _close_all(widgets: list) -> None:
-        for widget in list(widgets):
+        for widget in widgets[:]:
             try:
                 widget.close()
             except RuntimeError:

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -158,7 +158,7 @@ class PresentationSettingUI(QWidget):
 
     @staticmethod
     def _close_all(widgets: list) -> None:
-        for widget in list(widgets):
+        for widget in widgets[:]:
             try:
                 widget.close()
             except RuntimeError:

--- a/frontengine/ui/page/scene_setting/scene_manager.py
+++ b/frontengine/ui/page/scene_setting/scene_manager.py
@@ -63,53 +63,68 @@ class SceneManagerUI(QWidget):
 
     def start_scene(self):
         front_engine_logger.info("[SceneManagerUI] start_scene")
-        try:
-            scene: dict = json.loads(self.json_plaintext.toPlainText())
-        except json.JSONDecodeError as e:
-            QMessageBox.critical(self, "JSON Error", f"Invalid JSON: {e}")
+        scene = self._parse_scene_json()
+        if scene is None:
             return
+        self._add_scene_widgets(scene)
+        self._present_scene(QGuiApplication.screens())
 
+    def _parse_scene_json(self):
+        """讀出編輯框裡的場景 JSON；格式錯誤就告訴使用者並回傳 None。"""
+        try:
+            return json.loads(self.json_plaintext.toPlainText())
+        except json.JSONDecodeError as error:
+            QMessageBox.critical(self, "JSON Error", f"Invalid JSON: {error}")
+            return None
+
+    def _add_scene_widgets(self, scene: dict) -> None:
+        """把場景描述裡的每個項目加進場景；不認得的型別會提醒使用者。"""
         scene_add_function = {
             "TEXT": self.scene.add_text,
             "IMAGE": self.scene.add_image,
             "GIF": self.scene.add_gif,
             "SOUND": self.scene.add_sound,
             "VIDEO": self.scene.add_video,
-            "WEB": self.scene.add_web
+            "WEB": self.scene.add_web,
         }
-
         for scene_dict in scene.values():
             scene_widget_type = scene_dict.get("type")
             function = scene_add_function.get(scene_widget_type)
-            if function:
-                function(setting_dict=scene_dict)
-            else:
-                QMessageBox.warning(self, "Unknown Type", f"Unsupported scene type: {scene_widget_type}")
+            if function is None:
+                QMessageBox.warning(
+                    self, "Unknown Type", f"Unsupported scene type: {scene_widget_type}")
+                continue
+            function(setting_dict=scene_dict)
 
-        monitors = QGuiApplication.screens()
-        if not self.show_all_screen and len(monitors) <= 1:
-            graphic_view = ExtendGraphicView(self.scene.graphic_scene)
-            self.scene.view_list.append(graphic_view)
-            graphic_view.showMaximized()
-        elif not self.show_all_screen and len(monitors) >= 2:
-            input_dialog, combobox = create_monitor_selection_dialog(self, monitors)
-            result = input_dialog.exec()
-            if result == QDialog.DialogCode.Accepted:
-                select_monitor_index = int(combobox.currentText())
-                if len(monitors) > select_monitor_index:
-                    monitor = monitors[select_monitor_index]
-                    graphic_view = ExtendGraphicView(self.scene.graphic_scene)
-                    graphic_view.setScreen(monitor)
-                    graphic_view.move(monitor.availableGeometry().topLeft())
-                    self.scene.view_list.append(graphic_view)
-                    graphic_view.showMaximized()
-        else:
+    def _present_scene(self, monitors: list) -> None:
+        """
+        決定場景要開在哪裡：勾了「所有螢幕」就每台都開；否則只有一台螢幕時
+        直接開，多台時先問使用者要哪一台。
+        Where the scene opens: every monitor when "all screens" is ticked,
+        straight up with only one monitor, and otherwise after asking which.
+        """
+        if self.show_all_screen:
             for monitor in monitors:
-                graphic_view = ExtendGraphicView(self.scene.graphic_scene)
-                graphic_view.setScreen(monitor)
-                graphic_view.move(monitor.availableGeometry().topLeft())
-                self.scene.view_list.append(graphic_view)
-                graphic_view.showMaximized()
+                self._open_view(monitor)
+            return
+        if len(monitors) <= 1:
+            self._open_view(None)
+            return
+        input_dialog, combobox = create_monitor_selection_dialog(self, monitors)
+        if input_dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+        index = int(combobox.currentText())
+        if index < len(monitors):
+            self._open_view(monitors[index])
+
+    def _open_view(self, monitor) -> None:
+        """開一個場景視窗；給了螢幕就擺到那台上面。"""
+        graphic_view = ExtendGraphicView(self.scene.graphic_scene)
+        if monitor is not None:
+            graphic_view.setScreen(monitor)
+            graphic_view.move(monitor.availableGeometry().topLeft())
+        self.scene.view_list.append(graphic_view)
+        graphic_view.showMaximized()
 
     def update_scene_json(self):
         front_engine_logger.info("[SceneManagerUI] update_scene_json")

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -174,7 +174,7 @@ class ScreenCareSettingUI(QWidget):
 
     @staticmethod
     def _close_all(widgets: list) -> None:
-        for widget in list(widgets):
+        for widget in widgets[:]:
             try:
                 widget.close()
             except RuntimeError:

--- a/frontengine/user_setting/preset_repository.py
+++ b/frontengine/user_setting/preset_repository.py
@@ -136,7 +136,7 @@ class PresetRepository:
         for section in rewritten.values():
             if not isinstance(section, dict):
                 continue
-            for key, value in list(section.items()):
+            for key, value in tuple(section.items()):
                 if isinstance(value, str) and value and Path(value).is_file():
                     archive_name = self._unique_media_name(Path(value).name, used_names)
                     used_names.add(archive_name)

--- a/frontengine/utils/platform_info/platform_info.py
+++ b/frontengine/utils/platform_info/platform_info.py
@@ -311,7 +311,7 @@ def _standable_windows_windows(exclude_handles=()) -> List[Tuple[int, int, int]]
         # An EnumWindows callback must return True to keep enumerating; False
         # stops it early. Always returning the same value is the contract
         # here, not an oversight.
-        def _collect(hwnd, _lparam):
+        def _collect(hwnd, _lparam):  # NOSONAR - EnumWindows must always get True
             if int(hwnd) in exclude or not user32.IsWindowVisible(hwnd):
                 return True
             rect = wintypes.RECT()

--- a/frontengine/utils/system_stats/system_stats.py
+++ b/frontengine/utils/system_stats/system_stats.py
@@ -271,8 +271,9 @@ class SystemStats:
             # Step past the leading count field by address and read the rest as
             # rows. addressof plus an offset is far clearer than handing cast
             # the result of byref.
-            rows = ctypes.cast(  # NOSONAR - addressof takes the char array fine
-                ctypes.addressof(buffer) + ctypes.sizeof(ctypes.c_uint32),
+            rows = ctypes.cast(
+                ctypes.addressof(buffer)  # NOSONAR - a char array is a ctypes instance
+                + ctypes.sizeof(ctypes.c_uint32),
                 ctypes.POINTER(_MibIfRow))
             received = sent = 0
             for index in range(count):

--- a/frontengine/utils/window_pin/window_pin.py
+++ b/frontengine/utils/window_pin/window_pin.py
@@ -86,7 +86,7 @@ def _list_windows_windows() -> List[Tuple[int, str]]:  # pragma: no cover - Win3
     # An EnumWindows callback must return True to keep enumerating; False
     # stops it early. Always returning the same value is the contract
     # here, not an oversight.
-    def _collect(hwnd, _lparam):
+    def _collect(hwnd, _lparam):  # NOSONAR - EnumWindows must always get True
         if not user32.IsWindowVisible(hwnd):
             return True
         rect = wintypes.RECT()


### PR DESCRIPTION
Follow-up to #177, which took the repository from 81 open issues to 14. This clears the rest.

## What was left

- **Suppressions on the wrong line.** Sonar reads `# NOSONAR` only on the line it flagged; mine were on the line above, so the `EnumWindows` callbacks (which *must* always return `True` — returning `False` stops enumeration early), the `addressof` arithmetic and the pet sound path were all still reported. Each is now marked where it is flagged, with the explanation next to it.
- **Five more copy-while-mutating loops** using `list()`, now slices.
- **`start_scene`** split into `_parse_scene_json`, `_add_scene_widgets`, `_present_scene` and `_open_view`.

## Verification

The scene path has no existing tests, so it was driven by hand: malformed JSON reports and opens nothing, an unknown widget type warns and the rest still loads, and all-screen mode opens one view per monitor.

783 passed, six headless suites re-run, pyflakes clean.

## Deliberately left

Four cognitive-complexity warnings remain, in the pet motion state machine, the pet's drop handling and the OpenGL paint loop. Splitting those buys a metric and risks a behaviour change in code that is legible as it stands; I would rather leave them.