### PR TITLE
Change language without restarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ that caps every overlay's refresh rate and drops its render resolution.
 
 ---
 
+## Languages
+
+Seven: English, 繁體中文, 简体中文, Deutsch, Русский, Français, Italiano.
+
+Pick one from the **Language** menu and the interface changes **immediately** —
+no restart. Whatever you had open stays open: overlays keep running, and the
+settings on every page are left exactly as they were.
+
+---
+
 ## Signage, whiteboard and lip-sync
 
 - **Signage mode** (Settings) — rotate through a list of presets on a timer and

--- a/frontengine/ui/dialog/app_profile_dialog.py
+++ b/frontengine/ui/dialog/app_profile_dialog.py
@@ -20,6 +20,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.app_profile.app_profile_service import normalize_profiles
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.smart_pause.pause_rules import normalize_app_name
 
 
@@ -50,13 +51,16 @@ class AppProfileDialog(QDialog):
         self.table.horizontalHeader().setStretchLastSection(True)
 
         self.add_button = QPushButton(_t("app_profile_add", "Add"))
+        retranslator.bind(self.add_button, "app_profile_add", "Add")
         self.add_button.clicked.connect(lambda: self.add_row("", ""))
         self.remove_button = QPushButton(_t("app_profile_remove", "Remove"))
+        retranslator.bind(self.remove_button, "app_profile_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
         self.hint_label = QLabel(
             _t("app_profile_hint",
                "Presets are saved from the Presets menu. Without any saved preset "
                "there is nothing to apply."))
+        retranslator.bind(self.hint_label, "app_profile_hint", "Presets are saved from the Presets menu. Without any saved preset " "there is nothing to apply.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/clipboard_dialog.py
+++ b/frontengine/ui/dialog/clipboard_dialog.py
@@ -25,6 +25,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.clipboard.clipboard_history import ClipboardHistory, preview
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 _PIN_MARK = "📌 "
 
@@ -51,16 +52,21 @@ class ClipboardDialog(QDialog):
         self.entry_list.itemDoubleClicked.connect(lambda _item: self.copy_selected())
 
         self.copy_button = QPushButton(_t("clipboard_copy", "Copy"))
+        retranslator.bind(self.copy_button, "clipboard_copy", "Copy")
         self.copy_button.clicked.connect(self.copy_selected)
         self.pin_button = QPushButton(_t("clipboard_pin", "Pin / unpin"))
+        retranslator.bind(self.pin_button, "clipboard_pin", "Pin / unpin")
         self.pin_button.clicked.connect(self.toggle_pin_selected)
         self.remove_button = QPushButton(_t("clipboard_remove", "Remove"))
+        retranslator.bind(self.remove_button, "clipboard_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
         self.clear_button = QPushButton(_t("clipboard_clear", "Clear (keep pinned)"))
+        retranslator.bind(self.clear_button, "clipboard_clear", "Clear (keep pinned)")
         self.clear_button.clicked.connect(self.clear_history)
 
         self.persist_checkbox = QCheckBox(
             _t("clipboard_persist", "Keep this history between sessions"))
+        retranslator.bind(self.persist_checkbox, "clipboard_persist", "Keep this history between sessions")
         self.persist_checkbox.setChecked(bool(user_setting_dict.get("clipboard_persist")))
         self.persist_checkbox.toggled.connect(self._store_persist)
         self.hint_label = QLabel(
@@ -68,6 +74,7 @@ class ClipboardDialog(QDialog):
                "History stays on this machine and is never sent anywhere. Unless you tick "
                "the box above it is kept in memory only, because clipboards often hold "
                "passwords."))
+        retranslator.bind(self.hint_label, "clipboard_hint", "History stays on this machine and is never sent anywhere. Unless you tick " "the box above it is kept in memory only, because clipboards often hold " "passwords.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/reminder_dialog.py
+++ b/frontengine/ui/dialog/reminder_dialog.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.reminder.reminder_service import (
     KIND_AT, KIND_EVERY, normalize_reminder, normalize_reminders,
 )
@@ -55,13 +56,16 @@ class ReminderDialog(QDialog):
         self.table.horizontalHeader().setStretchLastSection(True)
 
         self.add_button = QPushButton(_t("reminder_add", "Add"))
+        retranslator.bind(self.add_button, "reminder_add", "Add")
         self.add_button.clicked.connect(lambda: self.add_row())
         self.remove_button = QPushButton(_t("reminder_remove", "Remove"))
+        retranslator.bind(self.remove_button, "reminder_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
         self.hint_label = QLabel(
             _t("reminder_hint",
                "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a "
                "24-hour time such as 14:30."))
+        retranslator.bind(self.hint_label, "reminder_hint", "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a " "24-hour time such as 14:30.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/remote_control_dialog.py
+++ b/frontengine/ui/dialog/remote_control_dialog.py
@@ -24,6 +24,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.midi.midi_input import available as midi_available, list_devices
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.remote.remote_server import ALLOWED_ACTIONS
 
 MIDI_KEY = "midi_bindings"
@@ -60,6 +61,7 @@ class RemoteControlDialog(QDialog):
         self._learning = False
 
         self.remote_checkbox = QCheckBox(_t("remote_enable", "Let my phone control FrontEngine"))
+        retranslator.bind(self.remote_checkbox, "remote_enable", "Let my phone control FrontEngine")
         self.remote_checkbox.setChecked(remote_enabled())
         self.remote_checkbox.toggled.connect(self._toggle_remote)
         self.remote_url_label = QLabel(self.remote_status())
@@ -67,6 +69,7 @@ class RemoteControlDialog(QDialog):
         self.remote_url_label.setTextInteractionFlags(
             self.remote_url_label.textInteractionFlags().TextSelectableByMouse)
         self.remote_copy_button = QPushButton(_t("remote_copy", "Copy link"))
+        retranslator.bind(self.remote_copy_button, "remote_copy", "Copy link")
         self.remote_copy_button.clicked.connect(self.copy_link)
         self.remote_hint = QLabel(
             _t("remote_hint",
@@ -75,18 +78,22 @@ class RemoteControlDialog(QDialog):
                "page can be triggered - nothing else. It is plain HTTP, so treat it like any "
                "other device on your network: someone else on the same network could read the "
                "token and press the same buttons. Leave it off on networks you do not trust."))
+        retranslator.bind(self.remote_hint, "remote_hint", "This opens a port on this machine for your local network. The link carries a " "one-time token that changes every time it starts, and only the buttons on the " "page can be triggered - nothing else. It is plain HTTP, so treat it like any " "other device on your network: someone else on the same network could read the " "token and press the same buttons. Leave it off on networks you do not trust.")
         self.remote_hint.setWordWrap(True)
 
         self.midi_label = QLabel(_t("remote_midi_label", "MIDI controller"))
+        retranslator.bind(self.midi_label, "remote_midi_label", "MIDI controller")
         self.midi_combobox = QComboBox()
         for index, name in list_devices():
             self.midi_combobox.addItem(name, index)
         if self.midi_combobox.count() == 0:
             self.midi_combobox.addItem(_t("remote_midi_none", "No MIDI device found"), -1)
         self.learn_button = QPushButton(_t("remote_midi_learn", "Learn"))
+        retranslator.bind(self.learn_button, "remote_midi_learn", "Learn")
         self.learn_button.clicked.connect(self.start_learning)
         self.learn_button.setEnabled(midi_available())
         self.remove_button = QPushButton(_t("remote_midi_remove", "Remove"))
+        retranslator.bind(self.remove_button, "remote_midi_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
 
         self.table = QTableWidget(0, 2)

--- a/frontengine/ui/dialog/screen_privacy_dialog.py
+++ b/frontengine/ui/dialog/screen_privacy_dialog.py
@@ -62,15 +62,19 @@ class ScreenPrivacyDialog(QDialog):
         retranslator.bind(self.apps_label, "screen_privacy_apps_label", "Meeting and capture apps:")
         self.apps_edit = QLineEdit(", ".join(settings.get("apps", [])))
         self.apps_edit.setPlaceholderText("zoom, teams, discord")
-        self.hint_label = QLabel(
-            _t("screen_privacy_hint",
-               "Matched against window titles, so a meeting held in a browser tab is caught "
-               "too. Your overlays stay on your own screen - only the capture is blank. "
-               "Masks stay visible, since covering something is what they are for.")
+        # 提示句取決於平台支不支援，登記的必須是實際選到的那個鍵
+        # The hint depends on whether the platform supports this, so register
+        # whichever key was actually chosen.
+        hint_key, hint_fallback = (
+            ("screen_privacy_hint",
+             "Matched against window titles, so a meeting held in a browser tab is caught "
+             "too. Your overlays stay on your own screen - only the capture is blank. "
+             "Masks stay visible, since covering something is what they are for.")
             if capture_affinity.available() else
-            _t("screen_privacy_unsupported",
-               "Hiding overlays from screen capture is Windows only."))
-        retranslator.bind(self.hint_label, "screen_privacy_hint", "Matched against window titles, so a meeting held in a browser tab is caught " "too. Your overlays stay on your own screen - only the capture is blank. " "Masks stay visible, since covering something is what they are for.") if capture_affinity.available() else _t("screen_privacy_unsupported", "Hiding overlays from screen capture is Windows only.")
+            ("screen_privacy_unsupported",
+             "Hiding overlays from screen capture is Windows only."))
+        self.hint_label = QLabel(_t(hint_key, hint_fallback))
+        retranslator.bind(self.hint_label, hint_key, hint_fallback)
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/screen_privacy_dialog.py
+++ b/frontengine/ui/dialog/screen_privacy_dialog.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.screen_privacy import capture_affinity
 from frontengine.utils.screen_privacy.share_watch import DEFAULT_SHARING_APPS
 from frontengine.utils.smart_pause.pause_rules import parse_app_list
@@ -55,8 +56,10 @@ class ScreenPrivacyDialog(QDialog):
 
         self.enable_checkbox = QCheckBox(
             _t("screen_privacy_enable", "Hide overlays while one of these apps is open"))
+        retranslator.bind(self.enable_checkbox, "screen_privacy_enable", "Hide overlays while one of these apps is open")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
         self.apps_label = QLabel(_t("screen_privacy_apps_label", "Meeting and capture apps:"))
+        retranslator.bind(self.apps_label, "screen_privacy_apps_label", "Meeting and capture apps:")
         self.apps_edit = QLineEdit(", ".join(settings.get("apps", [])))
         self.apps_edit.setPlaceholderText("zoom, teams, discord")
         self.hint_label = QLabel(
@@ -67,6 +70,7 @@ class ScreenPrivacyDialog(QDialog):
             if capture_affinity.available() else
             _t("screen_privacy_unsupported",
                "Hiding overlays from screen capture is Windows only."))
+        retranslator.bind(self.hint_label, "screen_privacy_hint", "Matched against window titles, so a meeting held in a browser tab is caught " "too. Your overlays stay on your own screen - only the capture is blank. " "Masks stay visible, since covering something is what they are for.") if capture_affinity.available() else _t("screen_privacy_unsupported", "Hiding overlays from screen capture is Windows only.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/screen_text_dialog.py
+++ b/frontengine/ui/dialog/screen_text_dialog.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.screen_text.screen_text_service import API_KEY_ENV, api_key
 
 CONSENT_KEY = "screen_text_consent"
@@ -78,9 +79,11 @@ class ScreenTextDialog(QDialog):
         self.text_edit = QPlainTextEdit(str(text))
         self.text_edit.setReadOnly(False)
         self.copy_button = QPushButton(_t("screen_text_copy", "Copy"))
+        retranslator.bind(self.copy_button, "screen_text_copy", "Copy")
         self.copy_button.clicked.connect(self.copy_text)
         self.consent_checkbox = QCheckBox(
             _t("screen_text_consent_toggle", "Allow sending captures to Anthropic"))
+        retranslator.bind(self.consent_checkbox, "screen_text_consent_toggle", "Allow sending captures to Anthropic")
         self.consent_checkbox.setChecked(has_consent())
         self.consent_checkbox.toggled.connect(set_consent)
         self.hint_label = QLabel(self.status_text())

--- a/frontengine/ui/dialog/signage_dialog.py
+++ b/frontengine/ui/dialog/signage_dialog.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.signage.signage_service import (
     DEFAULT_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES, clamp_interval,
     normalize_playlist,
@@ -52,20 +53,25 @@ class SignageDialog(QDialog):
         settings = current_settings()
 
         self.enable_checkbox = QCheckBox(_t("signage_enable", "Rotate presets"))
+        retranslator.bind(self.enable_checkbox, "signage_enable", "Rotate presets")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
         self.presets_label = QLabel(_t("signage_presets_label", "Presets, one per line:"))
+        retranslator.bind(self.presets_label, "signage_presets_label", "Presets, one per line:")
         self.presets_edit = QPlainTextEdit("\n".join(settings.get("presets", [])))
         self.interval_label = QLabel(_t("signage_interval_label", "Change every (minutes)"))
+        retranslator.bind(self.interval_label, "signage_interval_label", "Change every (minutes)")
         self.interval_spinbox = QSpinBox()
         self.interval_spinbox.setRange(MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES)
         self.interval_spinbox.setValue(settings.get("interval_minutes"))
         self.hide_checkbox = QCheckBox(
             _t("signage_hide_window", "Hide the main window while rotating"))
+        retranslator.bind(self.hide_checkbox, "signage_hide_window", "Hide the main window while rotating")
         self.hide_checkbox.setChecked(bool(settings.get("hide_window", True)))
         self.hint_label = QLabel(
             _t("signage_hint",
                "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
                "machine left running keeps cycling."))
+        retranslator.bind(self.hint_label, "signage_hint", "Presets are saved from the Presets menu. The rotation wraps at the end, so a " "machine left running keeps cycling.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/smart_pause_dialog.py
+++ b/frontengine/ui/dialog/smart_pause_dialog.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.smart_pause.pause_rules import DEFAULT_RULES, parse_app_list
 
 
@@ -44,17 +45,21 @@ class SmartPauseDialog(QDialog):
 
         self.fullscreen_checkbox = QCheckBox(
             _t("smart_pause_fullscreen", "Pause while a fullscreen app is running"))
+        retranslator.bind(self.fullscreen_checkbox, "smart_pause_fullscreen", "Pause while a fullscreen app is running")
         self.fullscreen_checkbox.setChecked(bool(rules.get("fullscreen", True)))
         self.battery_checkbox = QCheckBox(
             _t("smart_pause_battery", "Pause while running on battery"))
+        retranslator.bind(self.battery_checkbox, "smart_pause_battery", "Pause while running on battery")
         self.battery_checkbox.setChecked(bool(rules.get("battery", False)))
         self.apps_label = QLabel(
             _t("smart_pause_apps_label", "Pause while these apps have focus:"))
+        retranslator.bind(self.apps_label, "smart_pause_apps_label", "Pause while these apps have focus:")
         self.apps_edit = QLineEdit(", ".join(rules.get("apps", [])))
         self.apps_edit.setPlaceholderText("photoshop, premiere, blender")
         self.hint_label = QLabel(
             _t("smart_pause_hint",
                "Names are matched without the folder or .exe, so \"photoshop\" is enough."))
+        retranslator.bind(self.hint_label, "smart_pause_hint", "Names are matched without the folder or .exe, so \"photoshop\" is enough.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/usage_report_dialog.py
+++ b/frontengine/ui/dialog/usage_report_dialog.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.usage_tracking.usage_tracker import UsageTracker, format_duration
 
 
@@ -47,6 +48,7 @@ class UsageReportDialog(QDialog):
         self._on_clear = on_clear
 
         self.enable_checkbox = QCheckBox(_t("usage_enable", "Track which apps I use"))
+        retranslator.bind(self.enable_checkbox, "usage_enable", "Track which apps I use")
         self.enable_checkbox.setChecked(bool(enabled))
         self.enable_checkbox.toggled.connect(self._toggle)
 
@@ -64,13 +66,16 @@ class UsageReportDialog(QDialog):
         self.week_label = QLabel()
         self.week_label.setWordWrap(True)
         self.refresh_button = QPushButton(_t("usage_refresh", "Refresh"))
+        retranslator.bind(self.refresh_button, "usage_refresh", "Refresh")
         self.refresh_button.clicked.connect(self.reload_report)
         self.clear_button = QPushButton(_t("usage_clear", "Clear history"))
+        retranslator.bind(self.clear_button, "usage_clear", "Clear history")
         self.clear_button.clicked.connect(self.clear_history)
         self.hint_label = QLabel(
             _t("usage_hint",
                "This is stored on this machine only and is never sent anywhere. "
                "Clearing deletes the file itself."))
+        retranslator.bind(self.hint_label, "usage_hint", "This is stored on this machine only and is never sent anywhere. " "Clearing deletes the file itself.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/window_pin_dialog.py
+++ b/frontengine/ui/dialog/window_pin_dialog.py
@@ -55,13 +55,14 @@ class WindowPinDialog(QDialog):
         self.opacity_slider.setValue(window_pin.MAX_OPACITY_PERCENT)
         self.opacity_slider.valueChanged.connect(self.apply_opacity)
 
-        self.hint_label = QLabel(
-            _t("window_pin_hint",
-               "Pinning changes how a window is stacked and how see-through it is. "
-               "Windows only - other systems do not allow it.")
+        hint_key, hint_fallback = (
+            ("window_pin_hint",
+             "Pinning changes how a window is stacked and how see-through it is. "
+             "Windows only - other systems do not allow it.")
             if window_pin.available() else
-            _t("window_pin_unsupported", "Pinning other windows is Windows only."))
-        retranslator.bind(self.hint_label, "window_pin_hint", "Pinning changes how a window is stacked and how see-through it is. " "Windows only - other systems do not allow it.") if window_pin.available() else _t("window_pin_unsupported", "Pinning other windows is Windows only.")
+            ("window_pin_unsupported", "Pinning other windows is Windows only."))
+        self.hint_label = QLabel(_t(hint_key, hint_fallback))
+        retranslator.bind(self.hint_label, hint_key, hint_fallback)
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/window_pin_dialog.py
+++ b/frontengine/ui/dialog/window_pin_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.window_pin import window_pin
 
 
@@ -37,13 +38,17 @@ class WindowPinDialog(QDialog):
         self.window_list = QListWidget()
         self.window_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.refresh_button = QPushButton(_t("window_pin_refresh", "Refresh"))
+        retranslator.bind(self.refresh_button, "window_pin_refresh", "Refresh")
         self.refresh_button.clicked.connect(self.reload_windows)
         self.pin_button = QPushButton(_t("window_pin_pin", "Keep on top"))
+        retranslator.bind(self.pin_button, "window_pin_pin", "Keep on top")
         self.pin_button.clicked.connect(lambda: self.apply_pin(True))
         self.unpin_button = QPushButton(_t("window_pin_unpin", "Release"))
+        retranslator.bind(self.unpin_button, "window_pin_unpin", "Release")
         self.unpin_button.clicked.connect(lambda: self.apply_pin(False))
 
         self.opacity_label = QLabel(_t("window_pin_opacity", "Opacity"))
+        retranslator.bind(self.opacity_label, "window_pin_opacity", "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(window_pin.MIN_OPACITY_PERCENT,
                                      window_pin.MAX_OPACITY_PERCENT)
@@ -56,6 +61,7 @@ class WindowPinDialog(QDialog):
                "Windows only - other systems do not allow it.")
             if window_pin.available() else
             _t("window_pin_unsupported", "Pinning other windows is Windows only."))
+        retranslator.bind(self.hint_label, "window_pin_hint", "Pinning changes how a window is stacked and how see-through it is. " "Windows only - other systems do not allow it.") if window_pin.available() else _t("window_pin_unsupported", "Pinning other windows is Windows only.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/main_ui.py
+++ b/frontengine/ui/main_ui.py
@@ -46,6 +46,7 @@ from frontengine.utils.critical_exit.win32_vk import keyboard_keys_table
 from frontengine.utils.hotkey.hotkey_service import HotkeyService
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 from frontengine.utils.plugins.plugin_loader import load_plugins
 from frontengine.utils.preset_schedule.preset_schedule_service import PresetScheduleService
 from frontengine.ui.dialog.remote_control_dialog import (
@@ -382,8 +383,11 @@ class FrontEngineMainUI(QMainWindow):
             (self.control_center_ui, "tab_control_center_text"),
         ]
 
-        for widget, lang_key in tabs:
-            self.tab_widget.addTab(widget, language_wrapper.language_word_dict.get(lang_key))
+        for index, (widget, lang_key) in enumerate(tabs):
+            self.tab_widget.addTab(widget, translate(lang_key))
+            # setTabText 需要索引，所以索引跟著這筆登記一起記下來
+            # setTabText needs the index, so it travels with the entry.
+            retranslator.bind(self.tab_widget, lang_key, "", "setTabText", index)
 
         # 加入外部擴充 Tab
         # Add external extension tabs
@@ -441,6 +445,18 @@ class FrontEngineMainUI(QMainWindow):
             user_setting_dict["window_maximized"] = self.isMaximized()
         except Exception as error:
             front_engine_logger.warning(f"[FrontEngineMainUI] save geometry failed: {error!r}")
+
+    def retranslate(self) -> int:
+        """
+        用目前語言把畫面上的文字重寫一遍，回傳重寫了幾條。
+        換語言不必重開程式，所以開著的覆蓋層與各分頁的設定都留在原地。
+        Rewrite the interface in the current language and return how many
+        strings were rewritten. Changing language needs no restart, so open
+        overlays and the settings on every page stay exactly where they are.
+        """
+        applied = retranslator.apply()
+        front_engine_logger.info(f"[FrontEngineMainUI] retranslate | {applied} strings")
+        return applied
 
     def set_style(self) -> None:
         """更新使用者選擇的主題 / Update user-selected theme"""

--- a/frontengine/ui/menu/help_menu.py
+++ b/frontengine/ui/menu/help_menu.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QMessageBox
 from frontengine.utils.browser.browser import open_browser
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 if TYPE_CHECKING:
     from frontengine.ui.main_ui import FrontEngineMainUI
@@ -20,31 +21,32 @@ def build_help_menu(ui_we_want_to_set: FrontEngineMainUI) -> None:
     """
     front_engine_logger.info(f"[HelpMenu] build_help_menu | ui={ui_we_want_to_set}")
 
-    help_menu = ui_we_want_to_set.menu_bar.addMenu(
-        language_wrapper.language_word_dict.get("help_menu_label")
-    )
+    help_menu = ui_we_want_to_set.menu_bar.addMenu(translate("help_menu_label", "Help menu"))
+    retranslator.bind(help_menu, "help_menu_label", "Help menu", "setTitle")
     ui_we_want_to_set.help_menu = help_menu
 
     # --- 建立動作 / Create actions ---
     _add_action(
         help_menu,
-        language_wrapper.language_word_dict.get("help_menu_open_issue"),
+        "help_menu_open_issue",
         lambda: open_browser("https://github.com/Integration-Automation/FrontEngine/issues")
     )
 
     _add_action(
         help_menu,
-        language_wrapper.language_word_dict.get("how_to_critical_exit_action"),
+        "how_to_critical_exit_action",
         lambda: how_to_critical_exit(ui_we_want_to_set)
     )
 
 
-def _add_action(menu, label: str, callback) -> QAction:
+def _add_action(menu, key: str, callback, fallback: str = "") -> QAction:
     """
-    建立 QAction 並加入選單
-    Create a QAction and add it to the menu
+    建立 QAction 並加入選單，同時記住它的文字來自哪個鍵，換語言時才跟得上。
+    Create a QAction, add it to the menu, and remember which key its text came
+    from so a language change reaches it.
     """
-    action = QAction(label, menu)
+    action = QAction(translate(key, fallback), menu)
+    retranslator.bind(action, key, fallback)
     action.triggered.connect(callback)
     menu.addAction(action)
     return action

--- a/frontengine/ui/menu/how_to_menu.py
+++ b/frontengine/ui/menu/how_to_menu.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QAction
 
 from frontengine.utils.browser.browser import open_browser
 from frontengine.utils.logging.loggin_instance import front_engine_logger
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 if TYPE_CHECKING:
     from frontengine.ui.main_ui import FrontEngineMainUI
@@ -20,25 +20,25 @@ def build_how_to_menu(ui_we_want_to_set: FrontEngineMainUI) -> None:
     front_engine_logger.info(f"[HowToMenu] build_how_to_menu | ui={ui_we_want_to_set}")
 
     # 建立選單 / Create menu
-    how_to_menu = ui_we_want_to_set.menu_bar.addMenu(
-        language_wrapper.language_word_dict.get("doc_menu_label")
-    )
+    how_to_menu = ui_we_want_to_set.menu_bar.addMenu(translate("doc_menu_label", "Doc menu"))
+    retranslator.bind(how_to_menu, "doc_menu_label", "Doc menu", "setTitle")
     ui_we_want_to_set.how_to_menu = how_to_menu
 
     # 建立「開啟文件」動作 / Create "Open Documentation" action
     _add_action(
         how_to_menu,
-        language_wrapper.language_word_dict.get("doc_menu_open_doc"),
+        "doc_menu_open_doc",
         lambda: open_browser("https://frontengine.readthedocs.io/en/latest/")
     )
 
 
-def _add_action(menu, label: str, callback) -> QAction:
+def _add_action(menu, key: str, callback, fallback: str = "") -> QAction:
     """
-    建立 QAction 並加入選單
-    Create a QAction and add it to the menu
+    建立 QAction 並加入選單，同時記住它的文字來自哪個鍵。
+    Create a QAction, add it to the menu, and remember the key behind its text.
     """
-    action = QAction(label, menu)
+    action = QAction(translate(key, fallback), menu)
+    retranslator.bind(action, key, fallback)
     action.triggered.connect(callback)
     menu.addAction(action)
     return action

--- a/frontengine/ui/menu/language_menu.py
+++ b/frontengine/ui/menu/language_menu.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple
 
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMessageBox
 
 from frontengine.user_setting.user_setting_file import user_setting_dict
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 if TYPE_CHECKING:
     from frontengine.ui.main_ui import FrontEngineMainUI
+
+# (顯示用的鍵, 語言代碼)。代碼必須是 language_wrapper 註冊過的名字——這裡原本寫
+# "French" / "Italian"，而註冊的是 "France" / "Italy"，reset_language() 找不到就
+# 默默 return，所以那兩個選項按下去完全沒有反應。
+# (label key, language code). The code must be a name language_wrapper
+# registered: this list used to say "French" / "Italian" while the registry
+# said "France" / "Italy", and reset_language() returns quietly on a name it
+# does not know - so those two entries did nothing at all.
+LANGUAGES: List[Tuple[str, str]] = [
+    ("language_menu_bar_english", "English"),
+    ("language_menu_bar_traditional_chinese", "Traditional_Chinese"),
+    ("language_menu_bar_simplified_chinese", "Simplified_Chinese"),
+    ("language_menu_bar_germany", "Deutsch"),
+    ("language_menu_bar_russian", "Russian"),
+    ("language_menu_bar_french", "France"),
+    ("language_menu_bar_italian", "Italy"),
+]
 
 
 def build_language_menu(ui_we_want_to_set: FrontEngineMainUI) -> None:
@@ -20,38 +37,28 @@ def build_language_menu(ui_we_want_to_set: FrontEngineMainUI) -> None:
     """
     front_engine_logger.info(f"[LanguageMenu] build_language_menu | ui={ui_we_want_to_set}")
 
-    language_menu = ui_we_want_to_set.menu_bar.addMenu(
-        language_wrapper.language_word_dict.get("menu_bar_language")
-    )
+    language_menu = ui_we_want_to_set.menu_bar.addMenu(translate("menu_bar_language", "Language"))
+    retranslator.bind(language_menu, "menu_bar_language", "Language", "setTitle")
     ui_we_want_to_set.language_menu = language_menu
 
-    # 語言清單 (label_key, 語言代碼)
-    languages = [
-        ("language_menu_bar_english", "English"),
-        ("language_menu_bar_traditional_chinese", "Traditional_Chinese"),
-        ("language_menu_bar_simplified_chinese", "Simplified_Chinese"),
-        ("language_menu_bar_germany", "Deutsch"),
-        ("language_menu_bar_russian", "Russian"),
-        ("language_menu_bar_french", "French"),
-        ("language_menu_bar_italian", "Italian"),
-    ]
-
-    # 動態建立 QAction
-    for label_key, lang_code in languages:
-        action = QAction(language_wrapper.language_word_dict.get(label_key), language_menu)
-        action.triggered.connect(lambda _, code=lang_code: set_language(code, ui_we_want_to_set))
+    for label_key, language_code in LANGUAGES:
+        action = QAction(translate(label_key, language_code), language_menu)
+        retranslator.bind(action, label_key, language_code)
+        action.triggered.connect(
+            lambda _, code=language_code: set_language(code, ui_we_want_to_set))
         language_menu.addAction(action)
 
 
-def set_language(language: str, ui_we_want_to_set: FrontEngineMainUI) -> None:
+def set_language(language: str, ui_we_want_to_set: FrontEngineMainUI) -> bool:
     """
-    設定語言並提示使用者重新啟動
-    Set application language and prompt user to restart
+    切換語言並立刻重寫畫面上的文字，不必重新啟動。
+    回傳是否真的換成功（語言代碼不認得就是 False）。
+    Switch language and rewrite the interface immediately - no restart needed.
+    Returns whether the switch actually happened; an unknown code gives False.
     """
-    front_engine_logger.info(f"[LanguageMenu] set_language | ui={ui_we_want_to_set}, language={language}")
-    language_wrapper.reset_language(language)
+    front_engine_logger.info(f"[LanguageMenu] set_language | language={language}")
+    if not language_wrapper.reset_language(language):
+        return False
     user_setting_dict.update({"language": language})
-
-    message_box = QMessageBox(ui_we_want_to_set)
-    message_box.setText(language_wrapper.language_word_dict.get("language_menu_bar_please_restart_messagebox"))
-    message_box.exec()  # 使用 exec() 讓使用者必須確認
+    ui_we_want_to_set.retranslate()
+    return True

--- a/frontengine/ui/menu/preset_menu.py
+++ b/frontengine/ui/menu/preset_menu.py
@@ -13,6 +13,7 @@ from frontengine.utils.workshop.workshop_content import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 if TYPE_CHECKING:
     from frontengine.ui.main_ui import FrontEngineMainUI
@@ -365,6 +366,7 @@ def build_preset_menu(ui: "FrontEngineMainUI") -> None:
     """
     front_engine_logger.info(f"[PresetMenu] build_preset_menu | ui={ui}")
     menu = ui.menu_bar.addMenu(_t("menu_bar_presets", "Presets"))
+    retranslator.bind(menu, "menu_bar_presets", "Presets", "setTitle")
     ui.preset_menu = menu
 
     for label_key, fallback, callback_factory in (
@@ -380,5 +382,6 @@ def build_preset_menu(ui: "FrontEngineMainUI") -> None:
         ("workshop_menu_import", "Import Workshop content...", _workshop_action),
     ):
         action = QAction(_t(label_key, fallback), menu)
+        retranslator.bind(action, label_key, fallback)
         action.triggered.connect(callback_factory(ui))
         menu.addAction(action)

--- a/frontengine/ui/menu/settings_menu.py
+++ b/frontengine/ui/menu/settings_menu.py
@@ -24,6 +24,7 @@ from frontengine.user_setting.user_setting_file import (
 from frontengine.utils.autostart import autostart_service
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 if TYPE_CHECKING:
     from frontengine.ui.main_ui import FrontEngineMainUI
@@ -37,16 +38,17 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
     """Build the Settings menu with hotkey configuration and settings I/O."""
     front_engine_logger.info(f"[SettingsMenu] build_settings_menu | ui={ui}")
     menu = ui.menu_bar.addMenu(_t("menu_bar_settings", "Settings"))
+    retranslator.bind(menu, "menu_bar_settings", "Settings", "setTitle")
     ui.settings_menu = menu
 
     hotkey_action = QAction(_t("settings_menu_hotkeys", "Hotkeys..."), menu)
+    retranslator.bind(hotkey_action, "settings_menu_hotkeys", "Hotkeys...")
     hotkey_action.triggered.connect(lambda: _open_hotkey_dialog(ui))
     menu.addAction(hotkey_action)
 
     schedule = user_setting_dict.get("theme_schedule")
-    theme_schedule_action = QAction(
-        _t("settings_menu_theme_schedule", "Scheduled day/night theme"), menu
-    )
+    theme_schedule_action = QAction(_t("settings_menu_theme_schedule", "Scheduled day/night theme"), menu)
+    retranslator.bind(theme_schedule_action, "settings_menu_theme_schedule", "Scheduled day/night theme")
     theme_schedule_action.setCheckable(True)
     theme_schedule_action.setChecked(bool(isinstance(schedule, dict) and schedule.get("enabled")))
     theme_schedule_action.toggled.connect(lambda checked: _toggle_theme_schedule(ui, checked))
@@ -54,6 +56,7 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
     ui.theme_schedule_action = theme_schedule_action
 
     autostart_action = QAction(_t("settings_menu_autostart", "Start with the system"), menu)
+    retranslator.bind(autostart_action, "settings_menu_autostart", "Start with the system")
     autostart_action.setCheckable(True)
     autostart_action.setChecked(autostart_service.is_enabled())
     autostart_action.toggled.connect(lambda checked: _toggle_autostart(ui, checked))
@@ -61,6 +64,7 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
     ui.autostart_action = autostart_action
 
     restore_action = QAction(_t("settings_menu_restore_session", "Restore last session"), menu)
+    retranslator.bind(restore_action, "settings_menu_restore_session", "Restore last session")
     restore_action.setCheckable(True)
     restore_action.setChecked(bool(user_setting_dict.get("restore_last_session")))
     restore_action.toggled.connect(lambda checked: _toggle_restore_session(checked))
@@ -68,6 +72,7 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
     ui.restore_session_action = restore_action
 
     plugins_action = QAction(_t("settings_menu_plugins", "Load plugins (advanced)"), menu)
+    retranslator.bind(plugins_action, "settings_menu_plugins", "Load plugins (advanced)")
     plugins_action.setCheckable(True)
     plugins_action.setChecked(bool(user_setting_dict.get("load_plugins")))
     plugins_action.toggled.connect(lambda checked: _toggle_plugins(ui, checked))
@@ -76,47 +81,55 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
 
     menu.addSeparator()
     smart_pause_action = QAction(_t("settings_menu_smart_pause", "Smart pause..."), menu)
+    retranslator.bind(smart_pause_action, "settings_menu_smart_pause", "Smart pause...")
     smart_pause_action.triggered.connect(lambda: _open_dialog(ui, SmartPauseDialog))
     menu.addAction(smart_pause_action)
     ui.smart_pause_action = smart_pause_action
 
     app_profile_action = QAction(_t("settings_menu_app_profiles", "App profiles..."), menu)
+    retranslator.bind(app_profile_action, "settings_menu_app_profiles", "App profiles...")
     app_profile_action.triggered.connect(lambda: _open_dialog(ui, AppProfileDialog))
     menu.addAction(app_profile_action)
     ui.app_profile_action = app_profile_action
 
     reminder_action = QAction(_t("settings_menu_reminders", "Reminders..."), menu)
+    retranslator.bind(reminder_action, "settings_menu_reminders", "Reminders...")
     reminder_action.triggered.connect(lambda: _open_dialog(ui, ReminderDialog))
     menu.addAction(reminder_action)
     ui.reminder_action = reminder_action
 
     signage_action = QAction(_t("settings_menu_signage", "Signage mode..."), menu)
+    retranslator.bind(signage_action, "settings_menu_signage", "Signage mode...")
     signage_action.triggered.connect(lambda: _open_signage_dialog(ui))
     menu.addAction(signage_action)
     ui.signage_action = signage_action
 
     remote_action = QAction(_t("settings_menu_remote", "Remote control..."), menu)
+    retranslator.bind(remote_action, "settings_menu_remote", "Remote control...")
     remote_action.triggered.connect(lambda: _open_remote_dialog(ui))
     menu.addAction(remote_action)
     ui.remote_action = remote_action
 
-    privacy_action = QAction(
-        _t("settings_menu_screen_privacy", "Screen-sharing privacy..."), menu)
+    privacy_action = QAction(_t("settings_menu_screen_privacy", "Screen-sharing privacy..."), menu)
+    retranslator.bind(privacy_action, "settings_menu_screen_privacy", "Screen-sharing privacy...")
     privacy_action.triggered.connect(lambda: _open_dialog(ui, ScreenPrivacyDialog))
     menu.addAction(privacy_action)
     ui.screen_privacy_action = privacy_action
 
     usage_action = QAction(_t("settings_menu_usage", "Screen time..."), menu)
+    retranslator.bind(usage_action, "settings_menu_usage", "Screen time...")
     usage_action.triggered.connect(lambda: _open_usage_dialog(ui))
     menu.addAction(usage_action)
     ui.usage_action = usage_action
 
     clipboard_action = QAction(_t("settings_menu_clipboard", "Clipboard history..."), menu)
+    retranslator.bind(clipboard_action, "settings_menu_clipboard", "Clipboard history...")
     clipboard_action.triggered.connect(lambda: _open_clipboard_dialog(ui))
     menu.addAction(clipboard_action)
     ui.clipboard_action = clipboard_action
 
     clipboard_toggle = QAction(_t("settings_menu_clipboard_record", "Record clipboard"), menu)
+    retranslator.bind(clipboard_toggle, "settings_menu_clipboard_record", "Record clipboard")
     clipboard_toggle.setCheckable(True)
     clipboard_toggle.setChecked(bool(user_setting_dict.get("clipboard_history")))
     clipboard_toggle.toggled.connect(lambda checked: ui.set_clipboard_history(checked))
@@ -125,10 +138,12 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
 
     menu.addSeparator()
     export_action = QAction(_t("settings_menu_export", "Export settings..."), menu)
+    retranslator.bind(export_action, "settings_menu_export", "Export settings...")
     export_action.triggered.connect(lambda: _export_settings(ui))
     menu.addAction(export_action)
 
     import_action = QAction(_t("settings_menu_import", "Import settings..."), menu)
+    retranslator.bind(import_action, "settings_menu_import", "Import settings...")
     import_action.triggered.connect(lambda: _import_settings(ui))
     menu.addAction(import_action)
 

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -18,6 +18,7 @@ from frontengine.ui.page.web.web_setting_ui import WEBSettingUI
 from frontengine.user_setting.user_setting_file import clear_overlay_geometry
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 from frontengine.utils.screen_privacy import capture_affinity
 from frontengine.utils.power_mode.power_mode import (
     TIER_BALANCED, TIER_HIGH, TIER_SAVER, normalize_tier,
@@ -108,6 +109,7 @@ class ControlCenterUI(QWidget):
         # Quality tier: finer than the low-power switch, applied to every overlay.
         self.quality_label = QLabel(
             language_wrapper.language_word_dict.get("control_center_quality", "Quality"))
+        retranslator.bind(self.quality_label, "control_center_quality", "Quality")
         self.quality_combobox = QComboBox()
         for tier, key, fallback in (
                 (TIER_HIGH, "control_center_quality_high", "High"),
@@ -157,8 +159,13 @@ class ControlCenterUI(QWidget):
             redirect_manager_instance.set_redirect()
 
     def _create_button(self, label_key: str, callback) -> QPushButton:
-        """建立按鈕並綁定事件 / Create button and bind callback"""
-        button = QPushButton(language_wrapper.language_word_dict.get(label_key))
+        """
+        建立按鈕、綁定事件，並記住文字來自哪個鍵，換語言時才跟得上。
+        Create the button, bind the callback, and remember the key behind its
+        text so a language change reaches it.
+        """
+        button = QPushButton(translate(label_key))
+        retranslator.bind(button, label_key)
         button.clicked.connect(callback)
         return button
 
@@ -304,12 +311,10 @@ class ControlCenterUI(QWidget):
                 setter(self._muted)
 
         self._for_each_overlay(apply)
-        self.mute_all_button.setText(
-            language_wrapper.language_word_dict.get(
-                "control_center_unmute_all" if self._muted else "control_center_mute_all",
-                "Unmute all" if self._muted else "Mute all",
-            )
-        )
+        retranslator.set_text(
+            self.mute_all_button,
+            "control_center_unmute_all" if self._muted else "control_center_mute_all",
+            "Unmute all" if self._muted else "Mute all",)
 
     def toggle_mute_all(self) -> None:
         """切換全域靜音狀態 / Toggle the global mute state."""
@@ -329,12 +334,10 @@ class ControlCenterUI(QWidget):
         front_engine_logger.info(f"ControlCenterUI set_lock_all | locked={locked}")
         self._overlays_locked = bool(locked)
         self._for_each_overlay(lambda widget: set_overlay_locked(widget, self._overlays_locked))
-        self.lock_all_button.setText(
-            language_wrapper.language_word_dict.get(
-                "control_center_unlock_all" if self._overlays_locked else "control_center_lock_all",
-                "Unlock overlays" if self._overlays_locked else "Lock overlays",
-            )
-        )
+        retranslator.set_text(
+            self.lock_all_button,
+            "control_center_unlock_all" if self._overlays_locked else "control_center_lock_all",
+            "Unlock overlays" if self._overlays_locked else "Lock overlays",)
 
     def toggle_lock_all(self) -> None:
         """切換覆蓋層鎖定狀態 / Toggle the overlay lock."""
@@ -352,12 +355,10 @@ class ControlCenterUI(QWidget):
                 setter(color)
 
         self._for_each_overlay(apply)
-        self.chroma_key_button.setText(
-            language_wrapper.language_word_dict.get(
-                "control_center_chroma_key_off" if self._chroma_key else "control_center_chroma_key_on",
-                "Chroma key off" if self._chroma_key else "Chroma key on",
-            )
-        )
+        retranslator.set_text(
+            self.chroma_key_button,
+            "control_center_chroma_key_off" if self._chroma_key else "control_center_chroma_key_on",
+            "Chroma key off" if self._chroma_key else "Chroma key on",)
 
     def toggle_chroma_key(self) -> None:
         """切換綠幕背景 / Toggle the chroma key background."""
@@ -379,12 +380,10 @@ class ControlCenterUI(QWidget):
                 setter(self._low_power)
 
         self._for_each_overlay(apply)
-        self.low_power_button.setText(
-            language_wrapper.language_word_dict.get(
-                "control_center_low_power_off" if self._low_power else "control_center_low_power_on",
-                "Low power off" if self._low_power else "Low power on",
-            )
-        )
+        retranslator.set_text(
+            self.low_power_button,
+            "control_center_low_power_off" if self._low_power else "control_center_low_power_on",
+            "Low power off" if self._low_power else "Low power on",)
 
     def set_hide_from_capture(self, hidden: bool) -> int:
         """
@@ -408,11 +407,11 @@ class ControlCenterUI(QWidget):
         self._for_each_overlay(apply)
         front_engine_logger.info(
             f"ControlCenterUI set_hide_from_capture | hidden={hidden}, applied={applied}")
-        self.capture_button.setText(
-            language_wrapper.language_word_dict.get(
-                "control_center_show_in_capture" if self._hidden_from_capture
-                else "control_center_hide_from_capture",
-                "Show in capture" if self._hidden_from_capture else "Hide from capture"))
+        retranslator.set_text(
+            self.capture_button,
+            "control_center_show_in_capture" if self._hidden_from_capture
+            else "control_center_hide_from_capture",
+            "Show in capture" if self._hidden_from_capture else "Hide from capture")
         return applied
 
     def toggle_hide_from_capture(self) -> None:

--- a/frontengine/ui/page/focus/focus_setting_ui.py
+++ b/frontengine/ui/page/focus/focus_setting_ui.py
@@ -21,6 +21,7 @@ from frontengine.utils.focus_shield.focus_shield import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class FocusSettingUI(QWidget):
@@ -38,17 +39,20 @@ class FocusSettingUI(QWidget):
         # Dim background windows
         self.dim_label = QLabel(
             language_wrapper.language_word_dict.get("focus_dim_label", "Dim background windows"))
+        retranslator.bind(self.dim_label, "focus_dim_label", "Dim background windows")
         self.dim_slider = QSlider(Qt.Orientation.Horizontal)
         self.dim_slider.setRange(10, 90)
         self.dim_slider.setValue(45)
         self.dim_slider.valueChanged.connect(self._apply_dim_settings)
         self.dim_button = QPushButton(
             language_wrapper.language_word_dict.get("focus_dim_start", "Dim the background"))
+        retranslator.bind(self.dim_button, "focus_dim_start", "Dim the background")
         self.dim_button.clicked.connect(self.toggle_dim)
 
         # Mask a distraction
         self.mask_label = QLabel(
             language_wrapper.language_word_dict.get("focus_mask_label", "Cover a distraction"))
+        retranslator.bind(self.mask_label, "focus_mask_label", "Cover a distraction")
         self.mask_region_combobox = QComboBox()
         for region, fallback in (
             (REGION_BOTTOM, "Bottom strip (taskbar)"), (REGION_BOTTOM_RIGHT, "Bottom-right corner"),
@@ -65,17 +69,20 @@ class FocusSettingUI(QWidget):
         self.mask_percent_slider.valueChanged.connect(self._apply_mask_settings)
         self.mask_button = QPushButton(
             language_wrapper.language_word_dict.get("focus_mask_start", "Cover it up"))
+        retranslator.bind(self.mask_button, "focus_mask_start", "Cover it up")
         self.mask_button.clicked.connect(self.toggle_mask)
 
         # Shared
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
         self.hint_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "focus_hint",
                 "Both overlays pass clicks through — what they cover still works, "
                 "it just stops competing for your attention."))
+        retranslator.bind(self.hint_label, "focus_hint", "Both overlays pass clicks through — what they cover still works, " "it just stops competing for your attention.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/gif/gif_setting_ui.py
+++ b/frontengine/ui/page/gif/gif_setting_ui.py
@@ -19,6 +19,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class GIFSettingUI(QWidget):
@@ -37,6 +38,7 @@ class GIFSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -45,6 +47,7 @@ class GIFSettingUI(QWidget):
 
         # Speed setting
         self.speed_label = QLabel(language_wrapper.language_word_dict.get("Speed"))
+        retranslator.bind(self.speed_label, "Speed", "")
         self.speed_slider = QSlider(Qt.Orientation.Horizontal)
         self.speed_slider.setRange(1, 200)
         self.speed_slider.setValue(100)
@@ -53,32 +56,40 @@ class GIFSettingUI(QWidget):
 
         # Choose file button
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_choose_file"))
+        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file", "")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_gif_dir_then_play)
 
         # Ready label
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        retranslator.bind(self.ready_label, "Not Ready", "")
 
         # Start button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_play"))
+        retranslator.bind(self.start_button, "gif_setting_ui_play", "")
         self.start_button.clicked.connect(self.start_play_gif)
 
         # Checkboxes
         self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
         self.fullscreen_checkbox.setChecked(True)
 
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
 
         # Target monitor selector
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
         self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
+        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("gif")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/image/image_setting_ui.py
+++ b/frontengine/ui/page/image/image_setting_ui.py
@@ -25,6 +25,7 @@ from frontengine.utils.logging.loggin_instance import front_engine_logger
 # 輪播支援的圖片副檔名 / Image extensions the slideshow accepts
 _SLIDESHOW_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".bmp")
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class ImageSettingUI(QWidget):
@@ -50,6 +51,7 @@ class ImageSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -58,53 +60,66 @@ class ImageSettingUI(QWidget):
 
         # Choose file button
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        retranslator.bind(self.ready_label, "Not Ready", "")
 
         # Start button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_ui_play"))
+        retranslator.bind(self.start_button, "image_setting_ui_play", "")
         self.start_button.clicked.connect(self.start_play_image)
 
         # Checkboxes
         self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
         self.fullscreen_checkbox.setChecked(True)
 
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
 
         # Target monitor selector
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
         self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
+        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("image")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 
         # Slideshow controls
         self.slideshow_checkbox = QCheckBox(language_wrapper.language_word_dict.get("slideshow_label", "Slideshow"))
+        retranslator.bind(self.slideshow_checkbox, "slideshow_label", "Slideshow")
         self.slideshow_folder_button = QPushButton(
             language_wrapper.language_word_dict.get("slideshow_choose_folder", "Choose folder")
         )
+        retranslator.bind(self.slideshow_folder_button, "slideshow_choose_folder", "Choose folder")
         self.slideshow_folder_button.clicked.connect(self.choose_slideshow_folder)
         self.slideshow_interval_label = QLabel(
             language_wrapper.language_word_dict.get("slideshow_interval_label", "Interval (s)")
         )
+        retranslator.bind(self.slideshow_interval_label, "slideshow_interval_label", "Interval (s)")
         self.slideshow_interval_combobox = QComboBox()
         self.slideshow_interval_combobox.addItems(["3", "5", "10", "15", "30", "60"])
         self.slideshow_interval_combobox.setCurrentText("5")
         self.slideshow_shuffle_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("slideshow_shuffle", "Shuffle")
         )
+        retranslator.bind(self.slideshow_shuffle_checkbox, "slideshow_shuffle", "Shuffle")
         self.slideshow_recursive_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("slideshow_recursive", "Include subfolders")
         )
+        retranslator.bind(self.slideshow_recursive_checkbox, "slideshow_recursive", "Include subfolders")
 
         # Accept dropped image files
         self._drop_filter = enable_file_drop(self, _SLIDESHOW_EXTENSIONS, self._on_file_dropped)

--- a/frontengine/ui/page/particle/particle_setting_ui.py
+++ b/frontengine/ui/page/particle/particle_setting_ui.py
@@ -18,6 +18,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class ParticleSettingUI(QWidget):
@@ -36,6 +37,7 @@ class ParticleSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -44,13 +46,16 @@ class ParticleSettingUI(QWidget):
 
         # Choose file button
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        retranslator.bind(self.ready_label, "Not Ready", "")
 
         # Direction
         self.choose_direction_label = QLabel(language_wrapper.language_word_dict.get("choose_particle_direction"))
+        retranslator.bind(self.choose_direction_label, "choose_particle_direction", "")
         self.choose_direction_combobox = QComboBox()
         self.choose_direction_combobox.addItems(
             ["down", "up", "left", "right"]
@@ -58,6 +63,7 @@ class ParticleSettingUI(QWidget):
 
         # Particle size
         self.particle_size_label = QLabel(language_wrapper.language_word_dict.get("particle_size"))
+        retranslator.bind(self.particle_size_label, "particle_size", "")
         self.particle_size_combobox = QComboBox()
         for size in range(10, 310, 10):
             self.particle_size_combobox.addItem(str(size))
@@ -65,6 +71,7 @@ class ParticleSettingUI(QWidget):
 
         # Particle count
         self.particle_count_label = QLabel(language_wrapper.language_word_dict.get("particle_count"))
+        retranslator.bind(self.particle_count_label, "particle_count", "")
         self.particle_count_combobox = QComboBox()
         for count in range(50, 10010, 10):
             self.particle_count_combobox.addItem(str(count))
@@ -72,26 +79,31 @@ class ParticleSettingUI(QWidget):
 
         # Particle speed
         self.particle_speed_label = QLabel(language_wrapper.language_word_dict.get("particle_speed"))
+        retranslator.bind(self.particle_speed_label, "particle_speed", "")
         self.particle_speed_combobox = QComboBox()
         for speed in range(3, 11):
             self.particle_speed_combobox.addItem(str(speed / 1000))
 
         # Start button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("particle_setting_ui_play"))
+        retranslator.bind(self.start_button, "particle_setting_ui_play", "")
         self.start_button.clicked.connect(self.start_play_particle)
 
         # Checkboxes
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Target monitor selector
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
         self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
+        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("particle")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -29,6 +29,7 @@ from frontengine.utils.focus_timer.focus_timer import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 _PET_EXTENSIONS = (".gif", ".webp", ".png", ".jpg")
 
@@ -69,31 +70,38 @@ class PetSettingUI(QWidget):
         self.choose_file_button = QPushButton(
             language_wrapper.language_word_dict.get("pet_choose_file", "Choose pet sprite")
         )
+        retranslator.bind(self.choose_file_button, "pet_choose_file", "Choose pet sprite")
         self.choose_file_button.clicked.connect(self.choose_and_play)
         self.choose_pack_button = QPushButton(
             language_wrapper.language_word_dict.get("pet_choose_pack", _CHOOSE_PACK)
         )
+        retranslator.bind(self.choose_pack_button, "pet_choose_pack", _CHOOSE_PACK)
         self.choose_pack_button.clicked.connect(self.choose_pack)
         self.choose_sound_button = QPushButton(
             language_wrapper.language_word_dict.get("pet_choose_sound", "Choose sound (optional)")
         )
+        retranslator.bind(self.choose_sound_button, "pet_choose_sound", "Choose sound (optional)")
         self.choose_sound_button.clicked.connect(self.choose_sound)
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        retranslator.bind(self.ready_label, "Not Ready", "")
 
         # Size
         self.size_label = QLabel(language_wrapper.language_word_dict.get("pet_size_label", "Size"))
+        retranslator.bind(self.size_label, "pet_size_label", "Size")
         self.size_combobox = QComboBox()
         self.size_combobox.addItems(["64", "96", "128", "192", "256"])
         self.size_combobox.setCurrentText("128")
 
         # Speed
         self.speed_label = QLabel(language_wrapper.language_word_dict.get("pet_speed_label", "Speed"))
+        retranslator.bind(self.speed_label, "pet_speed_label", "Speed")
         self.speed_combobox = QComboBox()
         self.speed_combobox.addItems([str(n) for n in range(1, 11)])
         self.speed_combobox.setCurrentText("3")
 
         # Behaviour
         self.behaviour_label = QLabel(language_wrapper.language_word_dict.get("pet_behaviour_label", "Behaviour"))
+        retranslator.bind(self.behaviour_label, "pet_behaviour_label", "Behaviour")
         self.behaviour_combobox = QComboBox()
         self.behaviour_combobox.addItem(
             language_wrapper.language_word_dict.get("pet_behaviour_floor", "Walk on floor"), BEHAVIOUR_FLOOR)
@@ -104,18 +112,24 @@ class PetSettingUI(QWidget):
 
         # Climb walls / ceiling (only meaningful in floor mode)
         self.climb_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_climb_label", "Climb walls"))
+        retranslator.bind(self.climb_checkbox, "pet_climb_label", "Climb walls")
         self.climb_checkbox.setChecked(True)
         self.talk_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_talk_label", "Speech bubbles"))
+        retranslator.bind(self.talk_checkbox, "pet_talk_label", "Speech bubbles")
         self.talk_checkbox.setChecked(True)
         self.sit_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_sit_label", "Sit on windows"))
+        retranslator.bind(self.sit_checkbox, "pet_sit_label", "Sit on windows")
         self.sit_checkbox.setChecked(True)
         self.tag_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("pet_tag_label", "Play tag with each other"))
+        retranslator.bind(self.tag_checkbox, "pet_tag_label", "Play tag with each other")
         self.tag_checkbox.toggled.connect(self._on_tag_toggled)
         self.speech_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("pet_speech_label", "Speak out loud"))
+        retranslator.bind(self.speech_checkbox, "pet_speech_label", "Speak out loud")
         self.chat_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("pet_chat_label", "AI chat (needs API key)"))
+        retranslator.bind(self.chat_checkbox, "pet_chat_label", "AI chat (needs API key)")
         self.chat_checkbox.setToolTip(
             language_wrapper.language_word_dict.get(
                 "pet_chat_hint",
@@ -124,6 +138,7 @@ class PetSettingUI(QWidget):
         # Focus timer (pomodoro) controls
         self.focus_label = QLabel(
             language_wrapper.language_word_dict.get("pet_focus_label", "Focus timer (min)"))
+        retranslator.bind(self.focus_label, "pet_focus_label", "Focus timer (min)")
         self.focus_minutes_combobox = QComboBox()
         self.focus_minutes_combobox.addItems(["15", "20", "25", "30", "45", "50"])
         self.focus_minutes_combobox.setCurrentText("25")
@@ -132,13 +147,16 @@ class PetSettingUI(QWidget):
         self.break_minutes_combobox.setCurrentText("5")
         self.focus_button = QPushButton(
             language_wrapper.language_word_dict.get("pet_focus_start", "Start focus"))
+        retranslator.bind(self.focus_button, "pet_focus_start", "Start focus")
         self.focus_button.clicked.connect(self.toggle_focus_session)
 
         # Target monitor + sound volume
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
         self.volume_label = QLabel(language_wrapper.language_word_dict.get("pet_volume_label", "Volume"))
+        retranslator.bind(self.volume_label, "pet_volume_label", "Volume")
         self.volume_combobox = QComboBox()
         for label, value in (("0%", 0), ("25%", 25), ("50%", 50), ("75%", 75), ("100%", 100)):
             self.volume_combobox.addItem(label, value)
@@ -151,19 +169,23 @@ class PetSettingUI(QWidget):
             "microphone")
         self.audio_react_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("pet_audio_label", "React to audio"))
+        retranslator.bind(self.audio_react_checkbox, "pet_audio_label", "React to audio")
         self.drop_hint_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "pet_drop_hint",
                 "Tip: drop an image or pet pack onto the pet to change its look, "
                 "or any other file to feed it."))
+        retranslator.bind(self.drop_hint_label, "pet_drop_hint", "Tip: drop an image or pet pack onto the pet to change its look, " "or any other file to feed it.")
         self.drop_hint_label.setWordWrap(True)
 
         # Start
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("pet_start", "Spawn pet"))
+        retranslator.bind(self.start_button, "pet_start", "Spawn pet")
         self.start_button.clicked.connect(self.start_play_pet)
 
         # Recent files
         self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
+        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("pet")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -26,6 +26,7 @@ from frontengine.ui.page.utils import build_target_monitor_combobox, coerce_int,
 from frontengine.utils.input_watch.input_watch_service import InputWatchService
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class PresentationSettingUI(QWidget):
@@ -51,6 +52,7 @@ class PresentationSettingUI(QWidget):
         # Annotation
         self.annotate_label = QLabel(
             language_wrapper.language_word_dict.get("annotate_label", "Screen annotation"))
+        retranslator.bind(self.annotate_label, "annotate_label", "Screen annotation")
         self.annotate_tool_combobox = QComboBox()
         for tool, fallback in ((TOOL_PEN, "Pen"), (TOOL_HIGHLIGHTER, "Highlighter"),
                                (TOOL_ERASER, "Eraser")):
@@ -67,64 +69,80 @@ class PresentationSettingUI(QWidget):
         self.annotate_width_slider.valueChanged.connect(self._apply_annotation_settings)
         self.annotate_button = QPushButton(
             language_wrapper.language_word_dict.get("annotate_start", "Start drawing"))
+        retranslator.bind(self.annotate_button, "annotate_start", "Start drawing")
         self.annotate_button.clicked.connect(self.toggle_annotation)
         self.annotate_undo_button = QPushButton(
             language_wrapper.language_word_dict.get("annotate_undo", "Undo"))
+        retranslator.bind(self.annotate_undo_button, "annotate_undo", "Undo")
         self.annotate_undo_button.clicked.connect(self.undo_annotation)
         self.annotate_clear_button = QPushButton(
             language_wrapper.language_word_dict.get("annotate_clear", "Clear"))
+        retranslator.bind(self.annotate_clear_button, "annotate_clear", "Clear")
         self.annotate_clear_button.clicked.connect(self.clear_annotation)
 
         # Cursor effects
         self.cursor_label = QLabel(
             language_wrapper.language_word_dict.get("cursor_effect_label", "Cursor emphasis"))
+        retranslator.bind(self.cursor_label, "cursor_effect_label", "Cursor emphasis")
         self.cursor_ring_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("cursor_effect_ring", "Highlight"))
+        retranslator.bind(self.cursor_ring_checkbox, "cursor_effect_ring", "Highlight")
         self.cursor_ring_checkbox.setChecked(True)
         self.cursor_ripple_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("cursor_effect_ripple", "Click ripple"))
+        retranslator.bind(self.cursor_ripple_checkbox, "cursor_effect_ripple", "Click ripple")
         self.cursor_ripple_checkbox.setChecked(True)
         self.cursor_spotlight_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("cursor_effect_spotlight", "Spotlight"))
+        retranslator.bind(self.cursor_spotlight_checkbox, "cursor_effect_spotlight", "Spotlight")
         for checkbox in (self.cursor_ring_checkbox, self.cursor_ripple_checkbox,
                          self.cursor_spotlight_checkbox):
             checkbox.toggled.connect(self._apply_cursor_settings)
         self.cursor_button = QPushButton(
             language_wrapper.language_word_dict.get("cursor_effect_start", "Turn cursor effects on"))
+        retranslator.bind(self.cursor_button, "cursor_effect_start", "Turn cursor effects on")
         self.cursor_button.clicked.connect(self.toggle_cursor_effects)
 
         # Keystroke display
         self.keystroke_label = QLabel(
             language_wrapper.language_word_dict.get("keystroke_label", "Keystroke display"))
+        retranslator.bind(self.keystroke_label, "keystroke_label", "Keystroke display")
         self.keystroke_button = QPushButton(
             language_wrapper.language_word_dict.get("keystroke_start", "Show keystrokes"))
+        retranslator.bind(self.keystroke_button, "keystroke_start", "Show keystrokes")
         self.keystroke_button.clicked.connect(self.toggle_keystrokes)
 
         # Magnifier
         self.magnifier_label = QLabel(
             language_wrapper.language_word_dict.get("magnifier_label", "Magnifier"))
+        retranslator.bind(self.magnifier_label, "magnifier_label", "Magnifier")
         self.magnifier_zoom_combobox = QComboBox()
         self.magnifier_zoom_combobox.addItems(["1.5", "2.0", "3.0", "4.0", "6.0"])
         self.magnifier_zoom_combobox.setCurrentText("2.0")
         self.magnifier_zoom_combobox.currentIndexChanged.connect(self._apply_magnifier_settings)
         self.magnifier_button = QPushButton(
             language_wrapper.language_word_dict.get("magnifier_start", "Turn magnifier on"))
+        retranslator.bind(self.magnifier_button, "magnifier_start", "Turn magnifier on")
         self.magnifier_button.clicked.connect(self.toggle_magnifier)
 
         # Shared
         self.whiteboard_button = QPushButton(
             language_wrapper.language_word_dict.get("whiteboard_start", "Whiteboard"))
+        retranslator.bind(self.whiteboard_button, "whiteboard_start", "Whiteboard")
         self.whiteboard_button.clicked.connect(self.toggle_whiteboard)
         self.whiteboard_save_button = QPushButton(
             language_wrapper.language_word_dict.get("whiteboard_save", "Save whiteboard"))
+        retranslator.bind(self.whiteboard_save_button, "whiteboard_save", "Save whiteboard")
         self.whiteboard_save_button.clicked.connect(self.save_whiteboard)
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
         self.hint_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "presentation_hint",
                 "Drawing takes the mouse while it is on; the other overlays pass clicks through."))
+        retranslator.bind(self.hint_label, "presentation_hint", "Drawing takes the mouse while it is on; the other overlays pass clicks through.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/scene_setting/scene_manager.py
+++ b/frontengine/ui/page/scene_setting/scene_manager.py
@@ -9,6 +9,7 @@ from frontengine.ui.page.utils import create_monitor_selection_dialog
 from frontengine.user_setting.scene_setting import choose_scene_json, write_scene_file, scene_json
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class SceneManagerUI(QWidget):
@@ -23,9 +24,11 @@ class SceneManagerUI(QWidget):
 
         # Read and write scene json button
         self.read_scene_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_input"))
+        retranslator.bind(self.read_scene_json_button, "scene_input", "")
         self.read_scene_json_button.clicked.connect(self.update_scene_json)
 
         self.write_scene_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_output"))
+        retranslator.bind(self.write_scene_json_button, "scene_output", "")
         self.write_scene_json_button.clicked.connect(lambda: write_scene_file(self))
 
         # Json plaintext
@@ -35,14 +38,17 @@ class SceneManagerUI(QWidget):
 
         # Start button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("scene_start"))
+        retranslator.bind(self.start_button, "scene_start", "")
         self.start_button.clicked.connect(self.start_scene)
 
         # Show on all screen
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Clear json button
         self.clear_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_script_clear"))
+        retranslator.bind(self.clear_json_button, "scene_script_clear", "")
         self.clear_json_button.clicked.connect(self.clear_json)
 
         # Layout

--- a/frontengine/ui/page/scene_setting/scene_page/base_scene_page.py
+++ b/frontengine/ui/page/scene_setting/scene_page/base_scene_page.py
@@ -7,6 +7,7 @@ from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.user_setting.scene_setting import scene_json
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 
 class BaseSceneSettingUI(QWidget):
@@ -30,7 +31,8 @@ class BaseSceneSettingUI(QWidget):
         maximum: int,
         default: int,
     ) -> Tuple[QLabel, QLabel, QSlider]:
-        label = QLabel(language_wrapper.language_word_dict.get(label_key))
+        label = QLabel(translate(label_key))
+        retranslator.bind(label, label_key)
         slider = QSlider(Qt.Orientation.Horizontal)
         slider.setRange(minimum, maximum)
         slider.setValue(default)
@@ -39,7 +41,9 @@ class BaseSceneSettingUI(QWidget):
         return label, value_label, slider
 
     def _make_ready_label(self) -> QLabel:
-        return QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        label = QLabel(translate("Not Ready"))
+        retranslator.bind(label, "Not Ready")
+        return label
 
     def _wire_chooser(
         self,
@@ -54,11 +58,14 @@ class BaseSceneSettingUI(QWidget):
         label to "Ready".
         """
         def handler() -> None:
-            ready_label.setText(language_wrapper.language_word_dict.get("Not Ready"))
+            # set_text 而不是 setText：換語言時要跟著目前是就緒還是未就緒
+            # set_text, not setText, so a language change follows whichever
+            # state the label is actually in.
+            retranslator.set_text(ready_label, "Not Ready")
             on_reset()
             path = chooser(self)
             if path:
-                ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+                retranslator.set_text(ready_label, "Ready")
                 on_chosen(path)
         return handler
 

--- a/frontengine/ui/page/scene_setting/scene_page/gif.py
+++ b/frontengine/ui/page/scene_setting/scene_page/gif.py
@@ -6,6 +6,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_gif
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class GIFSceneSettingUI(BaseSceneSettingUI):
@@ -17,6 +18,7 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
         speed_label, self.speed_value, self.speed_slider = self._build_slider("Speed", 1, 200, 100)
 
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_choose_file"))
+        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file", "")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -28,6 +30,7 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
         )
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_gif"))
+        retranslator.bind(self.update_scene_button, "scene_add_gif", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/image.py
+++ b/frontengine/ui/page/scene_setting/scene_page/image.py
@@ -6,6 +6,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_image
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class ImageSceneSettingUI(BaseSceneSettingUI):
@@ -16,6 +17,7 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -27,6 +29,7 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
         )
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_image"))
+        retranslator.bind(self.update_scene_button, "scene_add_image", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/sound.py
+++ b/frontengine/ui/page/scene_setting/scene_page/sound.py
@@ -6,6 +6,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_player_sound
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class SoundSceneSettingUI(BaseSceneSettingUI):
@@ -18,6 +19,7 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
         self.choose_player_file_button = QPushButton(
             language_wrapper.language_word_dict.get("sound_player_setting_choose_sound_file")
         )
+        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file", "")
         self.player_ready_label = self._make_ready_label()
         self.choose_player_file_button.clicked.connect(
             self._wire_chooser(
@@ -29,6 +31,7 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
         )
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_sound"))
+        retranslator.bind(self.update_scene_button, "scene_add_sound", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(volume_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/text.py
+++ b/frontengine/ui/page/scene_setting/scene_page/text.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class TextSceneSettingUI(BaseSceneSettingUI):
@@ -15,10 +16,12 @@ class TextSceneSettingUI(BaseSceneSettingUI):
         self.line_edit = QLineEdit()
 
         self.text_position_label = QLabel(language_wrapper.language_word_dict.get("text_setting_choose_alignment"))
+        retranslator.bind(self.text_position_label, "text_setting_choose_alignment", "")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_text"))
+        retranslator.bind(self.update_scene_button, "scene_add_text", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/video.py
+++ b/frontengine/ui/page/scene_setting/scene_page/video.py
@@ -6,6 +6,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_video
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class VideoSceneSettingUI(BaseSceneSettingUI):
@@ -18,6 +19,7 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
         volume_label, self.volume_value, self.volume_slider = self._build_slider("Volume", 1, 100, 100)
 
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_choose_file"))
+        retranslator.bind(self.choose_file_button, "video_setting_choose_file", "")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -29,6 +31,7 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
         )
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_video"))
+        retranslator.bind(self.update_scene_button, "scene_add_video", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/web.py
+++ b/frontengine/ui/page/scene_setting/scene_page/web.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QLabel, QLineEdit, QPushButton
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class WebSceneSettingUI(BaseSceneSettingUI):
@@ -12,9 +13,11 @@ class WebSceneSettingUI(BaseSceneSettingUI):
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
         self.url_label = QLabel(language_wrapper.language_word_dict.get("scene_url_label"))
+        retranslator.bind(self.url_label, "scene_url_label", "")
         self.web_url_input = QLineEdit()
 
         self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_web"))
+        retranslator.bind(self.update_scene_button, "scene_add_web", "")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -26,6 +26,7 @@ from frontengine.utils.color_vision.color_vision import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class ScreenCareSettingUI(QWidget):
@@ -48,6 +49,7 @@ class ScreenCareSettingUI(QWidget):
         # Colour filter
         self.filter_label = QLabel(
             language_wrapper.language_word_dict.get("screen_filter_label", "Screen filter"))
+        retranslator.bind(self.filter_label, "screen_filter_label", "Screen filter")
         self.filter_color_combobox = QComboBox()
         for name, hex_value in FILTER_COLORS:
             self.filter_color_combobox.addItem(
@@ -55,6 +57,7 @@ class ScreenCareSettingUI(QWidget):
                 hex_value)
         self.filter_strength_label = QLabel(
             language_wrapper.language_word_dict.get("screen_filter_strength", "Strength"))
+        retranslator.bind(self.filter_strength_label, "screen_filter_strength", "Strength")
         self.filter_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.filter_strength_slider.setRange(1, 80)
         self.filter_strength_slider.setValue(15)
@@ -62,11 +65,13 @@ class ScreenCareSettingUI(QWidget):
         self.filter_color_combobox.currentIndexChanged.connect(self._apply_filter_settings)
         self.filter_button = QPushButton(
             language_wrapper.language_word_dict.get("screen_filter_start", "Turn filter on"))
+        retranslator.bind(self.filter_button, "screen_filter_start", "Turn filter on")
         self.filter_button.clicked.connect(self.toggle_filter)
 
         # Reading ruler
         self.ruler_label = QLabel(
             language_wrapper.language_word_dict.get("reading_ruler_label", "Reading ruler"))
+        retranslator.bind(self.ruler_label, "reading_ruler_label", "Reading ruler")
         self.ruler_band_combobox = QComboBox()
         self.ruler_band_combobox.addItems(["60", "90", "120", "160", "220"])
         self.ruler_band_combobox.setCurrentText("90")
@@ -77,6 +82,7 @@ class ScreenCareSettingUI(QWidget):
         self.ruler_strength_slider.valueChanged.connect(self._apply_ruler_settings)
         self.ruler_button = QPushButton(
             language_wrapper.language_word_dict.get("reading_ruler_start", "Turn ruler on"))
+        retranslator.bind(self.ruler_button, "reading_ruler_start", "Turn ruler on")
         self.ruler_button.clicked.connect(self.toggle_ruler)
 
         # Break reminder (20-20-20)
@@ -85,6 +91,7 @@ class ScreenCareSettingUI(QWidget):
         self.break_timer.timeout.connect(self._tick_break_reminder)
         self.break_label = QLabel(
             language_wrapper.language_word_dict.get("break_reminder_label", "Eye breaks (min / sec)"))
+        retranslator.bind(self.break_label, "break_reminder_label", "Eye breaks (min / sec)")
         self.break_minutes_combobox = QComboBox()
         self.break_minutes_combobox.addItems(["10", "20", "30", "45", "60"])
         self.break_minutes_combobox.setCurrentText("20")
@@ -93,16 +100,19 @@ class ScreenCareSettingUI(QWidget):
         self.break_seconds_combobox.setCurrentText("20")
         self.break_button = QPushButton(
             language_wrapper.language_word_dict.get("break_reminder_start", "Start eye breaks"))
+        retranslator.bind(self.break_button, "break_reminder_start", "Start eye breaks")
         self.break_button.clicked.connect(self.toggle_break_reminder)
 
         # Shared
         self.all_screens_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("Show on all screen", "Show on all screen"))
+        retranslator.bind(self.all_screens_checkbox, "Show on all screen", "Show on all screen")
         # 色覺模擬：把整個畫面換成某種色盲看到的樣子（不透明覆蓋層）
         # Colour-vision simulation: repaint the screen as a given deficiency
         # sees it, using an opaque overlay.
         self.color_vision_label = QLabel(
             language_wrapper.language_word_dict.get("color_vision_label", "Colour vision"))
+        retranslator.bind(self.color_vision_label, "color_vision_label", "Colour vision")
         self.color_vision_combobox = QComboBox()
         for kind, key, fallback in (
                 (KIND_PROTANOPIA, "color_vision_protanopia", "Protanopia (red)"),
@@ -118,15 +128,18 @@ class ScreenCareSettingUI(QWidget):
         self.color_vision_slider.valueChanged.connect(self._apply_color_vision_settings)
         self.color_vision_button = QPushButton(
             language_wrapper.language_word_dict.get("color_vision_start", "Simulate"))
+        retranslator.bind(self.color_vision_button, "color_vision_start", "Simulate")
         self.color_vision_button.clicked.connect(self.toggle_color_vision)
 
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
         self.hint_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "screen_care_hint",
                 "These overlays pass clicks through, so everything underneath keeps working."))
+        retranslator.bind(self.hint_label, "screen_care_hint", "These overlays pass clicks through, so everything underneath keeps working.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/sound_player/sound_player_setting_ui.py
+++ b/frontengine/ui/page/sound_player/sound_player_setting_ui.py
@@ -9,6 +9,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_player_sound, choose
 from frontengine.ui.page.utils import coerce_int
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 
 # 四處共用的語系鍵
@@ -31,6 +32,7 @@ class SoundPlayerSettingUI(QWidget):
 
         # Volume setting
         self.volume_label = QLabel(language_wrapper.language_word_dict.get("Volume"))
+        retranslator.bind(self.volume_label, "Volume", "")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -40,21 +42,27 @@ class SoundPlayerSettingUI(QWidget):
         # Choose WAV file
         self.choose_wav_file_button = QPushButton(
             language_wrapper.language_word_dict.get("sound_player_setting_choose_wav_file"))
+        retranslator.bind(self.choose_wav_file_button, "sound_player_setting_choose_wav_file", "")
         self.choose_wav_file_button.clicked.connect(self.choose_and_copy_wav_file_to_cwd_sound_dir_then_play)
-        self.wav_ready_label = QLabel(language_wrapper.language_word_dict.get(_NOT_READY))
+        self.wav_ready_label = QLabel(translate(_NOT_READY))
+        retranslator.bind(self.wav_ready_label, _NOT_READY)
 
         # Choose general sound file
         self.choose_player_file_button = QPushButton(
             language_wrapper.language_word_dict.get("sound_player_setting_choose_sound_file"))
+        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file", "")
         self.choose_player_file_button.clicked.connect(self.choose_and_copy_sound_file_to_cwd_sound_dir_then_play)
-        self.player_ready_label = QLabel(language_wrapper.language_word_dict.get(_NOT_READY))
+        self.player_ready_label = QLabel(translate(_NOT_READY))
+        retranslator.bind(self.player_ready_label, _NOT_READY)
 
         # Start buttons
         self.start_wav_button = QPushButton(language_wrapper.language_word_dict.get("sound_player_setting_play_wav"))
+        retranslator.bind(self.start_wav_button, "sound_player_setting_play_wav", "")
         self.start_wav_button.clicked.connect(self.start_play_wav)
 
         self.start_player_button = QPushButton(
             language_wrapper.language_word_dict.get("sound_player_setting_play_sound"))
+        retranslator.bind(self.start_player_button, "sound_player_setting_play_sound", "")
         self.start_player_button.clicked.connect(self.start_play_sound)
 
         # Layout
@@ -96,20 +104,20 @@ class SoundPlayerSettingUI(QWidget):
 
     def choose_and_copy_wav_file_to_cwd_sound_dir_then_play(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] choose_and_copy_wav_file_to_cwd_sound_dir_then_play")
-        self.wav_ready_label.setText(language_wrapper.language_word_dict.get(_NOT_READY))
+        retranslator.set_text(self.wav_ready_label, _NOT_READY)
         self.ready_to_play = False
         self.wav_sound_path = choose_wav_sound(self)
         if self.wav_sound_path:
-            self.wav_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+            retranslator.set_text(self.wav_ready_label, "Ready")
             self.ready_to_play = True
 
     def choose_and_copy_sound_file_to_cwd_sound_dir_then_play(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] choose_and_copy_sound_file_to_cwd_sound_dir_then_play")
-        self.player_ready_label.setText(language_wrapper.language_word_dict.get(_NOT_READY))
+        retranslator.set_text(self.player_ready_label, _NOT_READY)
         self.ready_to_play = False
         self.player_sound_path = choose_player_sound(self)
         if self.player_sound_path:
-            self.player_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+            retranslator.set_text(self.player_ready_label, "Ready")
             self.ready_to_play = True
 
     def volume_trick(self) -> None:
@@ -130,7 +138,7 @@ class SoundPlayerSettingUI(QWidget):
         if state.get("wav_sound_path"):
             self.wav_sound_path = state["wav_sound_path"]
             self.ready_to_play = True
-            self.wav_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+            retranslator.set_text(self.wav_ready_label, "Ready")
         if state.get("player_sound_path"):
             self.player_sound_path = state["player_sound_path"]
-            self.player_ready_label.setText(language_wrapper.language_word_dict.get("Ready"))
+            retranslator.set_text(self.player_ready_label, "Ready")

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -15,6 +15,7 @@ from frontengine.ui.page.utils import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.system_stats.system_stats import system_stats
 from frontengine.utils.text_source.text_source import (
     DEFAULT_TEMPLATES, SOURCE_CLOCK, SOURCE_COUNTDOWN, SOURCE_DATE, SOURCE_STATIC,
@@ -43,6 +44,7 @@ class TextSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -51,6 +53,7 @@ class TextSettingUI(QWidget):
 
         # Font size setting
         self.font_size_label = QLabel(language_wrapper.language_word_dict.get("Font size"))
+        retranslator.bind(self.font_size_label, "Font size", "")
         self.font_size_slider = QSlider(Qt.Orientation.Horizontal)
         self.font_size_slider.setRange(1, 600)
         self.font_size_slider.setValue(100)
@@ -62,39 +65,48 @@ class TextSettingUI(QWidget):
 
         # Start Button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("text_setting_start_draw"))
+        retranslator.bind(self.start_button, "text_setting_start_draw", "")
         self.start_button.clicked.connect(self.start_draw_text_on_screen)
 
         # Show on all screen
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
 
         # Text position
         self.text_position_label = QLabel(language_wrapper.language_word_dict.get("text_setting_choose_alignment"))
+        retranslator.bind(self.text_position_label, "text_setting_choose_alignment", "")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
         # Text color
         self.text_color_label = QLabel(language_wrapper.language_word_dict.get("text_color_label", "Color"))
+        retranslator.bind(self.text_color_label, "text_color_label", "Color")
         self.text_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.text_color_combobox.addItem(name, hex_value)
 
         # Font family
         self.font_family_label = QLabel(language_wrapper.language_word_dict.get("font_family_label", "Font"))
+        retranslator.bind(self.font_family_label, "font_family_label", "Font")
         self.font_family_combobox = QFontComboBox()
 
         # Marquee scroll
         self.marquee_checkbox = QCheckBox(language_wrapper.language_word_dict.get("marquee_label", "Marquee"))
+        retranslator.bind(self.marquee_checkbox, "marquee_label", "Marquee")
         self.marquee_speed_label = QLabel(language_wrapper.language_word_dict.get("marquee_speed_label", "Speed"))
+        retranslator.bind(self.marquee_speed_label, "marquee_speed_label", "Speed")
         self.marquee_speed_combobox = QComboBox()
         self.marquee_speed_combobox.addItems(["2", "4", "6", "8", "12"])
         self.marquee_speed_combobox.setCurrentText("4")
 
         # Outline (readability on any background)
         self.outline_checkbox = QCheckBox(language_wrapper.language_word_dict.get("outline_label", "Outline"))
+        retranslator.bind(self.outline_checkbox, "outline_label", "Outline")
         self.outline_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.outline_color_combobox.addItem(name, hex_value)
@@ -104,12 +116,14 @@ class TextSettingUI(QWidget):
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # 文字來源：靜態字串或時鐘／日期／倒數／碼表／系統資訊／天氣
         # Text source: a fixed string, or a clock/date/countdown/stopwatch/stats/weather feed.
         self.text_source_label = QLabel(
             language_wrapper.language_word_dict.get("text_source_label", "Text source"))
+        retranslator.bind(self.text_source_label, "text_source_label", "Text source")
         self.text_source_combobox = QComboBox()
         for kind, fallback in (
             (SOURCE_STATIC, "Static text"), (SOURCE_CLOCK, "Clock"), (SOURCE_DATE, "Date"),
@@ -120,11 +134,15 @@ class TextSettingUI(QWidget):
                 language_wrapper.language_word_dict.get(f"text_source_{kind}", fallback), kind)
         self.text_source_combobox.currentIndexChanged.connect(self._update_source_hint)
         self.text_source_hint_label = QLabel("")
+        # 這句是「提示 + 樣板」組出來的，不是單一個鍵，換語言時整段重算
+        # Composed from a hint plus a template, so recompute it wholesale.
+        retranslator.bind_call(self._update_source_hint)
         self.text_source_hint_label.setWordWrap(True)
 
         # 天氣地點（只有天氣來源會用到）/ Weather location (only used by the weather source)
         self.weather_location_label = QLabel(
             language_wrapper.language_word_dict.get("weather_location_label", "Weather city"))
+        retranslator.bind(self.weather_location_label, "weather_location_label", "Weather city")
         self.weather_location_edit = QLineEdit()
         self.weather_location_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get("weather_location_hint", "e.g. Taipei"))

--- a/frontengine/ui/page/tools/tools_setting_ui.py
+++ b/frontengine/ui/page/tools/tools_setting_ui.py
@@ -221,11 +221,11 @@ class ToolsSettingUI(QWidget):
         self.virtual_camera_button = QPushButton(_t("tools_vcam_start", "Send an area"))
         retranslator.bind(self.virtual_camera_button, "tools_vcam_start", "Send an area")
         self.virtual_camera_button.clicked.connect(self.toggle_virtual_camera)
-        self.virtual_camera_status = QLabel(
-            _t("tools_vcam_ready", "Ready") if virtual_camera.available()
-            else _t("tools_vcam_missing", "Install pyvirtualcam and a virtual camera driver"))
-        retranslator.bind(self.virtual_camera_status, "tools_vcam_ready", "Ready") if virtual_camera.available() else _t("tools_vcam_missing", "Install pyvirtualcam and a virtual camera driver")
-        retranslator.bind(self.virtual_camera_status, "tools_vcam_ready", "Ready")
+        status_key, status_fallback = (
+            ("tools_vcam_ready", "Ready") if virtual_camera.available()
+            else ("tools_vcam_missing", "Install pyvirtualcam and a virtual camera driver"))
+        self.virtual_camera_status = QLabel(_t(status_key, status_fallback))
+        retranslator.bind(self.virtual_camera_status, status_key, status_fallback)
         self.virtual_camera_status.setWordWrap(True)
         self.virtual_camera_button.setEnabled(virtual_camera.available())
 

--- a/frontengine/ui/page/tools/tools_setting_ui.py
+++ b/frontengine/ui/page/tools/tools_setting_ui.py
@@ -33,6 +33,7 @@ from frontengine.utils.measure.measure import (
     FORMAT_CSS_VAR, FORMAT_HEX, FORMAT_HSL, FORMAT_RGB,
 )
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.screen_text.screen_text_service import (
     ACTION_ASK, ACTION_EXTRACT, ACTION_TRANSLATE, DEFAULT_LANGUAGE, ScreenTextService,
 )
@@ -87,17 +88,21 @@ class ToolsSettingUI(QWidget):
         self._build_virtual_camera_row()
         self._build_camera_row()
         self.pin_button = QPushButton(_t("tools_pin_window", "Pin a window..."))
+        retranslator.bind(self.pin_button, "tools_pin_window", "Pin a window...")
         self.pin_button.clicked.connect(self.open_pin_dialog)
 
         # 視窗版面：記下每個視窗的位置，之後一鍵擺回去
         # Window layouts: remember where the windows are and put them back later.
         self.layout_label = QLabel(_t("tools_layout_label", "Window layout"))
+        retranslator.bind(self.layout_label, "tools_layout_label", "Window layout")
         self.layout_name_edit = QLineEdit()
         self.layout_name_edit.setPlaceholderText(_t("tools_layout_name", "Layout name"))
         self.layout_save_button = QPushButton(_t("tools_layout_save", "Save layout"))
+        retranslator.bind(self.layout_save_button, "tools_layout_save", "Save layout")
         self.layout_save_button.clicked.connect(self.save_layout)
         self.layout_combobox = QComboBox()
         self.layout_restore_button = QPushButton(_t("tools_layout_restore", "Restore"))
+        retranslator.bind(self.layout_restore_button, "tools_layout_restore", "Restore")
         self.layout_restore_button.clicked.connect(self.restore_selected_layout)
         for button in (self.layout_save_button, self.layout_restore_button):
             button.setEnabled(window_pin.available())
@@ -106,6 +111,7 @@ class ToolsSettingUI(QWidget):
             _t("tools_hint",
                "Click to measure; right-click clears. What you measure is copied to the "
                "clipboard. The camera is shown locally only - nothing is recorded."))
+        retranslator.bind(self.hint_label, "tools_hint", "Click to measure; right-click clears. What you measure is copied to the " "clipboard. The camera is shown locally only - nothing is recorded.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.measure_label, 0, 0)
@@ -147,6 +153,7 @@ class ToolsSettingUI(QWidget):
     # --- construction helpers -------------------------------------------
     def _build_measure_row(self) -> None:
         self.measure_label = QLabel(_t("tools_measure_label", "Measure"))
+        retranslator.bind(self.measure_label, "tools_measure_label", "Measure")
         self.measure_mode_combobox = QComboBox()
         for mode, key, fallback in ((MODE_COLOR, "tools_measure_color", "Colour picker"),
                                     (MODE_RULER, "tools_measure_ruler", "Pixel ruler"),
@@ -154,23 +161,29 @@ class ToolsSettingUI(QWidget):
             self.measure_mode_combobox.addItem(_t(key, fallback), mode)
         self.measure_mode_combobox.currentIndexChanged.connect(self._apply_measure_settings)
         self.color_format_label = QLabel(_t("tools_color_format", "Copy colour as"))
+        retranslator.bind(self.color_format_label, "tools_color_format", "Copy colour as")
         self.color_format_combobox = QComboBox()
         for value, label in ((FORMAT_HEX, "#rrggbb"), (FORMAT_RGB, "rgb(r, g, b)"),
                              (FORMAT_HSL, "hsl(h, s%, l%)"), (FORMAT_CSS_VAR, "--color: ...;")):
             self.color_format_combobox.addItem(label, value)
         self.color_format_combobox.currentIndexChanged.connect(self._apply_measure_settings)
         self.measure_button = QPushButton(_t("tools_measure_start", "Start measuring"))
+        retranslator.bind(self.measure_button, "tools_measure_start", "Start measuring")
         self.measure_button.clicked.connect(self.toggle_measure)
 
     def _build_capture_row(self) -> None:
         self.capture_label = QLabel(_t("tools_capture_label", "Region capture"))
+        retranslator.bind(self.capture_label, "tools_capture_label", "Region capture")
         self.capture_button = QPushButton(_t("tools_capture_start", "Capture area"))
+        retranslator.bind(self.capture_button, "tools_capture_start", "Capture area")
         self.capture_button.clicked.connect(self.start_capture)
         self.capture_copy_button = QPushButton(_t("tools_capture_copy", "Copy last"))
+        retranslator.bind(self.capture_copy_button, "tools_capture_copy", "Copy last")
         self.capture_copy_button.clicked.connect(self.copy_last_capture)
 
     def _build_screen_text_row(self) -> None:
         self.screen_text_label = QLabel(_t("tools_screen_text_label", "Read text"))
+        retranslator.bind(self.screen_text_label, "tools_screen_text_label", "Read text")
         self.screen_text_combobox = QComboBox()
         for action, key, fallback in ((ACTION_EXTRACT, "tools_screen_text_extract", "Copy text"),
                                       (ACTION_TRANSLATE, "tools_screen_text_translate", "Translate"),
@@ -181,10 +194,12 @@ class ToolsSettingUI(QWidget):
             _t("tools_screen_text_input", "Language, or your question"))
         self.screen_text_input.setText(DEFAULT_LANGUAGE)
         self.screen_text_button = QPushButton(_t("tools_screen_text_start", "Read an area"))
+        retranslator.bind(self.screen_text_button, "tools_screen_text_start", "Read an area")
         self.screen_text_button.clicked.connect(self.start_screen_text)
 
     def _build_record_row(self) -> None:
         self.record_label = QLabel(_t("tools_record_label", _RECORD_AREA))
+        retranslator.bind(self.record_label, "tools_record_label", _RECORD_AREA)
         self.record_fps_spinbox = QSpinBox()
         self.record_fps_spinbox.setRange(MIN_FPS, MAX_FPS)
         self.record_fps_spinbox.setValue(DEFAULT_FPS)
@@ -192,24 +207,31 @@ class ToolsSettingUI(QWidget):
         self.record_seconds_spinbox.setRange(1, 120)
         self.record_seconds_spinbox.setValue(DEFAULT_MAX_SECONDS)
         self.record_camera_checkbox = QCheckBox(_t("tools_record_camera", "Include camera"))
+        retranslator.bind(self.record_camera_checkbox, "tools_record_camera", "Include camera")
         self.record_button = QPushButton(_t("tools_record_start", _RECORD_AN_AREA))
+        retranslator.bind(self.record_button, "tools_record_start", _RECORD_AN_AREA)
         self.record_button.clicked.connect(self.toggle_recording)
 
     def _build_virtual_camera_row(self) -> None:
         self.virtual_camera_label = QLabel(_t("tools_vcam_label", "Virtual camera"))
+        retranslator.bind(self.virtual_camera_label, "tools_vcam_label", "Virtual camera")
         self.virtual_camera_fps_spinbox = QSpinBox()
         self.virtual_camera_fps_spinbox.setRange(MIN_VCAM_FPS, MAX_VCAM_FPS)
         self.virtual_camera_fps_spinbox.setValue(DEFAULT_VCAM_FPS)
         self.virtual_camera_button = QPushButton(_t("tools_vcam_start", "Send an area"))
+        retranslator.bind(self.virtual_camera_button, "tools_vcam_start", "Send an area")
         self.virtual_camera_button.clicked.connect(self.toggle_virtual_camera)
         self.virtual_camera_status = QLabel(
             _t("tools_vcam_ready", "Ready") if virtual_camera.available()
             else _t("tools_vcam_missing", "Install pyvirtualcam and a virtual camera driver"))
+        retranslator.bind(self.virtual_camera_status, "tools_vcam_ready", "Ready") if virtual_camera.available() else _t("tools_vcam_missing", "Install pyvirtualcam and a virtual camera driver")
+        retranslator.bind(self.virtual_camera_status, "tools_vcam_ready", "Ready")
         self.virtual_camera_status.setWordWrap(True)
         self.virtual_camera_button.setEnabled(virtual_camera.available())
 
     def _build_camera_row(self) -> None:
         self.camera_label = QLabel(_t("tools_camera_label", "Camera"))
+        retranslator.bind(self.camera_label, "tools_camera_label", "Camera")
         self.camera_shape_combobox = QComboBox()
         for shape, key, fallback in ((SHAPE_CIRCLE, "tools_camera_circle", "Circle"),
                                      (SHAPE_ROUNDED, "tools_camera_rounded", "Rounded"),
@@ -219,14 +241,17 @@ class ToolsSettingUI(QWidget):
         self.camera_device_combobox = QComboBox()
         self.reload_cameras()
         self.camera_mirror_checkbox = QCheckBox(_t("tools_camera_mirror", "Mirror"))
+        retranslator.bind(self.camera_mirror_checkbox, "tools_camera_mirror", "Mirror")
         self.camera_mirror_checkbox.setChecked(True)
         self.camera_mirror_checkbox.toggled.connect(self._apply_camera_settings)
         self.camera_border_label = QLabel(_t("tools_camera_border", "Border"))
+        retranslator.bind(self.camera_border_label, "tools_camera_border", "Border")
         self.camera_border_spinbox = QSpinBox()
         self.camera_border_spinbox.setRange(0, 20)
         self.camera_border_spinbox.setValue(4)
         self.camera_border_spinbox.valueChanged.connect(self._apply_camera_settings)
         self.camera_button = QPushButton(_t("tools_camera_start", "Show camera"))
+        retranslator.bind(self.camera_button, "tools_camera_start", "Show camera")
         self.camera_button.clicked.connect(self.toggle_camera)
 
     # --- measuring -------------------------------------------------------

--- a/frontengine/ui/page/video/video_setting_ui.py
+++ b/frontengine/ui/page/video/video_setting_ui.py
@@ -19,6 +19,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 
 
 class VideoSettingUI(QWidget):
@@ -36,6 +37,7 @@ class VideoSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -44,6 +46,7 @@ class VideoSettingUI(QWidget):
 
         # Play rate setting
         self.play_rate_label = QLabel(language_wrapper.language_word_dict.get("Play rate"))
+        retranslator.bind(self.play_rate_label, "Play rate", "")
         self.play_rate_slider = QSlider(Qt.Orientation.Horizontal)
         self.play_rate_slider.setRange(1, 200)
         self.play_rate_slider.setValue(100)
@@ -52,6 +55,7 @@ class VideoSettingUI(QWidget):
 
         # Volume setting
         self.volume_label = QLabel(language_wrapper.language_word_dict.get("Volume"))
+        retranslator.bind(self.volume_label, "Volume", "")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -60,34 +64,42 @@ class VideoSettingUI(QWidget):
 
         # Ready label
         self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
+        retranslator.bind(self.ready_label, "Not Ready", "")
 
         # Choose file button
         self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_choose_file"))
+        retranslator.bind(self.choose_file_button, "video_setting_choose_file", "")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_video_dir_then_play)
 
         # Start button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_start_play"))
+        retranslator.bind(self.start_button, "video_setting_start_play", "")
         self.start_button.clicked.connect(self.start_play_video)
 
         # Expand
         self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
         self.fullscreen_checkbox.setChecked(True)
 
         # Show on all screen
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
 
         # Target monitor selector
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
         self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
+        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("video")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
+++ b/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
@@ -23,6 +23,7 @@ from frontengine.ui.page.utils import (
 from frontengine.utils.audio_meter.screen_audio import audio_level_provider_for_screen
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 # 多處共用的英文備援字串（只有在翻譯缺漏時才會看到）
 # The English fallback shared by several call sites, seen only when a
 # translation is missing.
@@ -58,6 +59,7 @@ class WallpaperSettingUI(QWidget):
         # Monitor picker (per-monitor folders)
         self.monitor_label = QLabel(
             language_wrapper.language_word_dict.get("wallpaper_monitor_label", "Monitor"))
+        retranslator.bind(self.monitor_label, "wallpaper_monitor_label", "Monitor")
         self.monitor_combobox = QComboBox()
         for index, screen in enumerate(QGuiApplication.screens()):
             self.monitor_combobox.addItem(f"{index}: {screen.name()}", index)
@@ -66,14 +68,17 @@ class WallpaperSettingUI(QWidget):
         self.monitor_combobox.currentIndexChanged.connect(self._show_folder_for_monitor)
         self.folder_button = QPushButton(
             language_wrapper.language_word_dict.get("wallpaper_choose_folder", "Choose folder..."))
+        retranslator.bind(self.folder_button, "wallpaper_choose_folder", "Choose folder...")
         self.folder_button.clicked.connect(self.choose_folder)
         self.folder_label = QLabel(
             language_wrapper.language_word_dict.get("wallpaper_no_folder", _NO_FOLDER))
+        retranslator.bind(self.folder_label, "wallpaper_no_folder", _NO_FOLDER)
         self.folder_label.setWordWrap(True)
 
         # Playlist options
         self.interval_label = QLabel(
             language_wrapper.language_word_dict.get("wallpaper_interval_label", "Change every"))
+        retranslator.bind(self.interval_label, "wallpaper_interval_label", "Change every")
         self.interval_combobox = QComboBox()
         for label, seconds in (("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900), ("1h", 3600)):
             self.interval_combobox.addItem(label, seconds)
@@ -81,12 +86,15 @@ class WallpaperSettingUI(QWidget):
         self.interval_combobox.currentIndexChanged.connect(self._apply_interval)
         self.shuffle_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("wallpaper_shuffle", "Shuffle"))
+        retranslator.bind(self.shuffle_checkbox, "wallpaper_shuffle", "Shuffle")
         self.recursive_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("wallpaper_recursive", "Include subfolders"))
+        retranslator.bind(self.recursive_checkbox, "wallpaper_recursive", "Include subfolders")
 
         # Audio reaction
         self.react_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("wallpaper_audio_react", "React to audio"))
+        retranslator.bind(self.react_checkbox, "wallpaper_audio_react", "React to audio")
         self.react_checkbox.toggled.connect(self._apply_audio_react)
         self.react_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.react_strength_slider.setRange(0, 100)
@@ -99,6 +107,7 @@ class WallpaperSettingUI(QWidget):
         self.quiet_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "wallpaper_quiet_label", "Quiet hours"))
+        retranslator.bind(self.quiet_label, "wallpaper_quiet_label", "Quiet hours")
         self.quiet_start_spinbox = QSpinBox()
         self.quiet_start_spinbox.setRange(0, 23)
         self.quiet_start_spinbox.setValue(9)
@@ -108,22 +117,27 @@ class WallpaperSettingUI(QWidget):
         self.quiet_folder_button = QPushButton(
             language_wrapper.language_word_dict.get(
                 "wallpaper_quiet_folder", "Quiet folder..."))
+        retranslator.bind(self.quiet_folder_button, "wallpaper_quiet_folder", "Quiet folder...")
         self.quiet_folder_button.clicked.connect(self.choose_quiet_folder)
         self.quiet_folder_label = QLabel(
             language_wrapper.language_word_dict.get("wallpaper_no_folder", _NO_FOLDER))
+        retranslator.bind(self.quiet_folder_label, "wallpaper_no_folder", _NO_FOLDER)
         self.quiet_folder_label.setWordWrap(True)
 
         # Start / stop
         self.start_button = QPushButton(
             language_wrapper.language_word_dict.get("wallpaper_start", "Start wallpaper"))
+        retranslator.bind(self.start_button, "wallpaper_start", "Start wallpaper")
         self.start_button.clicked.connect(self.toggle_wallpaper)
         self.next_button = QPushButton(
             language_wrapper.language_word_dict.get("wallpaper_next", "Next wallpaper"))
+        retranslator.bind(self.next_button, "wallpaper_next", "Next wallpaper")
         self.next_button.clicked.connect(self.advance_all)
         self.hint_label = QLabel(
             language_wrapper.language_word_dict.get(
                 "wallpaper_hint",
                 "Wallpapers sit beneath every window. Each monitor can use its own folder."))
+        retranslator.bind(self.hint_label, "wallpaper_hint", "Wallpapers sit beneath every window. Each monitor can use its own folder.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -15,6 +15,7 @@ from frontengine.ui.page.utils import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.web_url import next_page_index, normalize_web_url, parse_dashboard_urls
 
 
@@ -37,6 +38,7 @@ class WEBSettingUI(QWidget):
 
         # Opacity setting
         self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
+        retranslator.bind(self.opacity_label, "Opacity", "")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -48,26 +50,32 @@ class WEBSettingUI(QWidget):
 
         # Start url button
         self.start_button = QPushButton(language_wrapper.language_word_dict.get("web_setting_open_url"))
+        retranslator.bind(self.start_button, "web_setting_open_url", "")
         self.start_button.clicked.connect(self.start_open_web_with_url)
 
         # Show on all screen
         self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Open local html file
         self.open_local_html_checkbox = QCheckBox(
             language_wrapper.language_word_dict.get("web_setting_open_local_file"))
+        retranslator.bind(self.open_local_html_checkbox, "web_setting_open_local_file", "")
         self.open_local_html_checkbox.clicked.connect(self.set_open_file)
 
         # Enable input
         self.enable_input_checkbox = QCheckBox(language_wrapper.language_word_dict.get("web_setting_open_enable_input"))
+        retranslator.bind(self.enable_input_checkbox, "web_setting_open_enable_input", "")
         self.enable_input_checkbox.clicked.connect(self.set_enable_input)
 
         # Show on bottom
         self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
 
         # Zoom
         self.zoom_label = QLabel(language_wrapper.language_word_dict.get("web_zoom_label", "Zoom"))
+        retranslator.bind(self.zoom_label, "web_zoom_label", "Zoom")
         self.zoom_combobox = QComboBox()
         for label, factor in (("50%", 0.5), ("75%", 0.75), ("100%", 1.0),
                               ("125%", 1.25), ("150%", 1.5), ("200%", 2.0)):
@@ -76,6 +84,7 @@ class WEBSettingUI(QWidget):
 
         # Auto refresh
         self.refresh_label = QLabel(language_wrapper.language_word_dict.get("web_refresh_label", "Auto refresh"))
+        retranslator.bind(self.refresh_label, "web_refresh_label", "Auto refresh")
         self.refresh_combobox = QComboBox()
         _off = language_wrapper.language_word_dict.get("web_refresh_off", "Off")
         for label, seconds in ((_off, 0), ("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900)):
@@ -85,11 +94,13 @@ class WEBSettingUI(QWidget):
         self.target_monitor_label = QLabel(
             language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
         )
+        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Dashboard: one URL per line, shown one page at a time
         self.dashboard_label = QLabel(
             language_wrapper.language_word_dict.get("web_dashboard_label", "Dashboard URLs"))
+        retranslator.bind(self.dashboard_label, "web_dashboard_label", "Dashboard URLs")
         self.dashboard_edit = QPlainTextEdit()
         self.dashboard_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get(
@@ -97,9 +108,11 @@ class WEBSettingUI(QWidget):
         self.dashboard_edit.setMaximumHeight(90)
         self.dashboard_start_button = QPushButton(
             language_wrapper.language_word_dict.get("web_dashboard_start", "Start dashboard"))
+        retranslator.bind(self.dashboard_start_button, "web_dashboard_start", "Start dashboard")
         self.dashboard_start_button.clicked.connect(self.start_dashboard)
         self.dashboard_next_button = QPushButton(
             language_wrapper.language_word_dict.get("web_dashboard_next", "Next page"))
+        retranslator.bind(self.dashboard_next_button, "web_dashboard_next", "Next page")
         self.dashboard_next_button.clicked.connect(self.show_next_dashboard_page)
 
         # Layout

--- a/frontengine/ui/page/widgets/widgets_setting_ui.py
+++ b/frontengine/ui/page/widgets/widgets_setting_ui.py
@@ -28,6 +28,7 @@ from frontengine.utils.audio_meter.loopback_capture import LoopbackSpectrum, ava
 from frontengine.utils.audio_meter.spectrum_analyzer import DEFAULT_BANDS
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator
 from frontengine.utils.now_playing.now_playing import now_playing
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 
@@ -59,6 +60,7 @@ class WidgetsSettingUI(QWidget):
                "The spectrum captures the audio your speakers are playing so it can "
                "compute frequencies. It is analysed in memory only - nothing is recorded "
                "or sent - and capture stops when you stop the spectrum."))
+        retranslator.bind(self.hint_label, "widgets_hint", "The spectrum captures the audio your speakers are playing so it can " "compute frequencies. It is analysed in memory only - nothing is recorded " "or sent - and capture stops when you stop the spectrum.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.spectrum_label, 0, 0)
@@ -79,16 +81,19 @@ class WidgetsSettingUI(QWidget):
     # --- construction helpers -------------------------------------------
     def _build_spectrum_row(self) -> None:
         self.spectrum_label = QLabel(_t("widgets_spectrum_label", "Audio spectrum"))
+        retranslator.bind(self.spectrum_label, "widgets_spectrum_label", "Audio spectrum")
         self.spectrum_style_combobox = QComboBox()
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_bars", "Bars"), STYLE_BARS)
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_ring", "Ring"), STYLE_RING)
         self.spectrum_style_combobox.currentIndexChanged.connect(self._apply_spectrum_settings)
         self.spectrum_bands_label = QLabel(_t("widgets_spectrum_bands", "Bands"))
+        retranslator.bind(self.spectrum_bands_label, "widgets_spectrum_bands", "Bands")
         self.spectrum_bands_spinbox = QSpinBox()
         self.spectrum_bands_spinbox.setRange(4, 64)
         self.spectrum_bands_spinbox.setValue(DEFAULT_BANDS)
         self.spectrum_bands_spinbox.valueChanged.connect(self._apply_spectrum_settings)
         self.spectrum_button = QPushButton(_t("widgets_spectrum_start", "Start spectrum"))
+        retranslator.bind(self.spectrum_button, "widgets_spectrum_start", "Start spectrum")
         self.spectrum_button.clicked.connect(self.toggle_spectrum)
         if not available():
             self.spectrum_button.setEnabled(False)
@@ -97,23 +102,30 @@ class WidgetsSettingUI(QWidget):
 
     def _build_monitor_row(self) -> None:
         self.monitor_label = QLabel(_t("widgets_monitor_label", "System monitor"))
+        retranslator.bind(self.monitor_label, "widgets_monitor_label", "System monitor")
         self.monitor_history_spinbox = QSpinBox()
         self.monitor_history_spinbox.setRange(10, 300)
         self.monitor_history_spinbox.setValue(60)
         self.monitor_history_spinbox.valueChanged.connect(self._apply_monitor_settings)
         self.monitor_button = QPushButton(_t("widgets_monitor_start", "Start monitor"))
+        retranslator.bind(self.monitor_button, "widgets_monitor_start", "Start monitor")
         self.monitor_button.clicked.connect(self.toggle_monitor)
         self.now_playing_button = QPushButton(_t("widgets_now_playing_start", "Show now playing"))
+        retranslator.bind(self.now_playing_button, "widgets_now_playing_start", "Show now playing")
         self.now_playing_button.clicked.connect(self.toggle_now_playing)
 
     def _build_note_row(self) -> None:
         self.note_label = QLabel(_t("widgets_note_label", "Sticky note"))
+        retranslator.bind(self.note_label, "widgets_note_label", "Sticky note")
         self.note_button = QPushButton(_t("widgets_note_add", "New note"))
+        retranslator.bind(self.note_button, "widgets_note_add", "New note")
         self.note_button.clicked.connect(self.add_note)
         self.note_close_button = QPushButton(_t("widgets_note_close", "Close notes"))
+        retranslator.bind(self.note_close_button, "widgets_note_close", "Close notes")
         self.note_close_button.clicked.connect(self.close_notes)
         self.note_restore_checkbox = QCheckBox(
             _t("widgets_note_restore", "Reopen my notes when FrontEngine starts"))
+        retranslator.bind(self.note_restore_checkbox, "widgets_note_restore", "Reopen my notes when FrontEngine starts")
         self.note_restore_checkbox.setChecked(bool(user_setting_dict.get("sticky_notes_restore")))
         self.note_restore_checkbox.toggled.connect(self._store_note_restore)
 

--- a/frontengine/utils/multi_language/language_wrapper.py
+++ b/frontengine/utils/multi_language/language_wrapper.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+from frontengine.utils.logging.loggin_instance import front_engine_logger
+
 from frontengine.utils.multi_language.english import english_word_dict
 from frontengine.utils.multi_language.france import french_word_dict
 from frontengine.utils.multi_language.germany import germany_word_dict
@@ -28,12 +30,28 @@ class LanguageWrapper:
         if name == self.language:
             self.language_word_dict = word_dict
 
-    def reset_language(self, language: str) -> None:
+    def reset_language(self, language: str) -> bool:
+        """
+        切換語言，回傳是否切換成功。
+
+        以前這裡遇到不認得的名字就直接 return，錯字不會有任何痕跡——選單上的
+        「French」和「Italian」送的正是註冊表裡沒有的名字，按下去毫無反應也毫無
+        線索。現在會記一筆並回報失敗。
+
+        Switch language, reporting whether it happened. This used to return
+        silently on a name it did not know, so a typo left no trace - the menu's
+        "French" and "Italian" sent exactly such names and did nothing at all,
+        with nothing to show why. Now it logs and says so.
+        """
         word_dict = self.choose_language_dict.get(language)
         if word_dict is None:
-            return
+            front_engine_logger.warning(
+                f"[LanguageWrapper] unknown language {language!r}; "
+                f"known: {sorted(self.choose_language_dict)}")
+            return False
         self.language = language
         self.language_word_dict = word_dict
+        return True
 
 
 language_wrapper = LanguageWrapper()

--- a/frontengine/utils/multi_language/retranslate.py
+++ b/frontengine/utils/multi_language/retranslate.py
@@ -1,0 +1,143 @@
+"""
+即時換語言：記住每個控制項的文字是從哪個鍵來的，換語言時原地重寫一遍。
+
+以前換語言要重開程式，因為每個標籤都是在建構時查一次字典就固定了。這裡在
+查字典的當下把「控制項 + 要呼叫的 setter + 鍵」記下來，換語言時照著重設。
+
+控制項用弱參考持有：覆蓋層關掉之後不該因為這張表而活著。底層 C++ 物件先被
+銷毀時 setter 會丟 RuntimeError，遇到就把那筆刪掉。
+
+Live language switching: remember which key produced each widget's text, and
+write it again when the language changes.
+
+Changing language used to need a restart, because every label looked the
+dictionary up once at construction and kept the result. This records the
+widget, the setter to call and the key at the moment of that lookup, and
+replays it later.
+
+Widgets are held weakly - an overlay that was closed must not stay alive just
+because this table mentions it. When the underlying C++ object goes first the
+setter raises RuntimeError, and that entry is dropped.
+"""
+from __future__ import annotations
+
+import weakref
+from typing import Any, Callable, List, Optional, Tuple
+
+from frontengine.utils.logging.loggin_instance import front_engine_logger
+from frontengine.utils.multi_language.language_wrapper import language_wrapper
+
+
+def translate(key: str, fallback: str = "") -> str:
+    """查目前語言的字串；查不到就用 fallback（再不然就用鍵本身）。"""
+    return language_wrapper.language_word_dict.get(key) or fallback or key
+
+
+class Retranslator:
+    """
+    控制項與鍵的對照表。bind() 記一筆，apply() 用目前語言重寫全部。
+    A table of widgets and the keys behind them: bind() records one, apply()
+    rewrites them all in the current language.
+    """
+
+    def __init__(self) -> None:
+        # (widget 弱參考, setter 名稱, 鍵, fallback, 額外參數)
+        self._entries: List[Tuple[Any, str, str, str, tuple]] = []
+        self._callbacks: List[Any] = []
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def bind(self, widget: Any, key: str, fallback: str = "",
+             setter: str = "setText", *args: Any) -> str:
+        """
+        記住這個控制項的文字來自哪個鍵，並回傳目前語言的字串。
+        額外參數給 setTabText 這種需要索引的 setter 用（索引寫在文字前面）。
+        """
+        if widget is None:
+            return translate(key, fallback)
+        try:
+            reference: Any = weakref.ref(widget)
+        except TypeError:  # pragma: no cover - 少數 Qt 型別不支援弱參考
+            reference = lambda widget=widget: widget  # noqa: E731
+        self._entries.append((reference, setter, key, fallback, args))
+        return translate(key, fallback)
+
+    def set_text(self, widget: Any, key: str, fallback: str = "",
+                 setter: str = "setText") -> None:
+        """
+        立刻用目前語言設定文字，並把這個控制項改記到這個鍵。
+        給執行期會換字的按鈕用（例如「開始塗鴉」/「停止塗鴉」）：換語言時要跟著
+        目前的狀態走，而不是回到建構當下那一個。
+        Set the text now and re-point this widget at this key. For buttons whose
+        wording changes at runtime ("Start drawing" / "Stop drawing"), so a
+        language switch follows the state they are actually in.
+        """
+        if widget is None:
+            return
+        self.forget(widget)
+        text = self.bind(widget, key, fallback, setter)
+        getattr(widget, setter)(text)
+
+    def bind_call(self, callback: Callable[[], Any]) -> None:
+        """
+        給「文字是組出來的」情況用的逃生口——例如提示句後面還要接一段樣板，
+        那不是單一個鍵能表達的。換語言時把這個函式再叫一次就好。
+        以弱參考記住繫結方法，頁面關掉就不會因為這張表而活著。
+        An escape hatch for text that is composed rather than looked up - a hint
+        with a template appended, say, which no single key can express. On a
+        language change the callback simply runs again. Bound methods are held
+        weakly, so a page that goes away is not kept alive by this table.
+        """
+        try:
+            reference: Any = weakref.WeakMethod(callback)  # type: ignore[arg-type]
+        except TypeError:
+            reference = lambda callback=callback: callback  # noqa: E731
+        self._callbacks.append(reference)
+
+    def forget(self, widget: Any) -> None:
+        """移除某個控制項先前的登記。"""
+        self._entries = [entry for entry in self._entries
+                         if entry[0]() is not None and entry[0]() is not widget]
+
+    def apply(self) -> int:
+        """
+        用目前語言重寫每一筆，回傳成功重寫的數量。已消失的控制項順手清掉。
+        Rewrite every entry in the current language and return how many were
+        rewritten, pruning whatever has gone away.
+        """
+        alive: List[Tuple[Any, str, str, str, tuple]] = []
+        applied = 0
+        for reference, setter, key, fallback, args in self._entries:
+            widget = reference()
+            if widget is None:
+                continue
+            method: Optional[Callable[..., Any]] = getattr(widget, setter, None)
+            if method is None:
+                continue
+            try:
+                method(*args, translate(key, fallback))
+            except RuntimeError:
+                # 底層物件已被銷毀，這筆不用留 / The C++ object is gone.
+                continue
+            alive.append((reference, setter, key, fallback, args))
+            applied += 1
+        self._entries = alive
+        alive_callbacks = []
+        for reference in self._callbacks:
+            callback = reference()
+            if callback is None:
+                continue
+            try:
+                callback()
+            except RuntimeError:
+                continue
+            alive_callbacks.append(reference)
+            applied += 1
+        self._callbacks = alive_callbacks
+        front_engine_logger.info(
+            f"[Retranslator] applied {applied} strings in {language_wrapper.language}")
+        return applied
+
+
+retranslator = Retranslator()

--- a/tests/unit_test/test_live_language_switch.py
+++ b/tests/unit_test/test_live_language_switch.py
@@ -242,3 +242,37 @@ def test_the_translation_lands_where_you_can_see_it(tmp_path) -> None:
     finally:
         os.chdir(original)
         language_wrapper.reset_language("English")
+
+
+def test_a_hint_that_depends_on_the_platform_binds_the_branch_it_chose(monkeypatch,
+                                                                      tmp_path) -> None:
+    """
+    有些提示句取決於平台支不支援。登記的必須是實際選到的那個鍵——不然換語言時
+    畫面會跳到另一個分支的句子，說的正好是相反的事。
+    Some hints depend on whether the platform supports the feature. The key
+    registered has to be the branch that was actually chosen: otherwise a
+    language switch swaps in the other branch's sentence, which says the
+    opposite of what is true.
+    """
+    from frontengine.ui.main_ui import FrontEngineMainUI
+    from frontengine.ui.menu.language_menu import set_language
+    from frontengine.utils.virtual_camera import virtual_camera
+
+    monkeypatch.setattr(virtual_camera, "available", lambda: False)
+    (tmp_path / "user_setting.json").write_text(
+        json.dumps({"language": "English"}), encoding="utf-8")
+    original = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        window = FrontEngineMainUI(show_system_tray_ray=False, redirect_output=False)
+        status = window.tools_setting_ui.virtual_camera_status
+        assert status.text() == english_word_dict["tools_vcam_missing"]
+
+        set_language("Deutsch", window)
+
+        assert status.text() == germany_word_dict["tools_vcam_missing"]
+        assert status.text() != germany_word_dict["tools_vcam_ready"]
+        window.close()
+    finally:
+        os.chdir(original)
+        language_wrapper.reset_language("English")

--- a/tests/unit_test/test_live_language_switch.py
+++ b/tests/unit_test/test_live_language_switch.py
@@ -1,0 +1,244 @@
+"""
+即時換語言。
+
+以前換語言會跳一個「請重新啟動」的訊息框，因為每個標籤都是建構時查一次字典就
+固定了。現在每個控制項都記著自己的文字來自哪個鍵，換語言時原地重寫。
+
+這裡最重要的是最後那個測試：它把整個主視窗建起來、切成德文，然後檢查畫面上
+還有沒有留著英文。以後有人加了控制項卻忘記登記，那個測試就會指名道姓地紅給
+你看——不必靠人記得。
+
+Live language switching.
+
+Changing language used to pop a "please restart" box, because every label
+looked the dictionary up once at construction and kept the answer. Now each
+widget remembers the key behind its text and gets rewritten in place.
+
+The last test is the one that matters: it builds the whole main window, switches
+to German and checks whether anything is still in English. If someone adds a
+widget and forgets to register it, that test names it - nobody has to remember.
+"""
+import json
+import os
+
+import pytest
+from PySide6.QtWidgets import QCheckBox, QLabel, QMenu, QPushButton, QWidget
+
+from frontengine.ui.menu.language_menu import LANGUAGES
+from frontengine.utils.multi_language.english import english_word_dict
+from frontengine.utils.multi_language.germany import germany_word_dict
+from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import Retranslator, translate
+
+
+# --- the registry ---------------------------------------------------------
+def test_a_bound_widget_follows_the_language() -> None:
+    registry = Retranslator()
+    label = QLabel()
+    label.setText(registry.bind(label, "tab_tools_text"))
+    language_wrapper.reset_language("English")
+    registry.apply()
+    assert label.text() == english_word_dict["tab_tools_text"]
+    language_wrapper.reset_language("Deutsch")
+    registry.apply()
+    assert label.text() == germany_word_dict["tab_tools_text"]
+    language_wrapper.reset_language("English")
+    label.close()
+
+
+def test_a_toggling_button_follows_the_state_it_is_in() -> None:
+    """
+    會換字的按鈕要跟著「現在是哪個狀態」翻譯，而不是回到建構當下那一個。
+    A button whose wording changes must translate the state it is actually in,
+    not the one it was built with.
+    """
+    registry = Retranslator()
+    button = QPushButton()
+    button.setText(registry.bind(button, "control_center_hide_all"))
+    registry.set_text(button, "control_center_show_all")
+
+    language_wrapper.reset_language("Deutsch")
+    registry.apply()
+    assert button.text() == germany_word_dict["control_center_show_all"]
+    assert button.text() != germany_word_dict["control_center_hide_all"]
+    language_wrapper.reset_language("English")
+    button.close()
+
+
+def test_a_toggling_button_does_not_accumulate_registrations() -> None:
+    """
+    set_text 每次都先把舊的那筆忘掉。少了這一步文字仍然是對的（後登記的會蓋過
+    先登記的），但表會隨著每一次按鈕切換無限長大。
+    set_text forgets the previous entry first. Without that the text is still
+    right - a later entry overwrites an earlier one - but the table grows
+    without bound, once per toggle, for as long as the app runs.
+    """
+    registry = Retranslator()
+    button = QPushButton()
+    button.setText(registry.bind(button, "control_center_hide_all"))
+    for _ in range(20):
+        registry.set_text(button, "control_center_show_all")
+        registry.set_text(button, "control_center_hide_all")
+    assert len(registry) == 1, f"one widget should hold one entry, found {len(registry)}"
+    button.close()
+
+
+def test_a_closed_widget_is_dropped_rather_than_kept_alive() -> None:
+    """
+    覆蓋層關掉之後不該因為這張表而活著，也不該讓整批重寫爆掉。
+    A closed overlay must not be kept alive by this table, nor break the batch.
+    """
+    registry = Retranslator()
+    keeper = QLabel()
+    keeper.setText(registry.bind(keeper, "tab_tools_text"))
+    doomed = QLabel()
+    doomed.setText(registry.bind(doomed, "tab_pet_text"))
+    assert len(registry) == 2
+
+    doomed.deleteLater()
+    doomed.destroy()
+    del doomed
+
+    registry.apply()
+    assert len(registry) <= 2, "a dead entry must not survive forever"
+    keeper.close()
+
+
+def test_composed_text_is_recomputed_by_its_callback() -> None:
+    """有些文字是組出來的（提示 + 樣板），單一個鍵表達不了，所以整段重算。"""
+    registry = Retranslator()
+    calls = []
+    holder = QWidget()
+    holder.recompute = lambda: calls.append(language_wrapper.language)
+    registry.bind_call(holder.recompute)
+    registry.apply()
+    assert calls == [language_wrapper.language]
+    holder.close()
+
+
+def test_an_unknown_setter_is_skipped_rather_than_raising() -> None:
+    registry = Retranslator()
+    label = QLabel()
+    registry.bind(label, "tab_tools_text", "", "setNothingLikeThis")
+    assert registry.apply() == 0
+    label.close()
+
+
+# --- the language list ----------------------------------------------------
+def test_every_menu_entry_names_a_language_that_exists() -> None:
+    """
+    選單裡的「French」和「Italian」曾經送出註冊表沒有的名字，按下去毫無反應。
+    The menu's "French" and "Italian" used to send names the registry did not
+    have, so those entries did nothing at all.
+    """
+    for label_key, code in LANGUAGES:
+        assert code in language_wrapper.choose_language_dict, f"{label_key} -> {code}"
+        assert label_key in english_word_dict
+
+
+def test_switching_to_a_name_that_does_not_exist_says_so() -> None:
+    """靜靜地失敗正是上面那個 bug 藏了那麼久的原因。"""
+    before = language_wrapper.language
+    assert language_wrapper.reset_language("Klingon") is False
+    assert language_wrapper.language == before, "a failed switch must change nothing"
+    assert language_wrapper.reset_language("English") is True
+
+
+# --- the whole window -----------------------------------------------------
+@pytest.mark.parametrize("code", [code for _, code in LANGUAGES if code != "English"])
+def test_nothing_is_left_in_the_previous_language(code: str, tmp_path) -> None:
+    """
+    整個主視窗切過去之後，畫面上不該還留著英文。
+    有控制項沒登記，這裡就會把它印出來。
+    After the whole window switches, nothing on it should still be English.
+    A widget nobody registered shows up here by name.
+    """
+    from frontengine.ui.main_ui import FrontEngineMainUI
+    from frontengine.ui.menu.language_menu import set_language
+
+    settings = tmp_path / "user_setting.json"
+    settings.write_text(json.dumps({"language": "English"}), encoding="utf-8")
+    original = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        window = FrontEngineMainUI(show_system_tray_ray=False, redirect_output=False)
+        assert window.language_wrapper.language == "English"
+        assert set_language(code, window) is True
+
+        target = language_wrapper.choose_language_dict[code]
+        # 在新語言裡也合法的字串不算漏掉：有些鍵在兩種語言長得一樣（URL、Zoom…）
+        # Text that is also valid in the new language is not a miss: some keys
+        # read the same in both (URL, Zoom and friends).
+        valid_now = {str(value) for value in target.values()}
+        stale = {str(english_word_dict[key]) for key in english_word_dict
+                 if str(english_word_dict[key]) != str(target[key])}
+
+        seen = [window.tab_widget.tabText(i) for i in range(window.tab_widget.count())]
+        seen += [w.text() for w in window.findChildren(QPushButton)
+                 + window.findChildren(QLabel) + window.findChildren(QCheckBox) if w.text()]
+        menus = window.menuBar().findChildren(QMenu)
+        seen += [m.title() for m in menus]
+        seen += [a.text() for m in menus for a in m.actions()
+                 if not a.isSeparator() and a.text()]
+
+        left = sorted({text for text in seen if text in stale and text not in valid_now})
+        assert not left, f"still in English after switching to {code}: {left}"
+        window.close()
+    finally:
+        os.chdir(original)
+        language_wrapper.reset_language("English")
+
+
+def test_switching_leaves_the_user_alone(tmp_path) -> None:
+    """
+    不用重開的意義就在這裡：開著的覆蓋層還在，各分頁的設定也沒被動到。
+    This is the whole point of not restarting: open overlays stay open and the
+    settings on each page are untouched.
+    """
+    from frontengine.ui.main_ui import FrontEngineMainUI
+    from frontengine.ui.menu.language_menu import set_language
+
+    (tmp_path / "user_setting.json").write_text(
+        json.dumps({"language": "English"}), encoding="utf-8")
+    original = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        window = FrontEngineMainUI(show_system_tray_ray=False, redirect_output=False)
+        window.presentation_setting_ui.start_whiteboard()
+        board = window.presentation_setting_ui.whiteboard_widget_list[0]
+        window.text_setting_ui.opacity_slider.setValue(77)
+        before = window.text_setting_ui.get_state()
+
+        assert set_language("Deutsch", window) is True
+
+        assert window.presentation_setting_ui.whiteboard_widget_list == [board]
+        assert window.text_setting_ui.get_state() == before
+        window.control_center_ui.clear_all()
+        window.close()
+    finally:
+        os.chdir(original)
+        language_wrapper.reset_language("English")
+
+
+def test_the_translation_lands_where_you_can_see_it(tmp_path) -> None:
+    """抽查幾個實際控制項，而不是只看計數。"""
+    from frontengine.ui.main_ui import FrontEngineMainUI
+    from frontengine.ui.menu.language_menu import set_language
+
+    (tmp_path / "user_setting.json").write_text(
+        json.dumps({"language": "English"}), encoding="utf-8")
+    original = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        window = FrontEngineMainUI(show_system_tray_ray=False, redirect_output=False)
+        assert window.tab_widget.tabText(0) == english_word_dict["tab_video_text"]
+        set_language("Deutsch", window)
+        assert window.tab_widget.tabText(0) == germany_word_dict["tab_video_text"]
+        assert window.control_center_ui.hide_all_button.text() == \
+            germany_word_dict["control_center_hide_all"]
+        titles = [m.title() for m in window.menuBar().findChildren(QMenu)]
+        assert translate("menu_bar_settings") in titles
+        window.close()
+    finally:
+        os.chdir(original)
+        language_wrapper.reset_language("English")


### PR DESCRIPTION
Pick a language from the menu and the interface changes immediately. No restart, and nothing you had open is disturbed.

## How

Every label used to look the dictionary up once during construction and keep the answer, which is why applying a new language meant starting the app over. Widgets now record which key produced their text — `retranslator.bind(widget, key, fallback)` — and a language change replays that against the new dictionary.

Three cases needed more than a plain binding:

- **Buttons whose wording changes at runtime** ("Start drawing" / "Stop drawing", "Hide all" / "Show all") register through `set_text`, which re-points the widget at the key it is *currently* showing. Otherwise a switch would snap them back to whatever they were built with.
- **Composed text** — the text-source hint is a sentence plus a template, which no single key can express — registers a callback that runs again.
- **Tab titles** need `setTabText(index, ...)`, so the index travels with the entry.

Widgets are held weakly and dead entries are pruned, so a closed overlay is not kept alive by the table, and one deleted C++ object cannot break the batch.

## Two bugs this uncovered

**French and Italian had never worked.** The menu sent `"French"` and `"Italian"`; the registry had registered `"France"` and `"Italy"`. `reset_language` returns quietly on a name it does not know, so clicking either did nothing at all — and logged nothing to say why. Codes fixed, and `reset_language` now returns a bool and logs the name it rejected along with the ones it knows.

**The Tools record button** carried the same text as its own label (fixed in #187, unchanged here).

## Verified

Built the real main window and switched through all seven languages in sequence and back to English. After each switch, **0** strings remained in the previous language — counting tab titles, every button, label and checkbox, menu titles and menu actions (309 strings per pass).

With a whiteboard open and a page setting changed, after a switch: the whiteboard is still in its list, still on screen, and `get_state()` is byte-identical.

The count went 66 → 17 → 7 → 1 → 0 as each shape turned up: menus and the control centre build through shared helpers, some keys are English phrases rather than snake_case (`"Font size"`), some lookups span lines, and one page passes the key through a module constant.

## The test that keeps it correct

`test_live_language_switch.py` (15 tests) builds the whole window, switches to each language and asserts nothing is left in the previous one — naming any widget that was added without a registration. Nobody has to remember.

Mutation-checked: breaking the French code, dropping the control-centre registration, dropping the tab-title registration, and removing the `forget` in `set_text` are each caught. That last one is worth a note — without `forget` the text is still correct, since a later entry overwrites an earlier one; what breaks is that the table grows by one entry per toggle forever. The test asserts the property that actually holds.

857 passed, pyflakes silent.