### PR TITLE
Make "close all" reach every overlay, and stop signage hiding the only way out

### DIFF
--- a/frontengine/show/gaming/crosshair_widget.py
+++ b/frontengine/show/gaming/crosshair_widget.py
@@ -13,10 +13,10 @@ stacks windows and not something to work around.
 """
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Any, Optional, Tuple
 
 from PySide6.QtCore import QPointF, Qt
-from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtGui import QColor, QPainter, QPen, QScreen
 
 from frontengine.show.base_widget import BaseWidget
 from frontengine.utils.logging.loggin_instance import front_engine_logger
@@ -35,13 +35,13 @@ MIN_SIZE = 4
 MAX_SIZE = 200
 
 
-def normalize_style(style) -> str:
+def normalize_style(style: Any) -> str:
     """把準星樣式正規化；不認得的一律當十字。"""
     name = str(style or "").strip().lower()
     return name if name in STYLES else STYLE_CROSS
 
 
-def clamp_size(value, fallback: int = DEFAULT_SIZE) -> int:
+def clamp_size(value: Any, fallback: int = DEFAULT_SIZE) -> int:
     """準星尺寸夾在看得見又不誇張的範圍。"""
     try:
         return max(MIN_SIZE, min(MAX_SIZE, int(value)))
@@ -49,7 +49,7 @@ def clamp_size(value, fallback: int = DEFAULT_SIZE) -> int:
         return fallback
 
 
-def clamp_thickness(value, fallback: int = DEFAULT_THICKNESS) -> int:
+def clamp_thickness(value: Any, fallback: int = DEFAULT_THICKNESS) -> int:
     """線寬夾在 1~12。"""
     try:
         return max(1, min(12, int(value)))
@@ -57,7 +57,7 @@ def clamp_thickness(value, fallback: int = DEFAULT_THICKNESS) -> int:
         return fallback
 
 
-def clamp_gap(value, size: int = DEFAULT_SIZE, fallback: int = DEFAULT_GAP) -> int:
+def clamp_gap(value: Any, size: int = DEFAULT_SIZE, fallback: int = DEFAULT_GAP) -> int:
     """
     中央空隙不能大到把準星吃光，所以上限跟著尺寸走。
     The centre gap cannot swallow the crosshair, so its ceiling follows the size.
@@ -100,7 +100,8 @@ class CrosshairWidget(BaseWidget):
         self.opacity = 1.0
         self.resize(self.size * 2 + 8, self.size * 2 + 8)
 
-    def set_crosshair(self, style=None, color=None, size=None,
+    def set_crosshair(self, style: Optional[str] = None, color: Optional[str] = None,
+                      size: Optional[int] = None,
                       thickness=None, gap=None) -> None:
         """一次改好幾項設定，改完立刻重畫。"""
         if style is not None:
@@ -119,7 +120,7 @@ class CrosshairWidget(BaseWidget):
         self.centre_on_screen()
         self.update()
 
-    def centre_on_screen(self, screen=None) -> None:
+    def centre_on_screen(self, screen: Optional[QScreen] = None) -> None:
         """擺到螢幕正中央（準星要對準的是畫面中心）。"""
         from PySide6.QtGui import QGuiApplication
 

--- a/frontengine/show/teleprompter/teleprompter_widget.py
+++ b/frontengine/show/teleprompter/teleprompter_widget.py
@@ -12,7 +12,7 @@ and it stops at the last line rather than snapping back to the top mid-read.
 """
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QTransform
@@ -31,7 +31,7 @@ _TICK_MS = 33
 _SIDE_MARGIN = 40
 
 
-def clamp_speed(value, fallback: int = DEFAULT_SPEED) -> int:
+def clamp_speed(value: Any, fallback: int = DEFAULT_SPEED) -> int:
     """捲動速度夾在讀得完又跟得上的範圍。"""
     try:
         return max(MIN_SPEED, min(MAX_SPEED, int(value)))
@@ -39,7 +39,7 @@ def clamp_speed(value, fallback: int = DEFAULT_SPEED) -> int:
         return fallback
 
 
-def clamp_font_size(value, fallback: int = DEFAULT_FONT_SIZE) -> int:
+def clamp_font_size(value: Any, fallback: int = DEFAULT_FONT_SIZE) -> int:
     """字級夾在看得見的範圍。"""
     try:
         return max(MIN_FONT_SIZE, min(MAX_FONT_SIZE, int(value)))

--- a/frontengine/ui/main_ui.py
+++ b/frontengine/ui/main_ui.py
@@ -2,7 +2,7 @@ import os
 import sys
 from os import getcwd
 from pathlib import Path
-from typing import Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from PySide6.QtCore import QByteArray, QTimer, QCoreApplication
 from PySide6.QtGui import QIcon, Qt
@@ -72,6 +72,20 @@ from frontengine.utils.theme_schedule.theme_schedule_service import ThemeSchedul
 # 可擴充的外部 Tab 註冊表
 # Registry for external tabs
 FrontEngine_EXTEND_TAB: Dict[str, Type[QWidget]] = {}
+
+
+def tray_can_restore_window(window: Any) -> bool:
+    """
+    系統匣能不能把主視窗叫回來。任何「把主視窗藏起來」的功能都得先問這件事，
+    不然藏掉的就是唯一能把該功能關掉的畫面。
+    Whether the tray can bring the main window back. Anything that hides the
+    window has to ask first: otherwise what it hides is the only screen that
+    can turn that same thing off.
+    """
+    tray = getattr(window, "system_tray", None)
+    return bool(ExtendSystemTray.isSystemTrayAvailable()
+                and getattr(window, "show_system_tray_ray", False)
+                and tray is not None and tray.isVisible())
 
 
 class FrontEngineMainUI(QMainWindow):
@@ -321,9 +335,10 @@ class FrontEngineMainUI(QMainWindow):
         """
         sources = (
             (self.screen_care_setting_ui, ("filter_widget_list", "ruler_widget_list",
-                                           "break_overlay_list")),
+                                           "break_overlay_list", "color_vision_widget_list")),
             (self.presentation_setting_ui, ("annotation_widget_list", "cursor_widget_list",
-                                            "keystroke_widget_list", "magnifier_widget_list")),
+                                            "keystroke_widget_list", "magnifier_widget_list",
+                                            "whiteboard_widget_list")),
             (self.focus_setting_ui, ("dim_widget_list", "mask_widget_list")),
         )
         for page, attributes in sources:
@@ -334,6 +349,12 @@ class FrontEngineMainUI(QMainWindow):
         # The wallpaper page keys its widgets by monitor, so hand over the values.
         self.control_center_ui.register_overlay_source(
             lambda: list(self.wallpaper_setting_ui.wallpaper_widgets.values()))
+        self.control_center_ui.register_overlay_source(
+            lambda: getattr(self.web_setting_ui, "dashboard_widgets", []))
+        # 批次關閉之後，沒有覆蓋層在聽就把全域輸入監聽收掉
+        # After a batch close nothing is listening, so drop the global input hook.
+        self.control_center_ui.register_cleanup(
+            self.presentation_setting_ui.release_input_watch)
         for attribute in ("spectrum_widget_list", "monitor_widget_list",
                           "now_playing_widget_list", "note_widget_list"):
             self.control_center_ui.register_overlay_source(
@@ -518,11 +539,27 @@ class FrontEngineMainUI(QMainWindow):
             self._handle_hotkey(action)
 
     def start_signage(self) -> Optional[str]:
-        """開始輪播；設定要求的話也把主視窗收起來。"""
+        """開始輪播；設定要求、而且托盤能把視窗叫回來時才收起主視窗。"""
         first = self.signage_service.start()
         if first is not None and current_signage_settings().get("hide_window", True):
-            self.hide()
+            self._hide_for_signage()
         return first
+
+    def _hide_for_signage(self) -> None:
+        """
+        收起主視窗——但只在系統匣真的能把它叫回來的時候。沒有系統匣就等於
+        把唯一能關掉輪播的畫面藏起來，重開也只會再被藏一次，使用者就只能去
+        手動改設定檔了。
+        Put the main window away - but only when the tray can actually bring it
+        back. Without a tray this would hide the only screen that can turn the
+        rotation off, and restarting just hides it again, leaving the settings
+        file as the only way out.
+        """
+        if tray_can_restore_window(self):
+            self.hide()
+            return
+        front_engine_logger.info(
+            "[FrontEngineMainUI] signage kept the window visible: no tray to restore it from")
 
     def stop_signage(self) -> None:
         """停止輪播並把主視窗放回來。"""

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from PySide6.QtCore import QTimer, Qt
 from PySide6.QtWidgets import (
     QComboBox, QGridLayout, QLabel, QPushButton, QScrollArea, QTextEdit, QWidget,
@@ -93,6 +95,7 @@ class ControlCenterUI(QWidget):
         # 其他分頁登記進來的覆蓋層來源（桌布、專注、護眼、簡報…）
         # Overlay sources registered by the other pages: wallpaper, focus, screen care, presenting.
         self._extra_overlay_sources: list = []
+        self._cleanup_callbacks: list = []
         self.low_power_button = self._create_button(
             "control_center_low_power_on", self.toggle_low_power)
         self._hidden_from_capture = False
@@ -190,19 +193,29 @@ class ControlCenterUI(QWidget):
         self.scene_setting_ui.close_scene()
 
     def clear_all(self) -> None:
+        """
+        關閉所有覆蓋層。先真的 close() 再清空清單：close() 會跑到 closeEvent，
+        計時器、媒體、全域監聽才停得掉；只丟掉 Python 參考做不到這件事，而且
+        對「其他分頁註冊進來的」覆蓋層根本沒作用——它們會留在螢幕上。
+        Close every overlay. Actually call close() before emptying the lists:
+        that runs closeEvent, which is what stops timers, releases media and
+        drops global listeners. Merely dropping a Python reference does none of
+        that, and for the overlays other pages registered it did nothing at all
+        - they stayed on screen.
+        """
         front_engine_logger.info("ControlCenterUI clear_all")
-        self.video_setting_ui.video_widget_list.clear()
-        self.image_setting_ui.image_widget_list.clear()
-        self.web_setting_ui.web_widget_list.clear()
-        self.gif_setting_ui.gif_widget_list.clear()
-        self.sound_player_setting_ui.sound_widget_list.clear()
-        self.text_setting_ui.text_widget_list.clear()
-        self.particle_setting_ui.particle_list.clear()
-        if self.pet_setting_ui is not None:
-            self.pet_setting_ui.pet_list.clear()
+        self._for_each_overlay(lambda widget: widget.close())
+        for widget_list in self._all_overlay_widget_lists():
+            widget_list.clear()
         self.scene_setting_ui.close_scene()
+        for callback in self._cleanup_callbacks:
+            try:
+                callback()
+            except Exception as error:
+                front_engine_logger.warning(
+                    f"[ControlCenterUI] cleanup failed: {error!r}")
 
-    def register_overlay_source(self, provider) -> None:
+    def register_overlay_source(self, provider: Callable[[], list]) -> None:
         """
         讓控制中心也管得到其他分頁開的覆蓋層。provider 是一個回傳 widget 清單
         的函式（每次都重新問，才拿得到當下還活著的那些）。
@@ -211,6 +224,16 @@ class ControlCenterUI(QWidget):
         what is actually on screen right now.
         """
         self._extra_overlay_sources.append(provider)
+
+    def register_cleanup(self, callback: Callable[[], None]) -> None:
+        """
+        批次關閉之後要順手收掉的東西。例如全域輸入監聽：覆蓋層都關掉了就
+        沒有東西需要它，繼續掛著只是白吃資源。
+        Something to release after a batch close - a global input listener,
+        say: with every overlay gone nothing needs it, and leaving it hooked
+        just costs for nothing.
+        """
+        self._cleanup_callbacks.append(callback)
 
     def _all_overlay_widget_lists(self) -> list:
         """回傳所有覆蓋層 widget 清單 / All overlay widget lists."""
@@ -231,11 +254,15 @@ class ControlCenterUI(QWidget):
             except Exception as error:  # pragma: no cover - defensive boundary
                 front_engine_logger.warning(f"[ControlCenterUI] overlay source failed: {error!r}")
                 continue
+            # 交回原本的清單物件（不是複本），死掉的參考才清得掉、
+            # 「全部關閉」也才真的能把它們清空。
+            # Hand back the provider's own list rather than a copy, so pruning
+            # a dead reference - and closing everything - reaches the real one.
             if widgets:
-                lists.append(list(widgets))
+                lists.append(widgets if isinstance(widgets, list) else list(widgets))
         return lists
 
-    def _for_each_overlay(self, action) -> None:
+    def _for_each_overlay(self, action: Callable[[QWidget], None]) -> None:
         """
         對每個仍存活的覆蓋層 widget 執行 action(widget)。手動關閉的覆蓋層因
         WA_DeleteOnClose 已被銷毀，其 Python 參考仍留在清單中，呼叫時會

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -6,7 +6,7 @@ The presentation page: screen annotation, cursor emphasis (ring, click ripple,
 spotlight), a keystroke display and a region magnifier. Everything except the
 annotation layer passes clicks straight through.
 """
-from typing import List
+from typing import List, Optional
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QGuiApplication
@@ -181,7 +181,8 @@ class PresentationSettingUI(QWidget):
         if self.keystroke_widget_list or self.cursor_widget_list:
             self.input_watch.start()
 
-    def _release_input_watch(self) -> None:
+    def release_input_watch(self) -> None:
+        """沒有覆蓋層要聽了就收掉全域輸入監聽（批次關閉之後也會呼叫）。"""
         if not self.keystroke_widget_list and not self.cursor_widget_list:
             self.input_watch.stop()
 
@@ -250,7 +251,7 @@ class PresentationSettingUI(QWidget):
 
     def stop_cursor_effects(self) -> None:
         self._close_all(self.cursor_widget_list)
-        self._release_input_watch()
+        self.release_input_watch()
         self.cursor_button.setText(
             language_wrapper.language_word_dict.get("cursor_effect_start", "Turn cursor effects on"))
 
@@ -285,7 +286,7 @@ class PresentationSettingUI(QWidget):
 
     def stop_keystrokes(self) -> None:
         self._close_all(self.keystroke_widget_list)
-        self._release_input_watch()
+        self.release_input_watch()
         self.keystroke_button.setText(
             language_wrapper.language_word_dict.get("keystroke_start", "Show keystrokes"))
 
@@ -341,7 +342,6 @@ class PresentationSettingUI(QWidget):
             except RuntimeError:
                 self.magnifier_widget_list.remove(widget)
 
-    # --- preset state ----------------------------------------------------
     # --- whiteboard ------------------------------------------------------
     def toggle_whiteboard(self) -> None:
         if self.whiteboard_widget_list:
@@ -364,7 +364,7 @@ class PresentationSettingUI(QWidget):
         self.whiteboard_button.setText(
             language_wrapper.language_word_dict.get("whiteboard_start", "Whiteboard"))
 
-    def save_whiteboard(self):
+    def save_whiteboard(self) -> Optional[str]:
         """把白板存成圖片；沒畫東西就不存。"""
         for board in self.whiteboard_widget_list[:]:
             try:
@@ -377,6 +377,7 @@ class PresentationSettingUI(QWidget):
                 self.whiteboard_widget_list.remove(board)
         return None
 
+    # --- preset state ----------------------------------------------------
     def get_state(self) -> dict:
         return {
             "annotate_tool": self.annotate_tool_combobox.currentData(),

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -292,7 +292,6 @@ class ScreenCareSettingUI(QWidget):
             self.break_overlay_list.append(overlay)
             self._present(overlay, screen)
 
-    # --- preset state ----------------------------------------------------
     # --- colour vision ---------------------------------------------------
     def toggle_color_vision(self) -> None:
         if self.color_vision_widget_list:
@@ -327,6 +326,7 @@ class ScreenCareSettingUI(QWidget):
             except RuntimeError:
                 self.color_vision_widget_list.remove(widget)
 
+    # --- preset state ----------------------------------------------------
     def get_state(self) -> dict:
         return {
             "color_vision_kind": self.color_vision_combobox.currentData(),

--- a/frontengine/utils/remote/remote_server.py
+++ b/frontengine/utils/remote/remote_server.py
@@ -24,7 +24,7 @@ import secrets
 import socket
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
 from PySide6.QtCore import QObject, Signal
@@ -138,7 +138,6 @@ class RemoteServer(QObject):
         self._on_action = on_action
         self._server: Optional[ThreadingHTTPServer] = None
         self._thread: Optional[threading.Thread] = None
-        self.received: List[str] = []
 
     @property
     def running(self) -> bool:
@@ -192,7 +191,6 @@ class RemoteServer(QObject):
             return 403
         if not is_allowed(action):
             return 400
-        self.received.append(str(action))
         self.action_requested.emit(str(action))
         if self._on_action is not None:
             self._on_action(str(action))

--- a/frontengine/utils/screen_privacy/capture_affinity.py
+++ b/frontengine/utils/screen_privacy/capture_affinity.py
@@ -22,9 +22,12 @@ determined attacker, and it never hides the window from the person at the desk.
 from __future__ import annotations
 
 import sys
-from typing import Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
+
+if TYPE_CHECKING:  # 只為了型別標註，執行時不需要把 Qt 拉進這支純 ctypes 工具
+    from PySide6.QtWidgets import QWidget
 
 # WDA_NONE：正常擷取；WDA_EXCLUDEFROMCAPTURE：擷取時整片留白
 # WDA_NONE captures normally; WDA_EXCLUDEFROMCAPTURE comes out blank.
@@ -92,7 +95,7 @@ def is_excluded_from_capture(handle: int) -> Optional[bool]:
         return None
 
 
-def apply_to_widget(widget, excluded: bool) -> bool:
+def apply_to_widget(widget: Optional[QWidget], excluded: bool) -> bool:
     """
     對一個 Qt widget 套用擷取可見性。視窗還沒建立原生 handle 時回傳 False，
     呼叫端可以等 show() 之後再試一次。
@@ -108,7 +111,7 @@ def apply_to_widget(widget, excluded: bool) -> bool:
     return set_excluded_from_capture(handle, excluded)
 
 
-def apply_to_widgets(widgets, excluded: bool) -> int:
+def apply_to_widgets(widgets: Optional[Iterable[QWidget]], excluded: bool) -> int:
     """對一批 widget 套用，回傳成功的數量。"""
     applied = 0
     for widget in tuple(widgets or ()):

--- a/frontengine/utils/virtual_camera/camera_feed.py
+++ b/frontengine/utils/virtual_camera/camera_feed.py
@@ -46,7 +46,7 @@ class VirtualCameraFeed(QObject):
             return None
         return screen.grabWindow(0, rect.x(), rect.y(), rect.width(), rect.height())
 
-    def set_grabber(self, grabber) -> None:
+    def set_grabber(self, grabber: Optional[Callable[[QRect], Optional[QPixmap]]]) -> None:
         self._grabber = grabber or self._default_grabber
 
     def start(self, region: QRect, fps: int) -> bool:

--- a/frontengine/utils/virtual_camera/virtual_camera.py
+++ b/frontengine/utils/virtual_camera/virtual_camera.py
@@ -15,7 +15,7 @@ False and the feature stays off; nothing is ever sent quietly.
 """
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import numpy
 
@@ -47,7 +47,7 @@ def available() -> bool:
     return _module() is not None
 
 
-def clamp_fps(value, fallback: int = DEFAULT_FPS) -> int:
+def clamp_fps(value: Any, fallback: int = DEFAULT_FPS) -> int:
     """每秒張數夾在驅動接受的範圍。"""
     try:
         return max(MIN_FPS, min(MAX_FPS, int(value)))
@@ -55,9 +55,9 @@ def clamp_fps(value, fallback: int = DEFAULT_FPS) -> int:
         return fallback
 
 
-def even_size(width, height) -> Tuple[int, int]:
+def even_size(width: Any, height: Any) -> Tuple[int, int]:
     """把尺寸調成偶數且不小於 2x2。"""
-    def fix(value, fallback):
+    def fix(value: Any, fallback: int) -> int:
         try:
             number = max(_SIZE_STEP, int(value))
         except (TypeError, ValueError):

--- a/tests/unit_test/test_control_center_batch.py
+++ b/tests/unit_test/test_control_center_batch.py
@@ -1,0 +1,145 @@
+"""
+控制中心的整批操作測試：重點在「其他分頁註冊進來的覆蓋層」也要真的關得掉。
+
+在這之前，「全部關閉」只清掉最早那幾個分頁自己的清單，後來加的覆蓋層
+（塗鴉、放大鏡、白板、準心、色盲濾鏡、儀表板…）它一個都碰不到，會留在
+螢幕上。同一顆按鈕的隱藏／顯示卻是好的，所以只看畫面很難發現。
+
+The control center's batch actions, with the emphasis on overlays other pages
+registered: those have to close too.
+
+Before this, "close all" only emptied the original pages' own lists and never
+touched anything registered later - annotation, magnifier, whiteboard,
+crosshair, colour-vision filter, dashboards - so they stayed on screen. Hide
+and show from the same panel worked, which is what made it easy to miss.
+"""
+from typing import List
+
+import pytest
+from PySide6.QtWidgets import QWidget
+
+from frontengine.ui.page.control_center.control_center_ui import ControlCenterUI
+
+
+class _StubPage:
+    """只提供整批操作會用到的清單 / Just the lists the batch actions look at."""
+
+    def __init__(self, attribute: str) -> None:
+        setattr(self, attribute, [])
+
+    def close_scene(self) -> None:
+        """場景頁的介面 / The scene page's interface."""
+
+
+def _control_center() -> ControlCenterUI:
+    return ControlCenterUI(
+        video_setting_ui=_StubPage("video_widget_list"),
+        image_setting_ui=_StubPage("image_widget_list"),
+        web_setting_ui=_StubPage("web_widget_list"),
+        gif_setting_ui=_StubPage("gif_widget_list"),
+        sound_player_setting_ui=_StubPage("sound_widget_list"),
+        text_setting_ui=_StubPage("text_widget_list"),
+        scene_setting_ui=_StubPage("scene_widget_list"),
+        particle_setting_ui=_StubPage("particle_list"),
+        redirect_output=False,
+    )
+
+
+@pytest.fixture(name="centre")
+def _centre() -> ControlCenterUI:
+    centre = _control_center()
+    yield centre
+    centre.close()
+
+
+def _overlay() -> QWidget:
+    widget = QWidget()
+    widget.show()
+    return widget
+
+
+def test_closing_everything_reaches_an_overlay_another_page_registered(centre) -> None:
+    registered: List[QWidget] = [_overlay(), _overlay()]
+    centre.register_overlay_source(lambda: registered)
+
+    centre.clear_all()
+
+    assert registered == [], "the page's own list must end up empty"
+
+
+def test_the_original_pages_still_end_up_empty(centre) -> None:
+    centre.video_setting_ui.video_widget_list.append(_overlay())
+    centre.image_setting_ui.image_widget_list.append(_overlay())
+
+    centre.clear_all()
+
+    assert centre.video_setting_ui.video_widget_list == []
+    assert centre.image_setting_ui.image_widget_list == []
+
+
+def test_hiding_and_showing_reach_a_registered_overlay(centre) -> None:
+    registered = [_overlay()]
+    centre.register_overlay_source(lambda: registered)
+
+    centre.hide_all()
+    assert registered[0].isVisible() is False
+    centre.show_all()
+    assert registered[0].isVisible() is True
+
+
+def test_a_source_that_hands_back_a_copy_still_gets_its_widgets_closed(centre) -> None:
+    """
+    桌布頁是以螢幕編號為鍵的 dict，交回來的是新的 list——清空那份複本沒有
+    意義，但裡面的 widget 還是得關掉。
+    The wallpaper page keys its overlays by monitor and hands back a fresh list.
+    Emptying that copy means nothing, but the widgets in it must still close.
+    """
+    kept = {1: _overlay()}
+    centre.register_overlay_source(lambda: list(kept.values()))
+
+    centre.clear_all()
+
+    assert kept[1].isVisible() is False
+
+
+def test_a_registered_cleanup_runs_after_a_batch_close(centre) -> None:
+    """覆蓋層都關光了，全域輸入監聽那類東西也該跟著收掉。"""
+    calls = []
+    centre.register_cleanup(lambda: calls.append("released"))
+
+    centre.clear_all()
+
+    assert calls == ["released"]
+
+
+def test_one_failing_cleanup_does_not_stop_the_others(centre) -> None:
+    calls = []
+
+    def explode() -> None:
+        raise RuntimeError("no listener")
+
+    centre.register_cleanup(explode)
+    centre.register_cleanup(lambda: calls.append("still ran"))
+
+    centre.clear_all()
+
+    assert calls == ["still ran"]
+
+
+def test_a_dead_overlay_does_not_stop_the_batch(centre) -> None:
+    """
+    使用者自己關掉的覆蓋層底層物件已經沒了，清單裡卻還留著參考；
+    碰到它會丟 RuntimeError，不能因此讓整批操作停在半路。
+    A widget the user already closed is gone underneath while its reference
+    lingers; touching it raises RuntimeError, which must not halt the batch.
+    """
+    dead, alive = _overlay(), _overlay()
+    registered = [dead, alive]
+    centre.register_overlay_source(lambda: registered)
+    dead.close()
+    dead.deleteLater()
+    dead.destroy()
+
+    centre.clear_all()
+
+    assert registered == []

--- a/tests/unit_test/test_signage_and_canvas.py
+++ b/tests/unit_test/test_signage_and_canvas.py
@@ -5,8 +5,11 @@ meter.
 """
 from datetime import datetime, timedelta
 
+import pytest
+
 from frontengine.show.canvas.whiteboard_widget import (
-    DEFAULT_COLOR, MAX_ZOOM, MIN_ZOOM, clamp_zoom, content_bounds, to_canvas, to_screen,
+    DEFAULT_COLOR, MAX_ZOOM, MIN_ZOOM, WhiteboardWidget, clamp_zoom, content_bounds, to_canvas,
+    to_screen,
 )
 from frontengine.utils.audio_meter.microphone_meter import (
     MicrophoneMeter, list_input_devices, microphone_level,
@@ -118,6 +121,41 @@ def test_panning_moves_the_view_not_the_drawing() -> None:
     assert after == (before[0] + 40, before[1] + 25)
 
 
+def test_zooming_keeps_the_point_under_the_cursor_in_place() -> None:
+    """
+    以游標為中心縮放的重點：游標底下的那一點縮放前後要停在原地，
+    不然每滾一格畫面就整個跑掉。
+    The point of zooming around the cursor: whatever sits under it must stay
+    put, or the view lurches away on every notch of the wheel.
+    """
+    from PySide6.QtCore import QPoint
+
+    board = WhiteboardWidget()
+    cursor = QPoint(300, 220)
+    under_cursor = to_canvas((cursor.x(), cursor.y()), board.offset, board.zoom)
+    for factor in (1.15, 1.15, 0.5, 2.0):
+        board.zoom_at(cursor, factor)
+        moved = to_screen(under_cursor, board.offset, board.zoom)
+        assert moved == pytest.approx((cursor.x(), cursor.y()), abs=1e-6), f"drifted at {factor}"
+    board.close()
+
+
+def test_a_stray_click_does_not_become_a_stroke() -> None:
+    """按一下就放開只有一個點，那是誤點不是筆畫，不留下來。"""
+    from PySide6.QtCore import QPoint
+
+    board = WhiteboardWidget()
+    board.begin_stroke(QPoint(10, 10))
+    assert board.end_stroke() is False
+    assert board.strokes == []
+
+    board.begin_stroke(QPoint(10, 10))
+    board.extend_stroke(QPoint(24, 31))
+    assert board.end_stroke() is True
+    assert len(board.strokes) == 1
+    board.close()
+
+
 def test_bounds_cover_every_stroke() -> None:
     strokes = [{"points": [(0, 0), (10, 40)]}, {"points": [(-5, 20), (30, 25)]}]
     assert content_bounds(strokes) == (-5, 0, 30, 40)
@@ -155,3 +193,40 @@ def test_closing_twice_is_safe() -> None:
     meter.close()
     meter.close()
     assert meter.level() is None
+
+
+# --- signage must not lock the user out -----------------------------------
+def test_the_window_is_only_put_away_when_the_tray_can_bring_it_back(monkeypatch) -> None:
+    """
+    看板模式會把主視窗收起來，但沒有系統匣就等於藏掉唯一能關掉輪播的畫面，
+    重開也只會再被藏一次。所以一定要先確認叫得回來。
+    Signage puts the main window away, but without a tray that hides the only
+    screen that can turn the rotation off - and restarting just hides it again.
+    So it has to be sure the window can come back first.
+    """
+    from frontengine.ui import main_ui
+
+    class _Tray:
+        def __init__(self, visible: bool) -> None:
+            self._visible = visible
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt's own spelling
+            return self._visible
+
+    class _Window:
+        def __init__(self, tray, enabled: bool = True) -> None:
+            self.system_tray = tray
+            self.show_system_tray_ray = enabled
+
+    monkeypatch.setattr(main_ui.ExtendSystemTray, "isSystemTrayAvailable",
+                        staticmethod(lambda: True))
+    assert main_ui.tray_can_restore_window(_Window(_Tray(True))) is True
+    assert main_ui.tray_can_restore_window(_Window(_Tray(False))) is False, "tray icon hidden"
+    assert main_ui.tray_can_restore_window(_Window(None)) is False, "no tray object"
+    assert main_ui.tray_can_restore_window(_Window(_Tray(True), enabled=False)) is False, \
+        "the user turned the tray off"
+
+    monkeypatch.setattr(main_ui.ExtendSystemTray, "isSystemTrayAvailable",
+                        staticmethod(lambda: False))
+    assert main_ui.tray_can_restore_window(_Window(_Tray(True))) is False, \
+        "the desktop has no tray at all"


### PR DESCRIPTION
A review pass over everything the recent waves added. Two of these are real bugs a user would hit.

## "Close all" left most overlays on screen

`clear_all` emptied the eight original pages' lists and nothing else. Every overlay registered since — annotation, cursor effects, keystroke display, magnifier, whiteboard, screen filters, rulers, break overlays, wallpaper, focus dim/mask, spectrum, monitor, now-playing, notes, measure, capture, camera, crosshair, teleprompter, colour vision, dashboards — was untouched by the control-center button, the `close_all` hotkey, the tray item and the phone remote.

Hide and show from the same panel worked fine, which is exactly why it went unnoticed: the feature looked wired up.

Two things were wrong. The batch never closed those overlays, and `_all_overlay_widget_lists` handed back a *copy* of each registered list, so pruning a dead reference never reached the real one. It now closes what it can already hide, and closes rather than merely dropping the reference — that is what runs `closeEvent`, which is what stops timers, releases media and unhooks listeners.

Closing them surfaced a follow-on: the presenting page keeps a global input hook alive while a keystroke or cursor overlay exists, and a batch close bypassed the method that releases it. Pages can now register a cleanup that runs after the batch.

Three lists were never registered in the first place — whiteboard, colour vision, dashboards — so they were unreachable even by hide.

## Signage could lock you out of the app

`start_signage` hid the main window whenever the setting asked. With no system tray there is no way back, and since signage starts on launch, restarting hides it again — leaving the settings JSON as the only exit. It now uses the same test `closeEvent` already applied, and stays visible when the tray cannot restore it.

## Smaller things

- The remote appended every action it ever handled to a list nothing reads — unbounded, and dead. The signal is the real output path.
- Two `# --- preset state ---` banners labelled nothing after code was inserted between them and the methods they described.
- Parameters that accept anything (`clamp_size(value)`, `apply_to_widget(widget)`, …) now say so. `set_grabber` was annotated wrong — it takes a `QRect` and returns a `QPixmap`, not a numpy array; pyflakes caught it.

## How these were found

A sentinel probe against the real overlay enumeration turned up the unreachable lists, and mutation testing on the newer modules found the two whiteboard behaviours nothing tested. The rest of the recent work held up: 8 of 9 further mutations were caught, including unmasked WebSocket frames, a forged handshake, and the remote's token and allowlist checks.

## Tests

`tests/unit_test/test_control_center_batch.py` — 7 tests over the batch actions with stub pages, including a source that hands back a copy and a cleanup that throws. Plus three in `test_signage_and_canvas.py`: zoom stays anchored to the cursor, a stray click is not a stroke, and the window is only put away when the tray can bring it back.

Each fix was mutation-checked — reverting any one of them fails the suite. 880 passed.