### PR TITLE
Pin PySide6 to 6.11.1

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-PySide6==6.10.2
+PySide6==6.11.1
 qt-material
 pytest
 twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "JE-Chen", email = "jechenmailman@gmail.com" },
 ]
 dependencies = [
-    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
+    "PySide6==6.11.1", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
 ]
 description = "FrontEngine is use-define frontview or only use like screen saver"
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # pyproject.toml and stable.toml - this file used to pin 6.8.2.1 while those
 # pinned 6.10.2, so the two disagreed. It must not list frontengine itself
 # either: that installs the published build over the working tree.
-PySide6==6.10.2
+PySide6==6.11.1
 qt-material
 PyOpenGL
 PyOpenGL_accelerate

--- a/stable.toml
+++ b/stable.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "JE-Chen", email = "jechenmailman@gmail.com" },
 ]
 dependencies = [
-    "PySide6==6.10.2", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
+    "PySide6==6.11.1", "qt-material", "PyOpenGL", "PyOpenGL_accelerate", "numpy", "pynput"
 ]
 description = "FrontEngine is use-define frontview or only use like screen saver"
 requires-python = ">=3.10"


### PR DESCRIPTION
The pins said **6.10.2** while all of the recent development and testing happened on **6.11.1** — so the pinned version was the one nobody had actually exercised, and the tested one was not pinned anywhere.

This aligns all four files (`requirements.txt`, `dev_requirements.txt`, `pyproject.toml`, `stable.toml`) on 6.11.1.

Supersedes dependabot's #134, which was raised against the old `6.8.2.1` pin, now conflicts, and would only take three of the four files.

783 passed locally on 6.11.1; CI runs the matrix on 3.10 / 3.11 / 3.12.