### PR TITLE
Stop writing every label's wording twice

### DIFF
--- a/frontengine/ui/dialog/app_profile_dialog.py
+++ b/frontengine/ui/dialog/app_profile_dialog.py
@@ -50,17 +50,18 @@ class AppProfileDialog(QDialog):
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-        self.add_button = QPushButton(_t("app_profile_add", "Add"))
-        retranslator.bind(self.add_button, "app_profile_add", "Add")
+        self.add_button = QPushButton()
+        retranslator.bind(self.add_button, "app_profile_add",
+                          "Add")
         self.add_button.clicked.connect(lambda: self.add_row("", ""))
-        self.remove_button = QPushButton(_t("app_profile_remove", "Remove"))
-        retranslator.bind(self.remove_button, "app_profile_remove", "Remove")
+        self.remove_button = QPushButton()
+        retranslator.bind(self.remove_button, "app_profile_remove",
+                          "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
-        self.hint_label = QLabel(
-            _t("app_profile_hint",
-               "Presets are saved from the Presets menu. Without any saved preset "
-               "there is nothing to apply."))
-        retranslator.bind(self.hint_label, "app_profile_hint", "Presets are saved from the Presets menu. Without any saved preset " "there is nothing to apply.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "app_profile_hint",
+                          "Presets are saved from the Presets menu. Without any saved preset "
+               "there is nothing to apply.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/app_profile_dialog.py
+++ b/frontengine/ui/dialog/app_profile_dialog.py
@@ -20,7 +20,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.app_profile.app_profile_service import normalize_profiles
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.smart_pause.pause_rules import normalize_app_name
 
 
@@ -50,18 +50,13 @@ class AppProfileDialog(QDialog):
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-        self.add_button = QPushButton()
-        retranslator.bind(self.add_button, "app_profile_add",
-                          "Add")
+        self.add_button = tr(QPushButton(), "app_profile_add", "Add")
         self.add_button.clicked.connect(lambda: self.add_row("", ""))
-        self.remove_button = QPushButton()
-        retranslator.bind(self.remove_button, "app_profile_remove",
-                          "Remove")
+        self.remove_button = tr(QPushButton(), "app_profile_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "app_profile_hint",
-                          "Presets are saved from the Presets menu. Without any saved preset "
-               "there is nothing to apply.")
+        self.hint_label = tr(QLabel(), "app_profile_hint",
+            "Presets are saved from the Presets menu. Without any saved preset "
+            "there is nothing to apply.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/clipboard_dialog.py
+++ b/frontengine/ui/dialog/clipboard_dialog.py
@@ -51,30 +51,33 @@ class ClipboardDialog(QDialog):
         self.entry_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.entry_list.itemDoubleClicked.connect(lambda _item: self.copy_selected())
 
-        self.copy_button = QPushButton(_t("clipboard_copy", "Copy"))
-        retranslator.bind(self.copy_button, "clipboard_copy", "Copy")
+        self.copy_button = QPushButton()
+        retranslator.bind(self.copy_button, "clipboard_copy",
+                          "Copy")
         self.copy_button.clicked.connect(self.copy_selected)
-        self.pin_button = QPushButton(_t("clipboard_pin", "Pin / unpin"))
-        retranslator.bind(self.pin_button, "clipboard_pin", "Pin / unpin")
+        self.pin_button = QPushButton()
+        retranslator.bind(self.pin_button, "clipboard_pin",
+                          "Pin / unpin")
         self.pin_button.clicked.connect(self.toggle_pin_selected)
-        self.remove_button = QPushButton(_t("clipboard_remove", "Remove"))
-        retranslator.bind(self.remove_button, "clipboard_remove", "Remove")
+        self.remove_button = QPushButton()
+        retranslator.bind(self.remove_button, "clipboard_remove",
+                          "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
-        self.clear_button = QPushButton(_t("clipboard_clear", "Clear (keep pinned)"))
-        retranslator.bind(self.clear_button, "clipboard_clear", "Clear (keep pinned)")
+        self.clear_button = QPushButton()
+        retranslator.bind(self.clear_button, "clipboard_clear",
+                          "Clear (keep pinned)")
         self.clear_button.clicked.connect(self.clear_history)
 
-        self.persist_checkbox = QCheckBox(
-            _t("clipboard_persist", "Keep this history between sessions"))
-        retranslator.bind(self.persist_checkbox, "clipboard_persist", "Keep this history between sessions")
+        self.persist_checkbox = QCheckBox()
+        retranslator.bind(self.persist_checkbox, "clipboard_persist",
+                          "Keep this history between sessions")
         self.persist_checkbox.setChecked(bool(user_setting_dict.get("clipboard_persist")))
         self.persist_checkbox.toggled.connect(self._store_persist)
-        self.hint_label = QLabel(
-            _t("clipboard_hint",
-               "History stays on this machine and is never sent anywhere. Unless you tick "
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "clipboard_hint",
+                          "History stays on this machine and is never sent anywhere. Unless you tick "
                "the box above it is kept in memory only, because clipboards often hold "
-               "passwords."))
-        retranslator.bind(self.hint_label, "clipboard_hint", "History stays on this machine and is never sent anywhere. Unless you tick " "the box above it is kept in memory only, because clipboards often hold " "passwords.")
+               "passwords.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/clipboard_dialog.py
+++ b/frontengine/ui/dialog/clipboard_dialog.py
@@ -25,7 +25,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.clipboard.clipboard_history import ClipboardHistory, preview
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 _PIN_MARK = "📌 "
 
@@ -51,33 +51,23 @@ class ClipboardDialog(QDialog):
         self.entry_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.entry_list.itemDoubleClicked.connect(lambda _item: self.copy_selected())
 
-        self.copy_button = QPushButton()
-        retranslator.bind(self.copy_button, "clipboard_copy",
-                          "Copy")
+        self.copy_button = tr(QPushButton(), "clipboard_copy", "Copy")
         self.copy_button.clicked.connect(self.copy_selected)
-        self.pin_button = QPushButton()
-        retranslator.bind(self.pin_button, "clipboard_pin",
-                          "Pin / unpin")
+        self.pin_button = tr(QPushButton(), "clipboard_pin", "Pin / unpin")
         self.pin_button.clicked.connect(self.toggle_pin_selected)
-        self.remove_button = QPushButton()
-        retranslator.bind(self.remove_button, "clipboard_remove",
-                          "Remove")
+        self.remove_button = tr(QPushButton(), "clipboard_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
-        self.clear_button = QPushButton()
-        retranslator.bind(self.clear_button, "clipboard_clear",
-                          "Clear (keep pinned)")
+        self.clear_button = tr(QPushButton(), "clipboard_clear", "Clear (keep pinned)")
         self.clear_button.clicked.connect(self.clear_history)
 
-        self.persist_checkbox = QCheckBox()
-        retranslator.bind(self.persist_checkbox, "clipboard_persist",
-                          "Keep this history between sessions")
+        self.persist_checkbox = tr(QCheckBox(), "clipboard_persist",
+            "Keep this history between sessions")
         self.persist_checkbox.setChecked(bool(user_setting_dict.get("clipboard_persist")))
         self.persist_checkbox.toggled.connect(self._store_persist)
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "clipboard_hint",
-                          "History stays on this machine and is never sent anywhere. Unless you tick "
-               "the box above it is kept in memory only, because clipboards often hold "
-               "passwords.")
+        self.hint_label = tr(QLabel(), "clipboard_hint",
+            "History stays on this machine and is never sent anywhere. Unless you tick "
+            "the box above it is kept in memory only, because clipboards often hold "
+            "passwords.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/reminder_dialog.py
+++ b/frontengine/ui/dialog/reminder_dialog.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.reminder.reminder_service import (
     KIND_AT, KIND_EVERY, normalize_reminder, normalize_reminders,
 )
@@ -55,18 +55,13 @@ class ReminderDialog(QDialog):
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-        self.add_button = QPushButton()
-        retranslator.bind(self.add_button, "reminder_add",
-                          "Add")
+        self.add_button = tr(QPushButton(), "reminder_add", "Add")
         self.add_button.clicked.connect(lambda: self.add_row())
-        self.remove_button = QPushButton()
-        retranslator.bind(self.remove_button, "reminder_remove",
-                          "Remove")
+        self.remove_button = tr(QPushButton(), "reminder_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "reminder_hint",
-                          "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a "
-               "24-hour time such as 14:30.")
+        self.hint_label = tr(QLabel(), "reminder_hint",
+            "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a "
+            "24-hour time such as 14:30.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/reminder_dialog.py
+++ b/frontengine/ui/dialog/reminder_dialog.py
@@ -55,17 +55,18 @@ class ReminderDialog(QDialog):
         self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.table.horizontalHeader().setStretchLastSection(True)
 
-        self.add_button = QPushButton(_t("reminder_add", "Add"))
-        retranslator.bind(self.add_button, "reminder_add", "Add")
+        self.add_button = QPushButton()
+        retranslator.bind(self.add_button, "reminder_add",
+                          "Add")
         self.add_button.clicked.connect(lambda: self.add_row())
-        self.remove_button = QPushButton(_t("reminder_remove", "Remove"))
-        retranslator.bind(self.remove_button, "reminder_remove", "Remove")
+        self.remove_button = QPushButton()
+        retranslator.bind(self.remove_button, "reminder_remove",
+                          "Remove")
         self.remove_button.clicked.connect(self.remove_selected_row)
-        self.hint_label = QLabel(
-            _t("reminder_hint",
-               "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a "
-               "24-hour time such as 14:30."))
-        retranslator.bind(self.hint_label, "reminder_hint", "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a " "24-hour time such as 14:30.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "reminder_hint",
+                          "Tick a row to keep it active. \"Every\" takes minutes, \"At\" takes a "
+               "24-hour time such as 14:30.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/remote_control_dialog.py
+++ b/frontengine/ui/dialog/remote_control_dialog.py
@@ -24,7 +24,7 @@ from frontengine.user_setting.user_setting_file import user_setting_dict, write_
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.midi.midi_input import available as midi_available, list_devices
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.remote.remote_server import ALLOWED_ACTIONS
 
 MIDI_KEY = "midi_bindings"
@@ -60,44 +60,33 @@ class RemoteControlDialog(QDialog):
         self._midi = midi
         self._learning = False
 
-        self.remote_checkbox = QCheckBox()
-        retranslator.bind(self.remote_checkbox, "remote_enable",
-                          "Let my phone control FrontEngine")
+        self.remote_checkbox = tr(QCheckBox(), "remote_enable", "Let my phone control FrontEngine")
         self.remote_checkbox.setChecked(remote_enabled())
         self.remote_checkbox.toggled.connect(self._toggle_remote)
         self.remote_url_label = QLabel(self.remote_status())
         self.remote_url_label.setWordWrap(True)
         self.remote_url_label.setTextInteractionFlags(
             self.remote_url_label.textInteractionFlags().TextSelectableByMouse)
-        self.remote_copy_button = QPushButton()
-        retranslator.bind(self.remote_copy_button, "remote_copy",
-                          "Copy link")
+        self.remote_copy_button = tr(QPushButton(), "remote_copy", "Copy link")
         self.remote_copy_button.clicked.connect(self.copy_link)
-        self.remote_hint = QLabel()
-        retranslator.bind(self.remote_hint, "remote_hint",
-                          "This opens a port on this machine for your local network. The link carries a "
-               "one-time token that changes every time it starts, and only the buttons on the "
-               "page can be triggered - nothing else. It is plain HTTP, so treat it like any "
-               "other device on your network: someone else on the same network could read the "
-               "token and press the same buttons. Leave it off on networks you do not trust.")
+        self.remote_hint = tr(QLabel(), "remote_hint",
+            "This opens a port on this machine for your local network. The link carries a "
+            "one-time token that changes every time it starts, and only the buttons on the "
+            "page can be triggered - nothing else. It is plain HTTP, so treat it like any "
+            "other device on your network: someone else on the same network could read the "
+            "token and press the same buttons. Leave it off on networks you do not trust.")
         self.remote_hint.setWordWrap(True)
 
-        self.midi_label = QLabel()
-        retranslator.bind(self.midi_label, "remote_midi_label",
-                          "MIDI controller")
+        self.midi_label = tr(QLabel(), "remote_midi_label", "MIDI controller")
         self.midi_combobox = QComboBox()
         for index, name in list_devices():
             self.midi_combobox.addItem(name, index)
         if self.midi_combobox.count() == 0:
             self.midi_combobox.addItem(_t("remote_midi_none", "No MIDI device found"), -1)
-        self.learn_button = QPushButton()
-        retranslator.bind(self.learn_button, "remote_midi_learn",
-                          "Learn")
+        self.learn_button = tr(QPushButton(), "remote_midi_learn", "Learn")
         self.learn_button.clicked.connect(self.start_learning)
         self.learn_button.setEnabled(midi_available())
-        self.remove_button = QPushButton()
-        retranslator.bind(self.remove_button, "remote_midi_remove",
-                          "Remove")
+        self.remove_button = tr(QPushButton(), "remote_midi_remove", "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
 
         self.table = QTableWidget(0, 2)

--- a/frontengine/ui/dialog/remote_control_dialog.py
+++ b/frontengine/ui/dialog/remote_control_dialog.py
@@ -60,40 +60,44 @@ class RemoteControlDialog(QDialog):
         self._midi = midi
         self._learning = False
 
-        self.remote_checkbox = QCheckBox(_t("remote_enable", "Let my phone control FrontEngine"))
-        retranslator.bind(self.remote_checkbox, "remote_enable", "Let my phone control FrontEngine")
+        self.remote_checkbox = QCheckBox()
+        retranslator.bind(self.remote_checkbox, "remote_enable",
+                          "Let my phone control FrontEngine")
         self.remote_checkbox.setChecked(remote_enabled())
         self.remote_checkbox.toggled.connect(self._toggle_remote)
         self.remote_url_label = QLabel(self.remote_status())
         self.remote_url_label.setWordWrap(True)
         self.remote_url_label.setTextInteractionFlags(
             self.remote_url_label.textInteractionFlags().TextSelectableByMouse)
-        self.remote_copy_button = QPushButton(_t("remote_copy", "Copy link"))
-        retranslator.bind(self.remote_copy_button, "remote_copy", "Copy link")
+        self.remote_copy_button = QPushButton()
+        retranslator.bind(self.remote_copy_button, "remote_copy",
+                          "Copy link")
         self.remote_copy_button.clicked.connect(self.copy_link)
-        self.remote_hint = QLabel(
-            _t("remote_hint",
-               "This opens a port on this machine for your local network. The link carries a "
+        self.remote_hint = QLabel()
+        retranslator.bind(self.remote_hint, "remote_hint",
+                          "This opens a port on this machine for your local network. The link carries a "
                "one-time token that changes every time it starts, and only the buttons on the "
                "page can be triggered - nothing else. It is plain HTTP, so treat it like any "
                "other device on your network: someone else on the same network could read the "
-               "token and press the same buttons. Leave it off on networks you do not trust."))
-        retranslator.bind(self.remote_hint, "remote_hint", "This opens a port on this machine for your local network. The link carries a " "one-time token that changes every time it starts, and only the buttons on the " "page can be triggered - nothing else. It is plain HTTP, so treat it like any " "other device on your network: someone else on the same network could read the " "token and press the same buttons. Leave it off on networks you do not trust.")
+               "token and press the same buttons. Leave it off on networks you do not trust.")
         self.remote_hint.setWordWrap(True)
 
-        self.midi_label = QLabel(_t("remote_midi_label", "MIDI controller"))
-        retranslator.bind(self.midi_label, "remote_midi_label", "MIDI controller")
+        self.midi_label = QLabel()
+        retranslator.bind(self.midi_label, "remote_midi_label",
+                          "MIDI controller")
         self.midi_combobox = QComboBox()
         for index, name in list_devices():
             self.midi_combobox.addItem(name, index)
         if self.midi_combobox.count() == 0:
             self.midi_combobox.addItem(_t("remote_midi_none", "No MIDI device found"), -1)
-        self.learn_button = QPushButton(_t("remote_midi_learn", "Learn"))
-        retranslator.bind(self.learn_button, "remote_midi_learn", "Learn")
+        self.learn_button = QPushButton()
+        retranslator.bind(self.learn_button, "remote_midi_learn",
+                          "Learn")
         self.learn_button.clicked.connect(self.start_learning)
         self.learn_button.setEnabled(midi_available())
-        self.remove_button = QPushButton(_t("remote_midi_remove", "Remove"))
-        retranslator.bind(self.remove_button, "remote_midi_remove", "Remove")
+        self.remove_button = QPushButton()
+        retranslator.bind(self.remove_button, "remote_midi_remove",
+                          "Remove")
         self.remove_button.clicked.connect(self.remove_selected)
 
         self.table = QTableWidget(0, 2)

--- a/frontengine/ui/dialog/screen_privacy_dialog.py
+++ b/frontengine/ui/dialog/screen_privacy_dialog.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 from frontengine.utils.screen_privacy import capture_affinity
 from frontengine.utils.screen_privacy.share_watch import DEFAULT_SHARING_APPS
 from frontengine.utils.smart_pause.pause_rules import parse_app_list
@@ -54,13 +54,10 @@ class ScreenPrivacyDialog(QDialog):
         self.setWindowTitle(_t("screen_privacy_title", "Screen-sharing privacy"))
         settings = current_settings()
 
-        self.enable_checkbox = QCheckBox()
-        retranslator.bind(self.enable_checkbox, "screen_privacy_enable",
-                          "Hide overlays while one of these apps is open")
+        self.enable_checkbox = tr(QCheckBox(), "screen_privacy_enable",
+            "Hide overlays while one of these apps is open")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
-        self.apps_label = QLabel()
-        retranslator.bind(self.apps_label, "screen_privacy_apps_label",
-                          "Meeting and capture apps:")
+        self.apps_label = tr(QLabel(), "screen_privacy_apps_label", "Meeting and capture apps:")
         self.apps_edit = QLineEdit(", ".join(settings.get("apps", [])))
         self.apps_edit.setPlaceholderText("zoom, teams, discord")
         # 提示句取決於平台支不支援，登記的必須是實際選到的那個鍵

--- a/frontengine/ui/dialog/screen_privacy_dialog.py
+++ b/frontengine/ui/dialog/screen_privacy_dialog.py
@@ -54,12 +54,13 @@ class ScreenPrivacyDialog(QDialog):
         self.setWindowTitle(_t("screen_privacy_title", "Screen-sharing privacy"))
         settings = current_settings()
 
-        self.enable_checkbox = QCheckBox(
-            _t("screen_privacy_enable", "Hide overlays while one of these apps is open"))
-        retranslator.bind(self.enable_checkbox, "screen_privacy_enable", "Hide overlays while one of these apps is open")
+        self.enable_checkbox = QCheckBox()
+        retranslator.bind(self.enable_checkbox, "screen_privacy_enable",
+                          "Hide overlays while one of these apps is open")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
-        self.apps_label = QLabel(_t("screen_privacy_apps_label", "Meeting and capture apps:"))
-        retranslator.bind(self.apps_label, "screen_privacy_apps_label", "Meeting and capture apps:")
+        self.apps_label = QLabel()
+        retranslator.bind(self.apps_label, "screen_privacy_apps_label",
+                          "Meeting and capture apps:")
         self.apps_edit = QLineEdit(", ".join(settings.get("apps", [])))
         self.apps_edit.setPlaceholderText("zoom, teams, discord")
         # 提示句取決於平台支不支援，登記的必須是實際選到的那個鍵

--- a/frontengine/ui/dialog/screen_text_dialog.py
+++ b/frontengine/ui/dialog/screen_text_dialog.py
@@ -78,12 +78,13 @@ class ScreenTextDialog(QDialog):
 
         self.text_edit = QPlainTextEdit(str(text))
         self.text_edit.setReadOnly(False)
-        self.copy_button = QPushButton(_t("screen_text_copy", "Copy"))
-        retranslator.bind(self.copy_button, "screen_text_copy", "Copy")
+        self.copy_button = QPushButton()
+        retranslator.bind(self.copy_button, "screen_text_copy",
+                          "Copy")
         self.copy_button.clicked.connect(self.copy_text)
-        self.consent_checkbox = QCheckBox(
-            _t("screen_text_consent_toggle", "Allow sending captures to Anthropic"))
-        retranslator.bind(self.consent_checkbox, "screen_text_consent_toggle", "Allow sending captures to Anthropic")
+        self.consent_checkbox = QCheckBox()
+        retranslator.bind(self.consent_checkbox, "screen_text_consent_toggle",
+                          "Allow sending captures to Anthropic")
         self.consent_checkbox.setChecked(has_consent())
         self.consent_checkbox.toggled.connect(set_consent)
         self.hint_label = QLabel(self.status_text())

--- a/frontengine/ui/dialog/screen_text_dialog.py
+++ b/frontengine/ui/dialog/screen_text_dialog.py
@@ -24,7 +24,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.screen_text.screen_text_service import API_KEY_ENV, api_key
 
 CONSENT_KEY = "screen_text_consent"
@@ -78,13 +78,10 @@ class ScreenTextDialog(QDialog):
 
         self.text_edit = QPlainTextEdit(str(text))
         self.text_edit.setReadOnly(False)
-        self.copy_button = QPushButton()
-        retranslator.bind(self.copy_button, "screen_text_copy",
-                          "Copy")
+        self.copy_button = tr(QPushButton(), "screen_text_copy", "Copy")
         self.copy_button.clicked.connect(self.copy_text)
-        self.consent_checkbox = QCheckBox()
-        retranslator.bind(self.consent_checkbox, "screen_text_consent_toggle",
-                          "Allow sending captures to Anthropic")
+        self.consent_checkbox = tr(QCheckBox(), "screen_text_consent_toggle",
+            "Allow sending captures to Anthropic")
         self.consent_checkbox.setChecked(has_consent())
         self.consent_checkbox.toggled.connect(set_consent)
         self.hint_label = QLabel(self.status_text())

--- a/frontengine/ui/dialog/signage_dialog.py
+++ b/frontengine/ui/dialog/signage_dialog.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.signage.signage_service import (
     DEFAULT_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES, clamp_interval,
     normalize_playlist,
@@ -52,28 +52,20 @@ class SignageDialog(QDialog):
         self.setWindowTitle(_t("signage_title", "Signage mode"))
         settings = current_settings()
 
-        self.enable_checkbox = QCheckBox()
-        retranslator.bind(self.enable_checkbox, "signage_enable",
-                          "Rotate presets")
+        self.enable_checkbox = tr(QCheckBox(), "signage_enable", "Rotate presets")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
-        self.presets_label = QLabel()
-        retranslator.bind(self.presets_label, "signage_presets_label",
-                          "Presets, one per line:")
+        self.presets_label = tr(QLabel(), "signage_presets_label", "Presets, one per line:")
         self.presets_edit = QPlainTextEdit("\n".join(settings.get("presets", [])))
-        self.interval_label = QLabel()
-        retranslator.bind(self.interval_label, "signage_interval_label",
-                          "Change every (minutes)")
+        self.interval_label = tr(QLabel(), "signage_interval_label", "Change every (minutes)")
         self.interval_spinbox = QSpinBox()
         self.interval_spinbox.setRange(MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES)
         self.interval_spinbox.setValue(settings.get("interval_minutes"))
-        self.hide_checkbox = QCheckBox()
-        retranslator.bind(self.hide_checkbox, "signage_hide_window",
-                          "Hide the main window while rotating")
+        self.hide_checkbox = tr(QCheckBox(), "signage_hide_window",
+            "Hide the main window while rotating")
         self.hide_checkbox.setChecked(bool(settings.get("hide_window", True)))
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "signage_hint",
-                          "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
-               "machine left running keeps cycling.")
+        self.hint_label = tr(QLabel(), "signage_hint",
+            "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
+            "machine left running keeps cycling.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/signage_dialog.py
+++ b/frontengine/ui/dialog/signage_dialog.py
@@ -52,26 +52,28 @@ class SignageDialog(QDialog):
         self.setWindowTitle(_t("signage_title", "Signage mode"))
         settings = current_settings()
 
-        self.enable_checkbox = QCheckBox(_t("signage_enable", "Rotate presets"))
-        retranslator.bind(self.enable_checkbox, "signage_enable", "Rotate presets")
+        self.enable_checkbox = QCheckBox()
+        retranslator.bind(self.enable_checkbox, "signage_enable",
+                          "Rotate presets")
         self.enable_checkbox.setChecked(bool(settings.get("enabled")))
-        self.presets_label = QLabel(_t("signage_presets_label", "Presets, one per line:"))
-        retranslator.bind(self.presets_label, "signage_presets_label", "Presets, one per line:")
+        self.presets_label = QLabel()
+        retranslator.bind(self.presets_label, "signage_presets_label",
+                          "Presets, one per line:")
         self.presets_edit = QPlainTextEdit("\n".join(settings.get("presets", [])))
-        self.interval_label = QLabel(_t("signage_interval_label", "Change every (minutes)"))
-        retranslator.bind(self.interval_label, "signage_interval_label", "Change every (minutes)")
+        self.interval_label = QLabel()
+        retranslator.bind(self.interval_label, "signage_interval_label",
+                          "Change every (minutes)")
         self.interval_spinbox = QSpinBox()
         self.interval_spinbox.setRange(MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES)
         self.interval_spinbox.setValue(settings.get("interval_minutes"))
-        self.hide_checkbox = QCheckBox(
-            _t("signage_hide_window", "Hide the main window while rotating"))
-        retranslator.bind(self.hide_checkbox, "signage_hide_window", "Hide the main window while rotating")
+        self.hide_checkbox = QCheckBox()
+        retranslator.bind(self.hide_checkbox, "signage_hide_window",
+                          "Hide the main window while rotating")
         self.hide_checkbox.setChecked(bool(settings.get("hide_window", True)))
-        self.hint_label = QLabel(
-            _t("signage_hint",
-               "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
-               "machine left running keeps cycling."))
-        retranslator.bind(self.hint_label, "signage_hint", "Presets are saved from the Presets menu. The rotation wraps at the end, so a " "machine left running keeps cycling.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "signage_hint",
+                          "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
+               "machine left running keeps cycling.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/smart_pause_dialog.py
+++ b/frontengine/ui/dialog/smart_pause_dialog.py
@@ -43,23 +43,22 @@ class SmartPauseDialog(QDialog):
         self.setWindowTitle(_t("smart_pause_title", "Smart pause"))
         rules = current_rules()
 
-        self.fullscreen_checkbox = QCheckBox(
-            _t("smart_pause_fullscreen", "Pause while a fullscreen app is running"))
-        retranslator.bind(self.fullscreen_checkbox, "smart_pause_fullscreen", "Pause while a fullscreen app is running")
+        self.fullscreen_checkbox = QCheckBox()
+        retranslator.bind(self.fullscreen_checkbox, "smart_pause_fullscreen",
+                          "Pause while a fullscreen app is running")
         self.fullscreen_checkbox.setChecked(bool(rules.get("fullscreen", True)))
-        self.battery_checkbox = QCheckBox(
-            _t("smart_pause_battery", "Pause while running on battery"))
-        retranslator.bind(self.battery_checkbox, "smart_pause_battery", "Pause while running on battery")
+        self.battery_checkbox = QCheckBox()
+        retranslator.bind(self.battery_checkbox, "smart_pause_battery",
+                          "Pause while running on battery")
         self.battery_checkbox.setChecked(bool(rules.get("battery", False)))
-        self.apps_label = QLabel(
-            _t("smart_pause_apps_label", "Pause while these apps have focus:"))
-        retranslator.bind(self.apps_label, "smart_pause_apps_label", "Pause while these apps have focus:")
+        self.apps_label = QLabel()
+        retranslator.bind(self.apps_label, "smart_pause_apps_label",
+                          "Pause while these apps have focus:")
         self.apps_edit = QLineEdit(", ".join(rules.get("apps", [])))
         self.apps_edit.setPlaceholderText("photoshop, premiere, blender")
-        self.hint_label = QLabel(
-            _t("smart_pause_hint",
-               "Names are matched without the folder or .exe, so \"photoshop\" is enough."))
-        retranslator.bind(self.hint_label, "smart_pause_hint", "Names are matched without the folder or .exe, so \"photoshop\" is enough.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "smart_pause_hint",
+                          "Names are matched without the folder or .exe, so \"photoshop\" is enough.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/smart_pause_dialog.py
+++ b/frontengine/ui/dialog/smart_pause_dialog.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.smart_pause.pause_rules import DEFAULT_RULES, parse_app_list
 
 
@@ -43,22 +43,18 @@ class SmartPauseDialog(QDialog):
         self.setWindowTitle(_t("smart_pause_title", "Smart pause"))
         rules = current_rules()
 
-        self.fullscreen_checkbox = QCheckBox()
-        retranslator.bind(self.fullscreen_checkbox, "smart_pause_fullscreen",
-                          "Pause while a fullscreen app is running")
+        self.fullscreen_checkbox = tr(QCheckBox(), "smart_pause_fullscreen",
+            "Pause while a fullscreen app is running")
         self.fullscreen_checkbox.setChecked(bool(rules.get("fullscreen", True)))
-        self.battery_checkbox = QCheckBox()
-        retranslator.bind(self.battery_checkbox, "smart_pause_battery",
-                          "Pause while running on battery")
+        self.battery_checkbox = tr(QCheckBox(), "smart_pause_battery",
+            "Pause while running on battery")
         self.battery_checkbox.setChecked(bool(rules.get("battery", False)))
-        self.apps_label = QLabel()
-        retranslator.bind(self.apps_label, "smart_pause_apps_label",
-                          "Pause while these apps have focus:")
+        self.apps_label = tr(QLabel(), "smart_pause_apps_label",
+            "Pause while these apps have focus:")
         self.apps_edit = QLineEdit(", ".join(rules.get("apps", [])))
         self.apps_edit.setPlaceholderText("photoshop, premiere, blender")
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "smart_pause_hint",
-                          "Names are matched without the folder or .exe, so \"photoshop\" is enough.")
+        self.hint_label = tr(QLabel(), "smart_pause_hint",
+            "Names are matched without the folder or .exe, so \"photoshop\" is enough.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(

--- a/frontengine/ui/dialog/usage_report_dialog.py
+++ b/frontengine/ui/dialog/usage_report_dialog.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.usage_tracking.usage_tracker import UsageTracker, format_duration
 
 
@@ -47,9 +47,7 @@ class UsageReportDialog(QDialog):
         self._on_toggle = on_toggle
         self._on_clear = on_clear
 
-        self.enable_checkbox = QCheckBox()
-        retranslator.bind(self.enable_checkbox, "usage_enable",
-                          "Track which apps I use")
+        self.enable_checkbox = tr(QCheckBox(), "usage_enable", "Track which apps I use")
         self.enable_checkbox.setChecked(bool(enabled))
         self.enable_checkbox.toggled.connect(self._toggle)
 
@@ -66,18 +64,13 @@ class UsageReportDialog(QDialog):
 
         self.week_label = QLabel()
         self.week_label.setWordWrap(True)
-        self.refresh_button = QPushButton()
-        retranslator.bind(self.refresh_button, "usage_refresh",
-                          "Refresh")
+        self.refresh_button = tr(QPushButton(), "usage_refresh", "Refresh")
         self.refresh_button.clicked.connect(self.reload_report)
-        self.clear_button = QPushButton()
-        retranslator.bind(self.clear_button, "usage_clear",
-                          "Clear history")
+        self.clear_button = tr(QPushButton(), "usage_clear", "Clear history")
         self.clear_button.clicked.connect(self.clear_history)
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "usage_hint",
-                          "This is stored on this machine only and is never sent anywhere. "
-               "Clearing deletes the file itself.")
+        self.hint_label = tr(QLabel(), "usage_hint",
+            "This is stored on this machine only and is never sent anywhere. "
+            "Clearing deletes the file itself.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/usage_report_dialog.py
+++ b/frontengine/ui/dialog/usage_report_dialog.py
@@ -47,8 +47,9 @@ class UsageReportDialog(QDialog):
         self._on_toggle = on_toggle
         self._on_clear = on_clear
 
-        self.enable_checkbox = QCheckBox(_t("usage_enable", "Track which apps I use"))
-        retranslator.bind(self.enable_checkbox, "usage_enable", "Track which apps I use")
+        self.enable_checkbox = QCheckBox()
+        retranslator.bind(self.enable_checkbox, "usage_enable",
+                          "Track which apps I use")
         self.enable_checkbox.setChecked(bool(enabled))
         self.enable_checkbox.toggled.connect(self._toggle)
 
@@ -65,17 +66,18 @@ class UsageReportDialog(QDialog):
 
         self.week_label = QLabel()
         self.week_label.setWordWrap(True)
-        self.refresh_button = QPushButton(_t("usage_refresh", "Refresh"))
-        retranslator.bind(self.refresh_button, "usage_refresh", "Refresh")
+        self.refresh_button = QPushButton()
+        retranslator.bind(self.refresh_button, "usage_refresh",
+                          "Refresh")
         self.refresh_button.clicked.connect(self.reload_report)
-        self.clear_button = QPushButton(_t("usage_clear", "Clear history"))
-        retranslator.bind(self.clear_button, "usage_clear", "Clear history")
+        self.clear_button = QPushButton()
+        retranslator.bind(self.clear_button, "usage_clear",
+                          "Clear history")
         self.clear_button.clicked.connect(self.clear_history)
-        self.hint_label = QLabel(
-            _t("usage_hint",
-               "This is stored on this machine only and is never sent anywhere. "
-               "Clearing deletes the file itself."))
-        retranslator.bind(self.hint_label, "usage_hint", "This is stored on this machine only and is never sent anywhere. " "Clearing deletes the file itself.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "usage_hint",
+                          "This is stored on this machine only and is never sent anywhere. "
+               "Clearing deletes the file itself.")
         self.hint_label.setWordWrap(True)
 
         self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)

--- a/frontengine/ui/dialog/window_pin_dialog.py
+++ b/frontengine/ui/dialog/window_pin_dialog.py
@@ -37,18 +37,22 @@ class WindowPinDialog(QDialog):
 
         self.window_list = QListWidget()
         self.window_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
-        self.refresh_button = QPushButton(_t("window_pin_refresh", "Refresh"))
-        retranslator.bind(self.refresh_button, "window_pin_refresh", "Refresh")
+        self.refresh_button = QPushButton()
+        retranslator.bind(self.refresh_button, "window_pin_refresh",
+                          "Refresh")
         self.refresh_button.clicked.connect(self.reload_windows)
-        self.pin_button = QPushButton(_t("window_pin_pin", "Keep on top"))
-        retranslator.bind(self.pin_button, "window_pin_pin", "Keep on top")
+        self.pin_button = QPushButton()
+        retranslator.bind(self.pin_button, "window_pin_pin",
+                          "Keep on top")
         self.pin_button.clicked.connect(lambda: self.apply_pin(True))
-        self.unpin_button = QPushButton(_t("window_pin_unpin", "Release"))
-        retranslator.bind(self.unpin_button, "window_pin_unpin", "Release")
+        self.unpin_button = QPushButton()
+        retranslator.bind(self.unpin_button, "window_pin_unpin",
+                          "Release")
         self.unpin_button.clicked.connect(lambda: self.apply_pin(False))
 
-        self.opacity_label = QLabel(_t("window_pin_opacity", "Opacity"))
-        retranslator.bind(self.opacity_label, "window_pin_opacity", "Opacity")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "window_pin_opacity",
+                          "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(window_pin.MIN_OPACITY_PERCENT,
                                      window_pin.MAX_OPACITY_PERCENT)

--- a/frontengine/ui/dialog/window_pin_dialog.py
+++ b/frontengine/ui/dialog/window_pin_dialog.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 from frontengine.utils.window_pin import window_pin
 
 
@@ -37,22 +37,14 @@ class WindowPinDialog(QDialog):
 
         self.window_list = QListWidget()
         self.window_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
-        self.refresh_button = QPushButton()
-        retranslator.bind(self.refresh_button, "window_pin_refresh",
-                          "Refresh")
+        self.refresh_button = tr(QPushButton(), "window_pin_refresh", "Refresh")
         self.refresh_button.clicked.connect(self.reload_windows)
-        self.pin_button = QPushButton()
-        retranslator.bind(self.pin_button, "window_pin_pin",
-                          "Keep on top")
+        self.pin_button = tr(QPushButton(), "window_pin_pin", "Keep on top")
         self.pin_button.clicked.connect(lambda: self.apply_pin(True))
-        self.unpin_button = QPushButton()
-        retranslator.bind(self.unpin_button, "window_pin_unpin",
-                          "Release")
+        self.unpin_button = tr(QPushButton(), "window_pin_unpin", "Release")
         self.unpin_button.clicked.connect(lambda: self.apply_pin(False))
 
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "window_pin_opacity",
-                          "Opacity")
+        self.opacity_label = tr(QLabel(), "window_pin_opacity", "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(window_pin.MIN_OPACITY_PERCENT,
                                      window_pin.MAX_OPACITY_PERCENT)

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -107,9 +107,9 @@ class ControlCenterUI(QWidget):
 
         # 畫質檔位：比省電模式更細，一次套用到所有覆蓋層
         # Quality tier: finer than the low-power switch, applied to every overlay.
-        self.quality_label = QLabel(
-            language_wrapper.language_word_dict.get("control_center_quality", "Quality"))
-        retranslator.bind(self.quality_label, "control_center_quality", "Quality")
+        self.quality_label = QLabel()
+        retranslator.bind(self.quality_label, "control_center_quality",
+                          "Quality")
         self.quality_combobox = QComboBox()
         for tier, key, fallback in (
                 (TIER_HIGH, "control_center_quality_high", "High"),

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -18,7 +18,7 @@ from frontengine.ui.page.web.web_setting_ui import WEBSettingUI
 from frontengine.user_setting.user_setting_file import clear_overlay_geometry
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator, translate
+from frontengine.utils.multi_language.retranslate import retranslator, tr, translate
 from frontengine.utils.screen_privacy import capture_affinity
 from frontengine.utils.power_mode.power_mode import (
     TIER_BALANCED, TIER_HIGH, TIER_SAVER, normalize_tier,
@@ -107,9 +107,7 @@ class ControlCenterUI(QWidget):
 
         # 畫質檔位：比省電模式更細，一次套用到所有覆蓋層
         # Quality tier: finer than the low-power switch, applied to every overlay.
-        self.quality_label = QLabel()
-        retranslator.bind(self.quality_label, "control_center_quality",
-                          "Quality")
+        self.quality_label = tr(QLabel(), "control_center_quality", "Quality")
         self.quality_combobox = QComboBox()
         for tier, key, fallback in (
                 (TIER_HIGH, "control_center_quality_high", "High"),

--- a/frontengine/ui/page/focus/focus_setting_ui.py
+++ b/frontengine/ui/page/focus/focus_setting_ui.py
@@ -21,7 +21,7 @@ from frontengine.utils.focus_shield.focus_shield import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class FocusSettingUI(QWidget):
@@ -37,22 +37,16 @@ class FocusSettingUI(QWidget):
         self.mask_widget_list: List[DistractionMaskWidget] = []
 
         # Dim background windows
-        self.dim_label = QLabel()
-        retranslator.bind(self.dim_label, "focus_dim_label",
-                          "Dim background windows")
+        self.dim_label = tr(QLabel(), "focus_dim_label", "Dim background windows")
         self.dim_slider = QSlider(Qt.Orientation.Horizontal)
         self.dim_slider.setRange(10, 90)
         self.dim_slider.setValue(45)
         self.dim_slider.valueChanged.connect(self._apply_dim_settings)
-        self.dim_button = QPushButton()
-        retranslator.bind(self.dim_button, "focus_dim_start",
-                          "Dim the background")
+        self.dim_button = tr(QPushButton(), "focus_dim_start", "Dim the background")
         self.dim_button.clicked.connect(self.toggle_dim)
 
         # Mask a distraction
-        self.mask_label = QLabel()
-        retranslator.bind(self.mask_label, "focus_mask_label",
-                          "Cover a distraction")
+        self.mask_label = tr(QLabel(), "focus_mask_label", "Cover a distraction")
         self.mask_region_combobox = QComboBox()
         for region, fallback in (
             (REGION_BOTTOM, "Bottom strip (taskbar)"), (REGION_BOTTOM_RIGHT, "Bottom-right corner"),
@@ -67,20 +61,15 @@ class FocusSettingUI(QWidget):
         self.mask_percent_slider.setRange(1, 50)
         self.mask_percent_slider.setValue(6)
         self.mask_percent_slider.valueChanged.connect(self._apply_mask_settings)
-        self.mask_button = QPushButton()
-        retranslator.bind(self.mask_button, "focus_mask_start",
-                          "Cover it up")
+        self.mask_button = tr(QPushButton(), "focus_mask_start", "Cover it up")
         self.mask_button.clicked.connect(self.toggle_mask)
 
         # Shared
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "focus_hint",
-                          "Both overlays pass clicks through — what they cover still works, "
-                "it just stops competing for your attention.")
+        self.hint_label = tr(QLabel(), "focus_hint",
+            "Both overlays pass clicks through — what they cover still works, "
+            "it just stops competing for your attention.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/focus/focus_setting_ui.py
+++ b/frontengine/ui/page/focus/focus_setting_ui.py
@@ -37,22 +37,22 @@ class FocusSettingUI(QWidget):
         self.mask_widget_list: List[DistractionMaskWidget] = []
 
         # Dim background windows
-        self.dim_label = QLabel(
-            language_wrapper.language_word_dict.get("focus_dim_label", "Dim background windows"))
-        retranslator.bind(self.dim_label, "focus_dim_label", "Dim background windows")
+        self.dim_label = QLabel()
+        retranslator.bind(self.dim_label, "focus_dim_label",
+                          "Dim background windows")
         self.dim_slider = QSlider(Qt.Orientation.Horizontal)
         self.dim_slider.setRange(10, 90)
         self.dim_slider.setValue(45)
         self.dim_slider.valueChanged.connect(self._apply_dim_settings)
-        self.dim_button = QPushButton(
-            language_wrapper.language_word_dict.get("focus_dim_start", "Dim the background"))
-        retranslator.bind(self.dim_button, "focus_dim_start", "Dim the background")
+        self.dim_button = QPushButton()
+        retranslator.bind(self.dim_button, "focus_dim_start",
+                          "Dim the background")
         self.dim_button.clicked.connect(self.toggle_dim)
 
         # Mask a distraction
-        self.mask_label = QLabel(
-            language_wrapper.language_word_dict.get("focus_mask_label", "Cover a distraction"))
-        retranslator.bind(self.mask_label, "focus_mask_label", "Cover a distraction")
+        self.mask_label = QLabel()
+        retranslator.bind(self.mask_label, "focus_mask_label",
+                          "Cover a distraction")
         self.mask_region_combobox = QComboBox()
         for region, fallback in (
             (REGION_BOTTOM, "Bottom strip (taskbar)"), (REGION_BOTTOM_RIGHT, "Bottom-right corner"),
@@ -67,22 +67,20 @@ class FocusSettingUI(QWidget):
         self.mask_percent_slider.setRange(1, 50)
         self.mask_percent_slider.setValue(6)
         self.mask_percent_slider.valueChanged.connect(self._apply_mask_settings)
-        self.mask_button = QPushButton(
-            language_wrapper.language_word_dict.get("focus_mask_start", "Cover it up"))
-        retranslator.bind(self.mask_button, "focus_mask_start", "Cover it up")
+        self.mask_button = QPushButton()
+        retranslator.bind(self.mask_button, "focus_mask_start",
+                          "Cover it up")
         self.mask_button.clicked.connect(self.toggle_mask)
 
         # Shared
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "focus_hint",
-                "Both overlays pass clicks through — what they cover still works, "
-                "it just stops competing for your attention."))
-        retranslator.bind(self.hint_label, "focus_hint", "Both overlays pass clicks through — what they cover still works, " "it just stops competing for your attention.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "focus_hint",
+                          "Both overlays pass clicks through — what they cover still works, "
+                "it just stops competing for your attention.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/gif/gif_setting_ui.py
+++ b/frontengine/ui/page/gif/gif_setting_ui.py
@@ -19,7 +19,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class GIFSettingUI(QWidget):
@@ -37,8 +37,7 @@ class GIFSettingUI(QWidget):
         self.gif_image_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -46,8 +45,7 @@ class GIFSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Speed setting
-        self.speed_label = QLabel()
-        retranslator.bind(self.speed_label, "Speed")
+        self.speed_label = tr(QLabel(), "Speed")
         self.speed_slider = QSlider(Qt.Orientation.Horizontal)
         self.speed_slider.setRange(1, 200)
         self.speed_slider.setValue(100)
@@ -55,41 +53,31 @@ class GIFSettingUI(QWidget):
         self.speed_slider.valueChanged.connect(self.speed_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file")
+        self.choose_file_button = tr(QPushButton(), "gif_setting_ui_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_gif_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel()
-        retranslator.bind(self.ready_label, "Not Ready")
+        self.ready_label = tr(QLabel(), "Not Ready")
 
         # Start button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "gif_setting_ui_play")
+        self.start_button = tr(QPushButton(), "gif_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_gif)
 
         # Checkboxes
-        self.fullscreen_checkbox = QCheckBox()
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
+        self.fullscreen_checkbox = tr(QCheckBox(), "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
-        self.show_on_bottom_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
+        self.show_on_bottom_checkbox = tr(QCheckBox(), "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel()
-        retranslator.bind(self.recent_files_label, "recent_files_label",
-                          "Recent")
+        self.recent_files_label = tr(QLabel(), "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("gif")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/gif/gif_setting_ui.py
+++ b/frontengine/ui/page/gif/gif_setting_ui.py
@@ -37,8 +37,8 @@ class GIFSettingUI(QWidget):
         self.gif_image_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -46,8 +46,8 @@ class GIFSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Speed setting
-        self.speed_label = QLabel(language_wrapper.language_word_dict.get("Speed"))
-        retranslator.bind(self.speed_label, "Speed", "")
+        self.speed_label = QLabel()
+        retranslator.bind(self.speed_label, "Speed")
         self.speed_slider = QSlider(Qt.Orientation.Horizontal)
         self.speed_slider.setRange(1, 200)
         self.speed_slider.setValue(100)
@@ -55,41 +55,41 @@ class GIFSettingUI(QWidget):
         self.speed_slider.valueChanged.connect(self.speed_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_choose_file"))
-        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_gif_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
-        retranslator.bind(self.ready_label, "Not Ready", "")
+        self.ready_label = QLabel()
+        retranslator.bind(self.ready_label, "Not Ready")
 
         # Start button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_play"))
-        retranslator.bind(self.start_button, "gif_setting_ui_play", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "gif_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_gif)
 
         # Checkboxes
-        self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
+        self.fullscreen_checkbox = QCheckBox()
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
-        self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
+        self.show_on_bottom_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
-        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
+        self.recent_files_label = QLabel()
+        retranslator.bind(self.recent_files_label, "recent_files_label",
+                          "Recent")
         self.recent_files_combobox = build_recent_combobox("gif")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/image/image_setting_ui.py
+++ b/frontengine/ui/page/image/image_setting_ui.py
@@ -50,8 +50,8 @@ class ImageSettingUI(QWidget):
         self._slideshow_timer.timeout.connect(self._advance_slideshow)
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -59,67 +59,64 @@ class ImageSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
-        retranslator.bind(self.ready_label, "Not Ready", "")
+        self.ready_label = QLabel()
+        retranslator.bind(self.ready_label, "Not Ready")
 
         # Start button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_ui_play"))
-        retranslator.bind(self.start_button, "image_setting_ui_play", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "image_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_image)
 
         # Checkboxes
-        self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
+        self.fullscreen_checkbox = QCheckBox()
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
-        self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
+        self.show_on_bottom_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
-        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
+        self.recent_files_label = QLabel()
+        retranslator.bind(self.recent_files_label, "recent_files_label",
+                          "Recent")
         self.recent_files_combobox = build_recent_combobox("image")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 
         # Slideshow controls
-        self.slideshow_checkbox = QCheckBox(language_wrapper.language_word_dict.get("slideshow_label", "Slideshow"))
-        retranslator.bind(self.slideshow_checkbox, "slideshow_label", "Slideshow")
-        self.slideshow_folder_button = QPushButton(
-            language_wrapper.language_word_dict.get("slideshow_choose_folder", "Choose folder")
-        )
-        retranslator.bind(self.slideshow_folder_button, "slideshow_choose_folder", "Choose folder")
+        self.slideshow_checkbox = QCheckBox()
+        retranslator.bind(self.slideshow_checkbox, "slideshow_label",
+                          "Slideshow")
+        self.slideshow_folder_button = QPushButton()
+        retranslator.bind(self.slideshow_folder_button, "slideshow_choose_folder",
+                          "Choose folder")
         self.slideshow_folder_button.clicked.connect(self.choose_slideshow_folder)
-        self.slideshow_interval_label = QLabel(
-            language_wrapper.language_word_dict.get("slideshow_interval_label", "Interval (s)")
-        )
-        retranslator.bind(self.slideshow_interval_label, "slideshow_interval_label", "Interval (s)")
+        self.slideshow_interval_label = QLabel()
+        retranslator.bind(self.slideshow_interval_label, "slideshow_interval_label",
+                          "Interval (s)")
         self.slideshow_interval_combobox = QComboBox()
         self.slideshow_interval_combobox.addItems(["3", "5", "10", "15", "30", "60"])
         self.slideshow_interval_combobox.setCurrentText("5")
-        self.slideshow_shuffle_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("slideshow_shuffle", "Shuffle")
-        )
-        retranslator.bind(self.slideshow_shuffle_checkbox, "slideshow_shuffle", "Shuffle")
-        self.slideshow_recursive_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("slideshow_recursive", "Include subfolders")
-        )
-        retranslator.bind(self.slideshow_recursive_checkbox, "slideshow_recursive", "Include subfolders")
+        self.slideshow_shuffle_checkbox = QCheckBox()
+        retranslator.bind(self.slideshow_shuffle_checkbox, "slideshow_shuffle",
+                          "Shuffle")
+        self.slideshow_recursive_checkbox = QCheckBox()
+        retranslator.bind(self.slideshow_recursive_checkbox, "slideshow_recursive",
+                          "Include subfolders")
 
         # Accept dropped image files
         self._drop_filter = enable_file_drop(self, _SLIDESHOW_EXTENSIONS, self._on_file_dropped)

--- a/frontengine/ui/page/image/image_setting_ui.py
+++ b/frontengine/ui/page/image/image_setting_ui.py
@@ -25,7 +25,7 @@ from frontengine.utils.logging.loggin_instance import front_engine_logger
 # 輪播支援的圖片副檔名 / Image extensions the slideshow accepts
 _SLIDESHOW_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".bmp")
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class ImageSettingUI(QWidget):
@@ -50,8 +50,7 @@ class ImageSettingUI(QWidget):
         self._slideshow_timer.timeout.connect(self._advance_slideshow)
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -59,64 +58,46 @@ class ImageSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
+        self.choose_file_button = tr(QPushButton(), "image_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel()
-        retranslator.bind(self.ready_label, "Not Ready")
+        self.ready_label = tr(QLabel(), "Not Ready")
 
         # Start button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "image_setting_ui_play")
+        self.start_button = tr(QPushButton(), "image_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_image)
 
         # Checkboxes
-        self.fullscreen_checkbox = QCheckBox()
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
+        self.fullscreen_checkbox = tr(QCheckBox(), "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
-        self.show_on_bottom_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
+        self.show_on_bottom_checkbox = tr(QCheckBox(), "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel()
-        retranslator.bind(self.recent_files_label, "recent_files_label",
-                          "Recent")
+        self.recent_files_label = tr(QLabel(), "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("image")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 
         # Slideshow controls
-        self.slideshow_checkbox = QCheckBox()
-        retranslator.bind(self.slideshow_checkbox, "slideshow_label",
-                          "Slideshow")
-        self.slideshow_folder_button = QPushButton()
-        retranslator.bind(self.slideshow_folder_button, "slideshow_choose_folder",
-                          "Choose folder")
+        self.slideshow_checkbox = tr(QCheckBox(), "slideshow_label", "Slideshow")
+        self.slideshow_folder_button = tr(QPushButton(), "slideshow_choose_folder",
+            "Choose folder")
         self.slideshow_folder_button.clicked.connect(self.choose_slideshow_folder)
-        self.slideshow_interval_label = QLabel()
-        retranslator.bind(self.slideshow_interval_label, "slideshow_interval_label",
-                          "Interval (s)")
+        self.slideshow_interval_label = tr(QLabel(), "slideshow_interval_label", "Interval (s)")
         self.slideshow_interval_combobox = QComboBox()
         self.slideshow_interval_combobox.addItems(["3", "5", "10", "15", "30", "60"])
         self.slideshow_interval_combobox.setCurrentText("5")
-        self.slideshow_shuffle_checkbox = QCheckBox()
-        retranslator.bind(self.slideshow_shuffle_checkbox, "slideshow_shuffle",
-                          "Shuffle")
-        self.slideshow_recursive_checkbox = QCheckBox()
-        retranslator.bind(self.slideshow_recursive_checkbox, "slideshow_recursive",
-                          "Include subfolders")
+        self.slideshow_shuffle_checkbox = tr(QCheckBox(), "slideshow_shuffle", "Shuffle")
+        self.slideshow_recursive_checkbox = tr(QCheckBox(), "slideshow_recursive",
+            "Include subfolders")
 
         # Accept dropped image files
         self._drop_filter = enable_file_drop(self, _SLIDESHOW_EXTENSIONS, self._on_file_dropped)

--- a/frontengine/ui/page/particle/particle_setting_ui.py
+++ b/frontengine/ui/page/particle/particle_setting_ui.py
@@ -36,8 +36,8 @@ class ParticleSettingUI(QWidget):
         self.image_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -45,65 +45,65 @@ class ParticleSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
-        retranslator.bind(self.ready_label, "Not Ready", "")
+        self.ready_label = QLabel()
+        retranslator.bind(self.ready_label, "Not Ready")
 
         # Direction
-        self.choose_direction_label = QLabel(language_wrapper.language_word_dict.get("choose_particle_direction"))
-        retranslator.bind(self.choose_direction_label, "choose_particle_direction", "")
+        self.choose_direction_label = QLabel()
+        retranslator.bind(self.choose_direction_label, "choose_particle_direction")
         self.choose_direction_combobox = QComboBox()
         self.choose_direction_combobox.addItems(
             ["down", "up", "left", "right"]
         )
 
         # Particle size
-        self.particle_size_label = QLabel(language_wrapper.language_word_dict.get("particle_size"))
-        retranslator.bind(self.particle_size_label, "particle_size", "")
+        self.particle_size_label = QLabel()
+        retranslator.bind(self.particle_size_label, "particle_size")
         self.particle_size_combobox = QComboBox()
         for size in range(10, 310, 10):
             self.particle_size_combobox.addItem(str(size))
         self.particle_size_combobox.setCurrentText("50")
 
         # Particle count
-        self.particle_count_label = QLabel(language_wrapper.language_word_dict.get("particle_count"))
-        retranslator.bind(self.particle_count_label, "particle_count", "")
+        self.particle_count_label = QLabel()
+        retranslator.bind(self.particle_count_label, "particle_count")
         self.particle_count_combobox = QComboBox()
         for count in range(50, 10010, 10):
             self.particle_count_combobox.addItem(str(count))
         self.particle_count_combobox.setCurrentText("100")
 
         # Particle speed
-        self.particle_speed_label = QLabel(language_wrapper.language_word_dict.get("particle_speed"))
-        retranslator.bind(self.particle_speed_label, "particle_speed", "")
+        self.particle_speed_label = QLabel()
+        retranslator.bind(self.particle_speed_label, "particle_speed")
         self.particle_speed_combobox = QComboBox()
         for speed in range(3, 11):
             self.particle_speed_combobox.addItem(str(speed / 1000))
 
         # Start button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("particle_setting_ui_play"))
-        retranslator.bind(self.start_button, "particle_setting_ui_play", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "particle_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_particle)
 
         # Checkboxes
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
-        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
+        self.recent_files_label = QLabel()
+        retranslator.bind(self.recent_files_label, "recent_files_label",
+                          "Recent")
         self.recent_files_combobox = build_recent_combobox("particle")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/particle/particle_setting_ui.py
+++ b/frontengine/ui/page/particle/particle_setting_ui.py
@@ -18,7 +18,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class ParticleSettingUI(QWidget):
@@ -36,8 +36,7 @@ class ParticleSettingUI(QWidget):
         self.image_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -45,65 +44,53 @@ class ParticleSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Choose file button
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
+        self.choose_file_button = tr(QPushButton(), "image_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_image_dir_then_play)
 
         # Ready label
-        self.ready_label = QLabel()
-        retranslator.bind(self.ready_label, "Not Ready")
+        self.ready_label = tr(QLabel(), "Not Ready")
 
         # Direction
-        self.choose_direction_label = QLabel()
-        retranslator.bind(self.choose_direction_label, "choose_particle_direction")
+        self.choose_direction_label = tr(QLabel(), "choose_particle_direction")
         self.choose_direction_combobox = QComboBox()
         self.choose_direction_combobox.addItems(
             ["down", "up", "left", "right"]
         )
 
         # Particle size
-        self.particle_size_label = QLabel()
-        retranslator.bind(self.particle_size_label, "particle_size")
+        self.particle_size_label = tr(QLabel(), "particle_size")
         self.particle_size_combobox = QComboBox()
         for size in range(10, 310, 10):
             self.particle_size_combobox.addItem(str(size))
         self.particle_size_combobox.setCurrentText("50")
 
         # Particle count
-        self.particle_count_label = QLabel()
-        retranslator.bind(self.particle_count_label, "particle_count")
+        self.particle_count_label = tr(QLabel(), "particle_count")
         self.particle_count_combobox = QComboBox()
         for count in range(50, 10010, 10):
             self.particle_count_combobox.addItem(str(count))
         self.particle_count_combobox.setCurrentText("100")
 
         # Particle speed
-        self.particle_speed_label = QLabel()
-        retranslator.bind(self.particle_speed_label, "particle_speed")
+        self.particle_speed_label = tr(QLabel(), "particle_speed")
         self.particle_speed_combobox = QComboBox()
         for speed in range(3, 11):
             self.particle_speed_combobox.addItem(str(speed / 1000))
 
         # Start button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "particle_setting_ui_play")
+        self.start_button = tr(QPushButton(), "particle_setting_ui_play")
         self.start_button.clicked.connect(self.start_play_particle)
 
         # Checkboxes
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel()
-        retranslator.bind(self.recent_files_label, "recent_files_label",
-                          "Recent")
+        self.recent_files_label = tr(QLabel(), "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("particle")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -67,41 +67,41 @@ class PetSettingUI(QWidget):
         self._chat_service = None
 
         # Choose file
-        self.choose_file_button = QPushButton(
-            language_wrapper.language_word_dict.get("pet_choose_file", "Choose pet sprite")
-        )
-        retranslator.bind(self.choose_file_button, "pet_choose_file", "Choose pet sprite")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "pet_choose_file",
+                          "Choose pet sprite")
         self.choose_file_button.clicked.connect(self.choose_and_play)
-        self.choose_pack_button = QPushButton(
-            language_wrapper.language_word_dict.get("pet_choose_pack", _CHOOSE_PACK)
-        )
-        retranslator.bind(self.choose_pack_button, "pet_choose_pack", _CHOOSE_PACK)
+        self.choose_pack_button = QPushButton()
+        retranslator.bind(self.choose_pack_button, "pet_choose_pack",
+                          _CHOOSE_PACK)
         self.choose_pack_button.clicked.connect(self.choose_pack)
-        self.choose_sound_button = QPushButton(
-            language_wrapper.language_word_dict.get("pet_choose_sound", "Choose sound (optional)")
-        )
-        retranslator.bind(self.choose_sound_button, "pet_choose_sound", "Choose sound (optional)")
+        self.choose_sound_button = QPushButton()
+        retranslator.bind(self.choose_sound_button, "pet_choose_sound",
+                          "Choose sound (optional)")
         self.choose_sound_button.clicked.connect(self.choose_sound)
-        self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
-        retranslator.bind(self.ready_label, "Not Ready", "")
+        self.ready_label = QLabel()
+        retranslator.bind(self.ready_label, "Not Ready")
 
         # Size
-        self.size_label = QLabel(language_wrapper.language_word_dict.get("pet_size_label", "Size"))
-        retranslator.bind(self.size_label, "pet_size_label", "Size")
+        self.size_label = QLabel()
+        retranslator.bind(self.size_label, "pet_size_label",
+                          "Size")
         self.size_combobox = QComboBox()
         self.size_combobox.addItems(["64", "96", "128", "192", "256"])
         self.size_combobox.setCurrentText("128")
 
         # Speed
-        self.speed_label = QLabel(language_wrapper.language_word_dict.get("pet_speed_label", "Speed"))
-        retranslator.bind(self.speed_label, "pet_speed_label", "Speed")
+        self.speed_label = QLabel()
+        retranslator.bind(self.speed_label, "pet_speed_label",
+                          "Speed")
         self.speed_combobox = QComboBox()
         self.speed_combobox.addItems([str(n) for n in range(1, 11)])
         self.speed_combobox.setCurrentText("3")
 
         # Behaviour
-        self.behaviour_label = QLabel(language_wrapper.language_word_dict.get("pet_behaviour_label", "Behaviour"))
-        retranslator.bind(self.behaviour_label, "pet_behaviour_label", "Behaviour")
+        self.behaviour_label = QLabel()
+        retranslator.bind(self.behaviour_label, "pet_behaviour_label",
+                          "Behaviour")
         self.behaviour_combobox = QComboBox()
         self.behaviour_combobox.addItem(
             language_wrapper.language_word_dict.get("pet_behaviour_floor", "Walk on floor"), BEHAVIOUR_FLOOR)
@@ -111,52 +111,56 @@ class PetSettingUI(QWidget):
             language_wrapper.language_word_dict.get("pet_behaviour_chase", "Chase cursor"), BEHAVIOUR_CHASE)
 
         # Climb walls / ceiling (only meaningful in floor mode)
-        self.climb_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_climb_label", "Climb walls"))
-        retranslator.bind(self.climb_checkbox, "pet_climb_label", "Climb walls")
+        self.climb_checkbox = QCheckBox()
+        retranslator.bind(self.climb_checkbox, "pet_climb_label",
+                          "Climb walls")
         self.climb_checkbox.setChecked(True)
-        self.talk_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_talk_label", "Speech bubbles"))
-        retranslator.bind(self.talk_checkbox, "pet_talk_label", "Speech bubbles")
+        self.talk_checkbox = QCheckBox()
+        retranslator.bind(self.talk_checkbox, "pet_talk_label",
+                          "Speech bubbles")
         self.talk_checkbox.setChecked(True)
-        self.sit_checkbox = QCheckBox(language_wrapper.language_word_dict.get("pet_sit_label", "Sit on windows"))
-        retranslator.bind(self.sit_checkbox, "pet_sit_label", "Sit on windows")
+        self.sit_checkbox = QCheckBox()
+        retranslator.bind(self.sit_checkbox, "pet_sit_label",
+                          "Sit on windows")
         self.sit_checkbox.setChecked(True)
-        self.tag_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("pet_tag_label", "Play tag with each other"))
-        retranslator.bind(self.tag_checkbox, "pet_tag_label", "Play tag with each other")
+        self.tag_checkbox = QCheckBox()
+        retranslator.bind(self.tag_checkbox, "pet_tag_label",
+                          "Play tag with each other")
         self.tag_checkbox.toggled.connect(self._on_tag_toggled)
-        self.speech_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("pet_speech_label", "Speak out loud"))
-        retranslator.bind(self.speech_checkbox, "pet_speech_label", "Speak out loud")
-        self.chat_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("pet_chat_label", "AI chat (needs API key)"))
-        retranslator.bind(self.chat_checkbox, "pet_chat_label", "AI chat (needs API key)")
+        self.speech_checkbox = QCheckBox()
+        retranslator.bind(self.speech_checkbox, "pet_speech_label",
+                          "Speak out loud")
+        self.chat_checkbox = QCheckBox()
+        retranslator.bind(self.chat_checkbox, "pet_chat_label",
+                          "AI chat (needs API key)")
         self.chat_checkbox.setToolTip(
             language_wrapper.language_word_dict.get(
                 "pet_chat_hint",
                 "Reads the ANTHROPIC_API_KEY environment variable; the key is never stored."))
 
         # Focus timer (pomodoro) controls
-        self.focus_label = QLabel(
-            language_wrapper.language_word_dict.get("pet_focus_label", "Focus timer (min)"))
-        retranslator.bind(self.focus_label, "pet_focus_label", "Focus timer (min)")
+        self.focus_label = QLabel()
+        retranslator.bind(self.focus_label, "pet_focus_label",
+                          "Focus timer (min)")
         self.focus_minutes_combobox = QComboBox()
         self.focus_minutes_combobox.addItems(["15", "20", "25", "30", "45", "50"])
         self.focus_minutes_combobox.setCurrentText("25")
         self.break_minutes_combobox = QComboBox()
         self.break_minutes_combobox.addItems(["3", "5", "10", "15"])
         self.break_minutes_combobox.setCurrentText("5")
-        self.focus_button = QPushButton(
-            language_wrapper.language_word_dict.get("pet_focus_start", "Start focus"))
-        retranslator.bind(self.focus_button, "pet_focus_start", "Start focus")
+        self.focus_button = QPushButton()
+        retranslator.bind(self.focus_button, "pet_focus_start",
+                          "Start focus")
         self.focus_button.clicked.connect(self.toggle_focus_session)
 
         # Target monitor + sound volume
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.volume_label = QLabel(language_wrapper.language_word_dict.get("pet_volume_label", "Volume"))
-        retranslator.bind(self.volume_label, "pet_volume_label", "Volume")
+        self.volume_label = QLabel()
+        retranslator.bind(self.volume_label, "pet_volume_label",
+                          "Volume")
         self.volume_combobox = QComboBox()
         for label, value in (("0%", 0), ("25%", 25), ("50%", 50), ("75%", 75), ("100%", 100)):
             self.volume_combobox.addItem(label, value)
@@ -167,25 +171,25 @@ class PetSettingUI(QWidget):
         self.audio_source_combobox.addItem(
             language_wrapper.language_word_dict.get("pet_audio_microphone", "Microphone"),
             "microphone")
-        self.audio_react_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("pet_audio_label", "React to audio"))
-        retranslator.bind(self.audio_react_checkbox, "pet_audio_label", "React to audio")
-        self.drop_hint_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "pet_drop_hint",
-                "Tip: drop an image or pet pack onto the pet to change its look, "
-                "or any other file to feed it."))
-        retranslator.bind(self.drop_hint_label, "pet_drop_hint", "Tip: drop an image or pet pack onto the pet to change its look, " "or any other file to feed it.")
+        self.audio_react_checkbox = QCheckBox()
+        retranslator.bind(self.audio_react_checkbox, "pet_audio_label",
+                          "React to audio")
+        self.drop_hint_label = QLabel()
+        retranslator.bind(self.drop_hint_label, "pet_drop_hint",
+                          "Tip: drop an image or pet pack onto the pet to change its look, "
+                "or any other file to feed it.")
         self.drop_hint_label.setWordWrap(True)
 
         # Start
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("pet_start", "Spawn pet"))
-        retranslator.bind(self.start_button, "pet_start", "Spawn pet")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "pet_start",
+                          "Spawn pet")
         self.start_button.clicked.connect(self.start_play_pet)
 
         # Recent files
-        self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
-        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
+        self.recent_files_label = QLabel()
+        retranslator.bind(self.recent_files_label, "recent_files_label",
+                          "Recent")
         self.recent_files_combobox = build_recent_combobox("pet")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -29,7 +29,7 @@ from frontengine.utils.focus_timer.focus_timer import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 _PET_EXTENSIONS = (".gif", ".webp", ".png", ".jpg")
 
@@ -67,41 +67,28 @@ class PetSettingUI(QWidget):
         self._chat_service = None
 
         # Choose file
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "pet_choose_file",
-                          "Choose pet sprite")
+        self.choose_file_button = tr(QPushButton(), "pet_choose_file", "Choose pet sprite")
         self.choose_file_button.clicked.connect(self.choose_and_play)
-        self.choose_pack_button = QPushButton()
-        retranslator.bind(self.choose_pack_button, "pet_choose_pack",
-                          _CHOOSE_PACK)
+        self.choose_pack_button = tr(QPushButton(), "pet_choose_pack", _CHOOSE_PACK)
         self.choose_pack_button.clicked.connect(self.choose_pack)
-        self.choose_sound_button = QPushButton()
-        retranslator.bind(self.choose_sound_button, "pet_choose_sound",
-                          "Choose sound (optional)")
+        self.choose_sound_button = tr(QPushButton(), "pet_choose_sound", "Choose sound (optional)")
         self.choose_sound_button.clicked.connect(self.choose_sound)
-        self.ready_label = QLabel()
-        retranslator.bind(self.ready_label, "Not Ready")
+        self.ready_label = tr(QLabel(), "Not Ready")
 
         # Size
-        self.size_label = QLabel()
-        retranslator.bind(self.size_label, "pet_size_label",
-                          "Size")
+        self.size_label = tr(QLabel(), "pet_size_label", "Size")
         self.size_combobox = QComboBox()
         self.size_combobox.addItems(["64", "96", "128", "192", "256"])
         self.size_combobox.setCurrentText("128")
 
         # Speed
-        self.speed_label = QLabel()
-        retranslator.bind(self.speed_label, "pet_speed_label",
-                          "Speed")
+        self.speed_label = tr(QLabel(), "pet_speed_label", "Speed")
         self.speed_combobox = QComboBox()
         self.speed_combobox.addItems([str(n) for n in range(1, 11)])
         self.speed_combobox.setCurrentText("3")
 
         # Behaviour
-        self.behaviour_label = QLabel()
-        retranslator.bind(self.behaviour_label, "pet_behaviour_label",
-                          "Behaviour")
+        self.behaviour_label = tr(QLabel(), "pet_behaviour_label", "Behaviour")
         self.behaviour_combobox = QComboBox()
         self.behaviour_combobox.addItem(
             language_wrapper.language_word_dict.get("pet_behaviour_floor", "Walk on floor"), BEHAVIOUR_FLOOR)
@@ -111,56 +98,36 @@ class PetSettingUI(QWidget):
             language_wrapper.language_word_dict.get("pet_behaviour_chase", "Chase cursor"), BEHAVIOUR_CHASE)
 
         # Climb walls / ceiling (only meaningful in floor mode)
-        self.climb_checkbox = QCheckBox()
-        retranslator.bind(self.climb_checkbox, "pet_climb_label",
-                          "Climb walls")
+        self.climb_checkbox = tr(QCheckBox(), "pet_climb_label", "Climb walls")
         self.climb_checkbox.setChecked(True)
-        self.talk_checkbox = QCheckBox()
-        retranslator.bind(self.talk_checkbox, "pet_talk_label",
-                          "Speech bubbles")
+        self.talk_checkbox = tr(QCheckBox(), "pet_talk_label", "Speech bubbles")
         self.talk_checkbox.setChecked(True)
-        self.sit_checkbox = QCheckBox()
-        retranslator.bind(self.sit_checkbox, "pet_sit_label",
-                          "Sit on windows")
+        self.sit_checkbox = tr(QCheckBox(), "pet_sit_label", "Sit on windows")
         self.sit_checkbox.setChecked(True)
-        self.tag_checkbox = QCheckBox()
-        retranslator.bind(self.tag_checkbox, "pet_tag_label",
-                          "Play tag with each other")
+        self.tag_checkbox = tr(QCheckBox(), "pet_tag_label", "Play tag with each other")
         self.tag_checkbox.toggled.connect(self._on_tag_toggled)
-        self.speech_checkbox = QCheckBox()
-        retranslator.bind(self.speech_checkbox, "pet_speech_label",
-                          "Speak out loud")
-        self.chat_checkbox = QCheckBox()
-        retranslator.bind(self.chat_checkbox, "pet_chat_label",
-                          "AI chat (needs API key)")
+        self.speech_checkbox = tr(QCheckBox(), "pet_speech_label", "Speak out loud")
+        self.chat_checkbox = tr(QCheckBox(), "pet_chat_label", "AI chat (needs API key)")
         self.chat_checkbox.setToolTip(
             language_wrapper.language_word_dict.get(
                 "pet_chat_hint",
                 "Reads the ANTHROPIC_API_KEY environment variable; the key is never stored."))
 
         # Focus timer (pomodoro) controls
-        self.focus_label = QLabel()
-        retranslator.bind(self.focus_label, "pet_focus_label",
-                          "Focus timer (min)")
+        self.focus_label = tr(QLabel(), "pet_focus_label", "Focus timer (min)")
         self.focus_minutes_combobox = QComboBox()
         self.focus_minutes_combobox.addItems(["15", "20", "25", "30", "45", "50"])
         self.focus_minutes_combobox.setCurrentText("25")
         self.break_minutes_combobox = QComboBox()
         self.break_minutes_combobox.addItems(["3", "5", "10", "15"])
         self.break_minutes_combobox.setCurrentText("5")
-        self.focus_button = QPushButton()
-        retranslator.bind(self.focus_button, "pet_focus_start",
-                          "Start focus")
+        self.focus_button = tr(QPushButton(), "pet_focus_start", "Start focus")
         self.focus_button.clicked.connect(self.toggle_focus_session)
 
         # Target monitor + sound volume
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.volume_label = QLabel()
-        retranslator.bind(self.volume_label, "pet_volume_label",
-                          "Volume")
+        self.volume_label = tr(QLabel(), "pet_volume_label", "Volume")
         self.volume_combobox = QComboBox()
         for label, value in (("0%", 0), ("25%", 25), ("50%", 50), ("75%", 75), ("100%", 100)):
             self.volume_combobox.addItem(label, value)
@@ -171,25 +138,18 @@ class PetSettingUI(QWidget):
         self.audio_source_combobox.addItem(
             language_wrapper.language_word_dict.get("pet_audio_microphone", "Microphone"),
             "microphone")
-        self.audio_react_checkbox = QCheckBox()
-        retranslator.bind(self.audio_react_checkbox, "pet_audio_label",
-                          "React to audio")
-        self.drop_hint_label = QLabel()
-        retranslator.bind(self.drop_hint_label, "pet_drop_hint",
-                          "Tip: drop an image or pet pack onto the pet to change its look, "
-                "or any other file to feed it.")
+        self.audio_react_checkbox = tr(QCheckBox(), "pet_audio_label", "React to audio")
+        self.drop_hint_label = tr(QLabel(), "pet_drop_hint",
+            "Tip: drop an image or pet pack onto the pet to change its look, "
+            "or any other file to feed it.")
         self.drop_hint_label.setWordWrap(True)
 
         # Start
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "pet_start",
-                          "Spawn pet")
+        self.start_button = tr(QPushButton(), "pet_start", "Spawn pet")
         self.start_button.clicked.connect(self.start_play_pet)
 
         # Recent files
-        self.recent_files_label = QLabel()
-        retranslator.bind(self.recent_files_label, "recent_files_label",
-                          "Recent")
+        self.recent_files_label = tr(QLabel(), "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("pet")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -50,9 +50,9 @@ class PresentationSettingUI(QWidget):
         self.input_watch.mouse_clicked.connect(self._on_mouse_clicked, Qt.ConnectionType.QueuedConnection)
 
         # Annotation
-        self.annotate_label = QLabel(
-            language_wrapper.language_word_dict.get("annotate_label", "Screen annotation"))
-        retranslator.bind(self.annotate_label, "annotate_label", "Screen annotation")
+        self.annotate_label = QLabel()
+        retranslator.bind(self.annotate_label, "annotate_label",
+                          "Screen annotation")
         self.annotate_tool_combobox = QComboBox()
         for tool, fallback in ((TOOL_PEN, "Pen"), (TOOL_HIGHLIGHTER, "Highlighter"),
                                (TOOL_ERASER, "Eraser")):
@@ -67,82 +67,80 @@ class PresentationSettingUI(QWidget):
         self.annotate_width_slider.setRange(1, 40)
         self.annotate_width_slider.setValue(4)
         self.annotate_width_slider.valueChanged.connect(self._apply_annotation_settings)
-        self.annotate_button = QPushButton(
-            language_wrapper.language_word_dict.get("annotate_start", "Start drawing"))
-        retranslator.bind(self.annotate_button, "annotate_start", "Start drawing")
+        self.annotate_button = QPushButton()
+        retranslator.bind(self.annotate_button, "annotate_start",
+                          "Start drawing")
         self.annotate_button.clicked.connect(self.toggle_annotation)
-        self.annotate_undo_button = QPushButton(
-            language_wrapper.language_word_dict.get("annotate_undo", "Undo"))
-        retranslator.bind(self.annotate_undo_button, "annotate_undo", "Undo")
+        self.annotate_undo_button = QPushButton()
+        retranslator.bind(self.annotate_undo_button, "annotate_undo",
+                          "Undo")
         self.annotate_undo_button.clicked.connect(self.undo_annotation)
-        self.annotate_clear_button = QPushButton(
-            language_wrapper.language_word_dict.get("annotate_clear", "Clear"))
-        retranslator.bind(self.annotate_clear_button, "annotate_clear", "Clear")
+        self.annotate_clear_button = QPushButton()
+        retranslator.bind(self.annotate_clear_button, "annotate_clear",
+                          "Clear")
         self.annotate_clear_button.clicked.connect(self.clear_annotation)
 
         # Cursor effects
-        self.cursor_label = QLabel(
-            language_wrapper.language_word_dict.get("cursor_effect_label", "Cursor emphasis"))
-        retranslator.bind(self.cursor_label, "cursor_effect_label", "Cursor emphasis")
-        self.cursor_ring_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("cursor_effect_ring", "Highlight"))
-        retranslator.bind(self.cursor_ring_checkbox, "cursor_effect_ring", "Highlight")
+        self.cursor_label = QLabel()
+        retranslator.bind(self.cursor_label, "cursor_effect_label",
+                          "Cursor emphasis")
+        self.cursor_ring_checkbox = QCheckBox()
+        retranslator.bind(self.cursor_ring_checkbox, "cursor_effect_ring",
+                          "Highlight")
         self.cursor_ring_checkbox.setChecked(True)
-        self.cursor_ripple_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("cursor_effect_ripple", "Click ripple"))
-        retranslator.bind(self.cursor_ripple_checkbox, "cursor_effect_ripple", "Click ripple")
+        self.cursor_ripple_checkbox = QCheckBox()
+        retranslator.bind(self.cursor_ripple_checkbox, "cursor_effect_ripple",
+                          "Click ripple")
         self.cursor_ripple_checkbox.setChecked(True)
-        self.cursor_spotlight_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("cursor_effect_spotlight", "Spotlight"))
-        retranslator.bind(self.cursor_spotlight_checkbox, "cursor_effect_spotlight", "Spotlight")
+        self.cursor_spotlight_checkbox = QCheckBox()
+        retranslator.bind(self.cursor_spotlight_checkbox, "cursor_effect_spotlight",
+                          "Spotlight")
         for checkbox in (self.cursor_ring_checkbox, self.cursor_ripple_checkbox,
                          self.cursor_spotlight_checkbox):
             checkbox.toggled.connect(self._apply_cursor_settings)
-        self.cursor_button = QPushButton(
-            language_wrapper.language_word_dict.get("cursor_effect_start", "Turn cursor effects on"))
-        retranslator.bind(self.cursor_button, "cursor_effect_start", "Turn cursor effects on")
+        self.cursor_button = QPushButton()
+        retranslator.bind(self.cursor_button, "cursor_effect_start",
+                          "Turn cursor effects on")
         self.cursor_button.clicked.connect(self.toggle_cursor_effects)
 
         # Keystroke display
-        self.keystroke_label = QLabel(
-            language_wrapper.language_word_dict.get("keystroke_label", "Keystroke display"))
-        retranslator.bind(self.keystroke_label, "keystroke_label", "Keystroke display")
-        self.keystroke_button = QPushButton(
-            language_wrapper.language_word_dict.get("keystroke_start", "Show keystrokes"))
-        retranslator.bind(self.keystroke_button, "keystroke_start", "Show keystrokes")
+        self.keystroke_label = QLabel()
+        retranslator.bind(self.keystroke_label, "keystroke_label",
+                          "Keystroke display")
+        self.keystroke_button = QPushButton()
+        retranslator.bind(self.keystroke_button, "keystroke_start",
+                          "Show keystrokes")
         self.keystroke_button.clicked.connect(self.toggle_keystrokes)
 
         # Magnifier
-        self.magnifier_label = QLabel(
-            language_wrapper.language_word_dict.get("magnifier_label", "Magnifier"))
-        retranslator.bind(self.magnifier_label, "magnifier_label", "Magnifier")
+        self.magnifier_label = QLabel()
+        retranslator.bind(self.magnifier_label, "magnifier_label",
+                          "Magnifier")
         self.magnifier_zoom_combobox = QComboBox()
         self.magnifier_zoom_combobox.addItems(["1.5", "2.0", "3.0", "4.0", "6.0"])
         self.magnifier_zoom_combobox.setCurrentText("2.0")
         self.magnifier_zoom_combobox.currentIndexChanged.connect(self._apply_magnifier_settings)
-        self.magnifier_button = QPushButton(
-            language_wrapper.language_word_dict.get("magnifier_start", "Turn magnifier on"))
-        retranslator.bind(self.magnifier_button, "magnifier_start", "Turn magnifier on")
+        self.magnifier_button = QPushButton()
+        retranslator.bind(self.magnifier_button, "magnifier_start",
+                          "Turn magnifier on")
         self.magnifier_button.clicked.connect(self.toggle_magnifier)
 
         # Shared
-        self.whiteboard_button = QPushButton(
-            language_wrapper.language_word_dict.get("whiteboard_start", "Whiteboard"))
-        retranslator.bind(self.whiteboard_button, "whiteboard_start", "Whiteboard")
+        self.whiteboard_button = QPushButton()
+        retranslator.bind(self.whiteboard_button, "whiteboard_start",
+                          "Whiteboard")
         self.whiteboard_button.clicked.connect(self.toggle_whiteboard)
-        self.whiteboard_save_button = QPushButton(
-            language_wrapper.language_word_dict.get("whiteboard_save", "Save whiteboard"))
-        retranslator.bind(self.whiteboard_save_button, "whiteboard_save", "Save whiteboard")
+        self.whiteboard_save_button = QPushButton()
+        retranslator.bind(self.whiteboard_save_button, "whiteboard_save",
+                          "Save whiteboard")
         self.whiteboard_save_button.clicked.connect(self.save_whiteboard)
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "presentation_hint",
-                "Drawing takes the mouse while it is on; the other overlays pass clicks through."))
-        retranslator.bind(self.hint_label, "presentation_hint", "Drawing takes the mouse while it is on; the other overlays pass clicks through.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "presentation_hint",
+                          "Drawing takes the mouse while it is on; the other overlays pass clicks through.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -26,7 +26,7 @@ from frontengine.ui.page.utils import build_target_monitor_combobox, coerce_int,
 from frontengine.utils.input_watch.input_watch_service import InputWatchService
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class PresentationSettingUI(QWidget):
@@ -50,9 +50,7 @@ class PresentationSettingUI(QWidget):
         self.input_watch.mouse_clicked.connect(self._on_mouse_clicked, Qt.ConnectionType.QueuedConnection)
 
         # Annotation
-        self.annotate_label = QLabel()
-        retranslator.bind(self.annotate_label, "annotate_label",
-                          "Screen annotation")
+        self.annotate_label = tr(QLabel(), "annotate_label", "Screen annotation")
         self.annotate_tool_combobox = QComboBox()
         for tool, fallback in ((TOOL_PEN, "Pen"), (TOOL_HIGHLIGHTER, "Highlighter"),
                                (TOOL_ERASER, "Eraser")):
@@ -67,80 +65,49 @@ class PresentationSettingUI(QWidget):
         self.annotate_width_slider.setRange(1, 40)
         self.annotate_width_slider.setValue(4)
         self.annotate_width_slider.valueChanged.connect(self._apply_annotation_settings)
-        self.annotate_button = QPushButton()
-        retranslator.bind(self.annotate_button, "annotate_start",
-                          "Start drawing")
+        self.annotate_button = tr(QPushButton(), "annotate_start", "Start drawing")
         self.annotate_button.clicked.connect(self.toggle_annotation)
-        self.annotate_undo_button = QPushButton()
-        retranslator.bind(self.annotate_undo_button, "annotate_undo",
-                          "Undo")
+        self.annotate_undo_button = tr(QPushButton(), "annotate_undo", "Undo")
         self.annotate_undo_button.clicked.connect(self.undo_annotation)
-        self.annotate_clear_button = QPushButton()
-        retranslator.bind(self.annotate_clear_button, "annotate_clear",
-                          "Clear")
+        self.annotate_clear_button = tr(QPushButton(), "annotate_clear", "Clear")
         self.annotate_clear_button.clicked.connect(self.clear_annotation)
 
         # Cursor effects
-        self.cursor_label = QLabel()
-        retranslator.bind(self.cursor_label, "cursor_effect_label",
-                          "Cursor emphasis")
-        self.cursor_ring_checkbox = QCheckBox()
-        retranslator.bind(self.cursor_ring_checkbox, "cursor_effect_ring",
-                          "Highlight")
+        self.cursor_label = tr(QLabel(), "cursor_effect_label", "Cursor emphasis")
+        self.cursor_ring_checkbox = tr(QCheckBox(), "cursor_effect_ring", "Highlight")
         self.cursor_ring_checkbox.setChecked(True)
-        self.cursor_ripple_checkbox = QCheckBox()
-        retranslator.bind(self.cursor_ripple_checkbox, "cursor_effect_ripple",
-                          "Click ripple")
+        self.cursor_ripple_checkbox = tr(QCheckBox(), "cursor_effect_ripple", "Click ripple")
         self.cursor_ripple_checkbox.setChecked(True)
-        self.cursor_spotlight_checkbox = QCheckBox()
-        retranslator.bind(self.cursor_spotlight_checkbox, "cursor_effect_spotlight",
-                          "Spotlight")
+        self.cursor_spotlight_checkbox = tr(QCheckBox(), "cursor_effect_spotlight", "Spotlight")
         for checkbox in (self.cursor_ring_checkbox, self.cursor_ripple_checkbox,
                          self.cursor_spotlight_checkbox):
             checkbox.toggled.connect(self._apply_cursor_settings)
-        self.cursor_button = QPushButton()
-        retranslator.bind(self.cursor_button, "cursor_effect_start",
-                          "Turn cursor effects on")
+        self.cursor_button = tr(QPushButton(), "cursor_effect_start", "Turn cursor effects on")
         self.cursor_button.clicked.connect(self.toggle_cursor_effects)
 
         # Keystroke display
-        self.keystroke_label = QLabel()
-        retranslator.bind(self.keystroke_label, "keystroke_label",
-                          "Keystroke display")
-        self.keystroke_button = QPushButton()
-        retranslator.bind(self.keystroke_button, "keystroke_start",
-                          "Show keystrokes")
+        self.keystroke_label = tr(QLabel(), "keystroke_label", "Keystroke display")
+        self.keystroke_button = tr(QPushButton(), "keystroke_start", "Show keystrokes")
         self.keystroke_button.clicked.connect(self.toggle_keystrokes)
 
         # Magnifier
-        self.magnifier_label = QLabel()
-        retranslator.bind(self.magnifier_label, "magnifier_label",
-                          "Magnifier")
+        self.magnifier_label = tr(QLabel(), "magnifier_label", "Magnifier")
         self.magnifier_zoom_combobox = QComboBox()
         self.magnifier_zoom_combobox.addItems(["1.5", "2.0", "3.0", "4.0", "6.0"])
         self.magnifier_zoom_combobox.setCurrentText("2.0")
         self.magnifier_zoom_combobox.currentIndexChanged.connect(self._apply_magnifier_settings)
-        self.magnifier_button = QPushButton()
-        retranslator.bind(self.magnifier_button, "magnifier_start",
-                          "Turn magnifier on")
+        self.magnifier_button = tr(QPushButton(), "magnifier_start", "Turn magnifier on")
         self.magnifier_button.clicked.connect(self.toggle_magnifier)
 
         # Shared
-        self.whiteboard_button = QPushButton()
-        retranslator.bind(self.whiteboard_button, "whiteboard_start",
-                          "Whiteboard")
+        self.whiteboard_button = tr(QPushButton(), "whiteboard_start", "Whiteboard")
         self.whiteboard_button.clicked.connect(self.toggle_whiteboard)
-        self.whiteboard_save_button = QPushButton()
-        retranslator.bind(self.whiteboard_save_button, "whiteboard_save",
-                          "Save whiteboard")
+        self.whiteboard_save_button = tr(QPushButton(), "whiteboard_save", "Save whiteboard")
         self.whiteboard_save_button.clicked.connect(self.save_whiteboard)
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "presentation_hint",
-                          "Drawing takes the mouse while it is on; the other overlays pass clicks through.")
+        self.hint_label = tr(QLabel(), "presentation_hint",
+            "Drawing takes the mouse while it is on; the other overlays pass clicks through.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/scene_setting/scene_manager.py
+++ b/frontengine/ui/page/scene_setting/scene_manager.py
@@ -8,7 +8,6 @@ from frontengine.show.scene.extend_graphic_view import ExtendGraphicView
 from frontengine.ui.page.utils import create_monitor_selection_dialog
 from frontengine.user_setting.scene_setting import choose_scene_json, write_scene_file, scene_json
 from frontengine.utils.logging.loggin_instance import front_engine_logger
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -23,12 +22,12 @@ class SceneManagerUI(QWidget):
         self.show_all_screen = False
 
         # Read and write scene json button
-        self.read_scene_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_input"))
-        retranslator.bind(self.read_scene_json_button, "scene_input", "")
+        self.read_scene_json_button = QPushButton()
+        retranslator.bind(self.read_scene_json_button, "scene_input")
         self.read_scene_json_button.clicked.connect(self.update_scene_json)
 
-        self.write_scene_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_output"))
-        retranslator.bind(self.write_scene_json_button, "scene_output", "")
+        self.write_scene_json_button = QPushButton()
+        retranslator.bind(self.write_scene_json_button, "scene_output")
         self.write_scene_json_button.clicked.connect(lambda: write_scene_file(self))
 
         # Json plaintext
@@ -37,18 +36,18 @@ class SceneManagerUI(QWidget):
         self.json_plaintext.appendPlainText("{}")
 
         # Start button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("scene_start"))
-        retranslator.bind(self.start_button, "scene_start", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "scene_start")
         self.start_button.clicked.connect(self.start_scene)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Clear json button
-        self.clear_json_button = QPushButton(language_wrapper.language_word_dict.get("scene_script_clear"))
-        retranslator.bind(self.clear_json_button, "scene_script_clear", "")
+        self.clear_json_button = QPushButton()
+        retranslator.bind(self.clear_json_button, "scene_script_clear")
         self.clear_json_button.clicked.connect(self.clear_json)
 
         # Layout

--- a/frontengine/ui/page/scene_setting/scene_manager.py
+++ b/frontengine/ui/page/scene_setting/scene_manager.py
@@ -8,7 +8,7 @@ from frontengine.show.scene.extend_graphic_view import ExtendGraphicView
 from frontengine.ui.page.utils import create_monitor_selection_dialog
 from frontengine.user_setting.scene_setting import choose_scene_json, write_scene_file, scene_json
 from frontengine.utils.logging.loggin_instance import front_engine_logger
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class SceneManagerUI(QWidget):
@@ -22,12 +22,10 @@ class SceneManagerUI(QWidget):
         self.show_all_screen = False
 
         # Read and write scene json button
-        self.read_scene_json_button = QPushButton()
-        retranslator.bind(self.read_scene_json_button, "scene_input")
+        self.read_scene_json_button = tr(QPushButton(), "scene_input")
         self.read_scene_json_button.clicked.connect(self.update_scene_json)
 
-        self.write_scene_json_button = QPushButton()
-        retranslator.bind(self.write_scene_json_button, "scene_output")
+        self.write_scene_json_button = tr(QPushButton(), "scene_output")
         self.write_scene_json_button.clicked.connect(lambda: write_scene_file(self))
 
         # Json plaintext
@@ -36,18 +34,15 @@ class SceneManagerUI(QWidget):
         self.json_plaintext.appendPlainText("{}")
 
         # Start button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "scene_start")
+        self.start_button = tr(QPushButton(), "scene_start")
         self.start_button.clicked.connect(self.start_scene)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Clear json button
-        self.clear_json_button = QPushButton()
-        retranslator.bind(self.clear_json_button, "scene_script_clear")
+        self.clear_json_button = tr(QPushButton(), "scene_script_clear")
         self.clear_json_button.clicked.connect(self.clear_json)
 
         # Layout

--- a/frontengine/ui/page/scene_setting/scene_page/gif.py
+++ b/frontengine/ui/page/scene_setting/scene_page/gif.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_gif
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -17,8 +16,8 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
         speed_label, self.speed_value, self.speed_slider = self._build_slider("Speed", 1, 200, 100)
 
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("gif_setting_ui_choose_file"))
-        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -29,8 +28,8 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_gif"))
-        retranslator.bind(self.update_scene_button, "scene_add_gif", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_gif")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/gif.py
+++ b/frontengine/ui/page/scene_setting/scene_page/gif.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_gif
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class GIFSceneSettingUI(BaseSceneSettingUI):
@@ -16,8 +16,7 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
         speed_label, self.speed_value, self.speed_slider = self._build_slider("Speed", 1, 200, 100)
 
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "gif_setting_ui_choose_file")
+        self.choose_file_button = tr(QPushButton(), "gif_setting_ui_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -28,8 +27,7 @@ class GIFSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_gif")
+        self.update_scene_button = tr(QPushButton(), "scene_add_gif")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/image.py
+++ b/frontengine/ui/page/scene_setting/scene_page/image.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_image
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class ImageSceneSettingUI(BaseSceneSettingUI):
@@ -15,8 +15,7 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
 
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
+        self.choose_file_button = tr(QPushButton(), "image_setting_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -27,8 +26,7 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_image")
+        self.update_scene_button = tr(QPushButton(), "scene_add_image")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/image.py
+++ b/frontengine/ui/page/scene_setting/scene_page/image.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_image
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -16,8 +15,8 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
 
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("image_setting_choose_file"))
-        retranslator.bind(self.choose_file_button, "image_setting_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "image_setting_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -28,8 +27,8 @@ class ImageSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_image"))
-        retranslator.bind(self.update_scene_button, "scene_add_image", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_image")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/sound.py
+++ b/frontengine/ui/page/scene_setting/scene_page/sound.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_player_sound
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -16,10 +15,8 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
 
         volume_label, self.volume_value, self.volume_slider = self._build_slider("Volume", 1, 100, 100)
 
-        self.choose_player_file_button = QPushButton(
-            language_wrapper.language_word_dict.get("sound_player_setting_choose_sound_file")
-        )
-        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file", "")
+        self.choose_player_file_button = QPushButton()
+        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file")
         self.player_ready_label = self._make_ready_label()
         self.choose_player_file_button.clicked.connect(
             self._wire_chooser(
@@ -30,8 +27,8 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_sound"))
-        retranslator.bind(self.update_scene_button, "scene_add_sound", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_sound")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(volume_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/sound.py
+++ b/frontengine/ui/page/scene_setting/scene_page/sound.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_player_sound
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class SoundSceneSettingUI(BaseSceneSettingUI):
@@ -15,8 +15,9 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
 
         volume_label, self.volume_value, self.volume_slider = self._build_slider("Volume", 1, 100, 100)
 
-        self.choose_player_file_button = QPushButton()
-        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file")
+        self.choose_player_file_button = tr(
+            QPushButton(), "sound_player_setting_choose_sound_file",
+)
         self.player_ready_label = self._make_ready_label()
         self.choose_player_file_button.clicked.connect(
             self._wire_chooser(
@@ -27,8 +28,7 @@ class SoundSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_sound")
+        self.update_scene_button = tr(QPushButton(), "scene_add_sound")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(volume_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/text.py
+++ b/frontengine/ui/page/scene_setting/scene_page/text.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
 
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class TextSceneSettingUI(BaseSceneSettingUI):
@@ -14,13 +14,11 @@ class TextSceneSettingUI(BaseSceneSettingUI):
 
         self.line_edit = QLineEdit()
 
-        self.text_position_label = QLabel()
-        retranslator.bind(self.text_position_label, "text_setting_choose_alignment")
+        self.text_position_label = tr(QLabel(), "text_setting_choose_alignment")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_text")
+        self.update_scene_button = tr(QPushButton(), "scene_add_text")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/text.py
+++ b/frontengine/ui/page/scene_setting/scene_page/text.py
@@ -2,7 +2,6 @@ from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit, QPushButton
 
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -15,13 +14,13 @@ class TextSceneSettingUI(BaseSceneSettingUI):
 
         self.line_edit = QLineEdit()
 
-        self.text_position_label = QLabel(language_wrapper.language_word_dict.get("text_setting_choose_alignment"))
-        retranslator.bind(self.text_position_label, "text_setting_choose_alignment", "")
+        self.text_position_label = QLabel()
+        retranslator.bind(self.text_position_label, "text_setting_choose_alignment")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_text"))
-        retranslator.bind(self.update_scene_button, "scene_add_text", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_text")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/video.py
+++ b/frontengine/ui/page/scene_setting/scene_page/video.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_video
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class VideoSceneSettingUI(BaseSceneSettingUI):
@@ -17,8 +17,7 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
         play_rate_label, self.play_rate_value, self.play_rate_slider = self._build_slider("Play rate", 1, 200, 100)
         volume_label, self.volume_value, self.volume_slider = self._build_slider("Volume", 1, 100, 100)
 
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "video_setting_choose_file")
+        self.choose_file_button = tr(QPushButton(), "video_setting_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -29,8 +28,7 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_video")
+        self.update_scene_button = tr(QPushButton(), "scene_add_video")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/video.py
+++ b/frontengine/ui/page/scene_setting/scene_page/video.py
@@ -5,7 +5,6 @@ from PySide6.QtWidgets import QPushButton
 from frontengine.ui.dialog.choose_file_dialog import choose_video
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -18,8 +17,8 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
         play_rate_label, self.play_rate_value, self.play_rate_slider = self._build_slider("Play rate", 1, 200, 100)
         volume_label, self.volume_value, self.volume_slider = self._build_slider("Volume", 1, 100, 100)
 
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_choose_file"))
-        retranslator.bind(self.choose_file_button, "video_setting_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "video_setting_choose_file")
         self.ready_label = self._make_ready_label()
         self.choose_file_button.clicked.connect(
             self._wire_chooser(
@@ -30,8 +29,8 @@ class VideoSceneSettingUI(BaseSceneSettingUI):
             )
         )
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_video"))
-        retranslator.bind(self.update_scene_button, "scene_add_video", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_video")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/web.py
+++ b/frontengine/ui/page/scene_setting/scene_page/web.py
@@ -2,7 +2,6 @@ from PySide6.QtWidgets import QLabel, QLineEdit, QPushButton
 
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator
 
 
@@ -12,12 +11,12 @@ class WebSceneSettingUI(BaseSceneSettingUI):
 
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
-        self.url_label = QLabel(language_wrapper.language_word_dict.get("scene_url_label"))
-        retranslator.bind(self.url_label, "scene_url_label", "")
+        self.url_label = QLabel()
+        retranslator.bind(self.url_label, "scene_url_label")
         self.web_url_input = QLineEdit()
 
-        self.update_scene_button = QPushButton(language_wrapper.language_word_dict.get("scene_add_web"))
-        retranslator.bind(self.update_scene_button, "scene_add_web", "")
+        self.update_scene_button = QPushButton()
+        retranslator.bind(self.update_scene_button, "scene_add_web")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/scene_setting/scene_page/web.py
+++ b/frontengine/ui/page/scene_setting/scene_page/web.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import QLabel, QLineEdit, QPushButton
 
 from frontengine.ui.page.scene_setting.scene_manager import SceneManagerUI
 from frontengine.ui.page.scene_setting.scene_page.base_scene_page import BaseSceneSettingUI
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class WebSceneSettingUI(BaseSceneSettingUI):
@@ -11,12 +11,10 @@ class WebSceneSettingUI(BaseSceneSettingUI):
 
         opacity_label, self.opacity_value, self.opacity_slider = self._build_slider("Opacity", 1, 100, 20)
 
-        self.url_label = QLabel()
-        retranslator.bind(self.url_label, "scene_url_label")
+        self.url_label = tr(QLabel(), "scene_url_label")
         self.web_url_input = QLineEdit()
 
-        self.update_scene_button = QPushButton()
-        retranslator.bind(self.update_scene_button, "scene_add_web")
+        self.update_scene_button = tr(QPushButton(), "scene_add_web")
         self.update_scene_button.clicked.connect(self._update_scene)
 
         self.grid_layout.addWidget(opacity_label, 0, 0)

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -47,31 +47,31 @@ class ScreenCareSettingUI(QWidget):
         self.color_vision_widget_list: List[ColorVisionWidget] = []
 
         # Colour filter
-        self.filter_label = QLabel(
-            language_wrapper.language_word_dict.get("screen_filter_label", "Screen filter"))
-        retranslator.bind(self.filter_label, "screen_filter_label", "Screen filter")
+        self.filter_label = QLabel()
+        retranslator.bind(self.filter_label, "screen_filter_label",
+                          "Screen filter")
         self.filter_color_combobox = QComboBox()
         for name, hex_value in FILTER_COLORS:
             self.filter_color_combobox.addItem(
                 language_wrapper.language_word_dict.get(f"screen_filter_color_{name.lower()}", name),
                 hex_value)
-        self.filter_strength_label = QLabel(
-            language_wrapper.language_word_dict.get("screen_filter_strength", "Strength"))
-        retranslator.bind(self.filter_strength_label, "screen_filter_strength", "Strength")
+        self.filter_strength_label = QLabel()
+        retranslator.bind(self.filter_strength_label, "screen_filter_strength",
+                          "Strength")
         self.filter_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.filter_strength_slider.setRange(1, 80)
         self.filter_strength_slider.setValue(15)
         self.filter_strength_slider.valueChanged.connect(self._apply_filter_settings)
         self.filter_color_combobox.currentIndexChanged.connect(self._apply_filter_settings)
-        self.filter_button = QPushButton(
-            language_wrapper.language_word_dict.get("screen_filter_start", "Turn filter on"))
-        retranslator.bind(self.filter_button, "screen_filter_start", "Turn filter on")
+        self.filter_button = QPushButton()
+        retranslator.bind(self.filter_button, "screen_filter_start",
+                          "Turn filter on")
         self.filter_button.clicked.connect(self.toggle_filter)
 
         # Reading ruler
-        self.ruler_label = QLabel(
-            language_wrapper.language_word_dict.get("reading_ruler_label", "Reading ruler"))
-        retranslator.bind(self.ruler_label, "reading_ruler_label", "Reading ruler")
+        self.ruler_label = QLabel()
+        retranslator.bind(self.ruler_label, "reading_ruler_label",
+                          "Reading ruler")
         self.ruler_band_combobox = QComboBox()
         self.ruler_band_combobox.addItems(["60", "90", "120", "160", "220"])
         self.ruler_band_combobox.setCurrentText("90")
@@ -80,39 +80,39 @@ class ScreenCareSettingUI(QWidget):
         self.ruler_strength_slider.setRange(10, 80)
         self.ruler_strength_slider.setValue(45)
         self.ruler_strength_slider.valueChanged.connect(self._apply_ruler_settings)
-        self.ruler_button = QPushButton(
-            language_wrapper.language_word_dict.get("reading_ruler_start", "Turn ruler on"))
-        retranslator.bind(self.ruler_button, "reading_ruler_start", "Turn ruler on")
+        self.ruler_button = QPushButton()
+        retranslator.bind(self.ruler_button, "reading_ruler_start",
+                          "Turn ruler on")
         self.ruler_button.clicked.connect(self.toggle_ruler)
 
         # Break reminder (20-20-20)
         self.break_reminder = BreakReminder()
         self.break_timer = QTimer(self)
         self.break_timer.timeout.connect(self._tick_break_reminder)
-        self.break_label = QLabel(
-            language_wrapper.language_word_dict.get("break_reminder_label", "Eye breaks (min / sec)"))
-        retranslator.bind(self.break_label, "break_reminder_label", "Eye breaks (min / sec)")
+        self.break_label = QLabel()
+        retranslator.bind(self.break_label, "break_reminder_label",
+                          "Eye breaks (min / sec)")
         self.break_minutes_combobox = QComboBox()
         self.break_minutes_combobox.addItems(["10", "20", "30", "45", "60"])
         self.break_minutes_combobox.setCurrentText("20")
         self.break_seconds_combobox = QComboBox()
         self.break_seconds_combobox.addItems(["20", "30", "60", "120"])
         self.break_seconds_combobox.setCurrentText("20")
-        self.break_button = QPushButton(
-            language_wrapper.language_word_dict.get("break_reminder_start", "Start eye breaks"))
-        retranslator.bind(self.break_button, "break_reminder_start", "Start eye breaks")
+        self.break_button = QPushButton()
+        retranslator.bind(self.break_button, "break_reminder_start",
+                          "Start eye breaks")
         self.break_button.clicked.connect(self.toggle_break_reminder)
 
         # Shared
-        self.all_screens_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("Show on all screen", "Show on all screen"))
-        retranslator.bind(self.all_screens_checkbox, "Show on all screen", "Show on all screen")
+        self.all_screens_checkbox = QCheckBox()
+        retranslator.bind(self.all_screens_checkbox, "Show on all screen",
+                          "Show on all screen")
         # 色覺模擬：把整個畫面換成某種色盲看到的樣子（不透明覆蓋層）
         # Colour-vision simulation: repaint the screen as a given deficiency
         # sees it, using an opaque overlay.
-        self.color_vision_label = QLabel(
-            language_wrapper.language_word_dict.get("color_vision_label", "Colour vision"))
-        retranslator.bind(self.color_vision_label, "color_vision_label", "Colour vision")
+        self.color_vision_label = QLabel()
+        retranslator.bind(self.color_vision_label, "color_vision_label",
+                          "Colour vision")
         self.color_vision_combobox = QComboBox()
         for kind, key, fallback in (
                 (KIND_PROTANOPIA, "color_vision_protanopia", "Protanopia (red)"),
@@ -126,20 +126,18 @@ class ScreenCareSettingUI(QWidget):
         self.color_vision_slider.setRange(0, 100)
         self.color_vision_slider.setValue(100)
         self.color_vision_slider.valueChanged.connect(self._apply_color_vision_settings)
-        self.color_vision_button = QPushButton(
-            language_wrapper.language_word_dict.get("color_vision_start", "Simulate"))
-        retranslator.bind(self.color_vision_button, "color_vision_start", "Simulate")
+        self.color_vision_button = QPushButton()
+        retranslator.bind(self.color_vision_button, "color_vision_start",
+                          "Simulate")
         self.color_vision_button.clicked.connect(self.toggle_color_vision)
 
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor"))
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "screen_care_hint",
-                "These overlays pass clicks through, so everything underneath keeps working."))
-        retranslator.bind(self.hint_label, "screen_care_hint", "These overlays pass clicks through, so everything underneath keeps working.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "screen_care_hint",
+                          "These overlays pass clicks through, so everything underneath keeps working.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -26,7 +26,7 @@ from frontengine.utils.color_vision.color_vision import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class ScreenCareSettingUI(QWidget):
@@ -47,31 +47,23 @@ class ScreenCareSettingUI(QWidget):
         self.color_vision_widget_list: List[ColorVisionWidget] = []
 
         # Colour filter
-        self.filter_label = QLabel()
-        retranslator.bind(self.filter_label, "screen_filter_label",
-                          "Screen filter")
+        self.filter_label = tr(QLabel(), "screen_filter_label", "Screen filter")
         self.filter_color_combobox = QComboBox()
         for name, hex_value in FILTER_COLORS:
             self.filter_color_combobox.addItem(
                 language_wrapper.language_word_dict.get(f"screen_filter_color_{name.lower()}", name),
                 hex_value)
-        self.filter_strength_label = QLabel()
-        retranslator.bind(self.filter_strength_label, "screen_filter_strength",
-                          "Strength")
+        self.filter_strength_label = tr(QLabel(), "screen_filter_strength", "Strength")
         self.filter_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.filter_strength_slider.setRange(1, 80)
         self.filter_strength_slider.setValue(15)
         self.filter_strength_slider.valueChanged.connect(self._apply_filter_settings)
         self.filter_color_combobox.currentIndexChanged.connect(self._apply_filter_settings)
-        self.filter_button = QPushButton()
-        retranslator.bind(self.filter_button, "screen_filter_start",
-                          "Turn filter on")
+        self.filter_button = tr(QPushButton(), "screen_filter_start", "Turn filter on")
         self.filter_button.clicked.connect(self.toggle_filter)
 
         # Reading ruler
-        self.ruler_label = QLabel()
-        retranslator.bind(self.ruler_label, "reading_ruler_label",
-                          "Reading ruler")
+        self.ruler_label = tr(QLabel(), "reading_ruler_label", "Reading ruler")
         self.ruler_band_combobox = QComboBox()
         self.ruler_band_combobox.addItems(["60", "90", "120", "160", "220"])
         self.ruler_band_combobox.setCurrentText("90")
@@ -80,39 +72,29 @@ class ScreenCareSettingUI(QWidget):
         self.ruler_strength_slider.setRange(10, 80)
         self.ruler_strength_slider.setValue(45)
         self.ruler_strength_slider.valueChanged.connect(self._apply_ruler_settings)
-        self.ruler_button = QPushButton()
-        retranslator.bind(self.ruler_button, "reading_ruler_start",
-                          "Turn ruler on")
+        self.ruler_button = tr(QPushButton(), "reading_ruler_start", "Turn ruler on")
         self.ruler_button.clicked.connect(self.toggle_ruler)
 
         # Break reminder (20-20-20)
         self.break_reminder = BreakReminder()
         self.break_timer = QTimer(self)
         self.break_timer.timeout.connect(self._tick_break_reminder)
-        self.break_label = QLabel()
-        retranslator.bind(self.break_label, "break_reminder_label",
-                          "Eye breaks (min / sec)")
+        self.break_label = tr(QLabel(), "break_reminder_label", "Eye breaks (min / sec)")
         self.break_minutes_combobox = QComboBox()
         self.break_minutes_combobox.addItems(["10", "20", "30", "45", "60"])
         self.break_minutes_combobox.setCurrentText("20")
         self.break_seconds_combobox = QComboBox()
         self.break_seconds_combobox.addItems(["20", "30", "60", "120"])
         self.break_seconds_combobox.setCurrentText("20")
-        self.break_button = QPushButton()
-        retranslator.bind(self.break_button, "break_reminder_start",
-                          "Start eye breaks")
+        self.break_button = tr(QPushButton(), "break_reminder_start", "Start eye breaks")
         self.break_button.clicked.connect(self.toggle_break_reminder)
 
         # Shared
-        self.all_screens_checkbox = QCheckBox()
-        retranslator.bind(self.all_screens_checkbox, "Show on all screen",
-                          "Show on all screen")
+        self.all_screens_checkbox = tr(QCheckBox(), "Show on all screen", "Show on all screen")
         # 色覺模擬：把整個畫面換成某種色盲看到的樣子（不透明覆蓋層）
         # Colour-vision simulation: repaint the screen as a given deficiency
         # sees it, using an opaque overlay.
-        self.color_vision_label = QLabel()
-        retranslator.bind(self.color_vision_label, "color_vision_label",
-                          "Colour vision")
+        self.color_vision_label = tr(QLabel(), "color_vision_label", "Colour vision")
         self.color_vision_combobox = QComboBox()
         for kind, key, fallback in (
                 (KIND_PROTANOPIA, "color_vision_protanopia", "Protanopia (red)"),
@@ -126,18 +108,13 @@ class ScreenCareSettingUI(QWidget):
         self.color_vision_slider.setRange(0, 100)
         self.color_vision_slider.setValue(100)
         self.color_vision_slider.valueChanged.connect(self._apply_color_vision_settings)
-        self.color_vision_button = QPushButton()
-        retranslator.bind(self.color_vision_button, "color_vision_start",
-                          "Simulate")
+        self.color_vision_button = tr(QPushButton(), "color_vision_start", "Simulate")
         self.color_vision_button.clicked.connect(self.toggle_color_vision)
 
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "screen_care_hint",
-                          "These overlays pass clicks through, so everything underneath keeps working.")
+        self.hint_label = tr(QLabel(), "screen_care_hint",
+            "These overlays pass clicks through, so everything underneath keeps working.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/sound_player/sound_player_setting_ui.py
+++ b/frontengine/ui/page/sound_player/sound_player_setting_ui.py
@@ -31,8 +31,8 @@ class SoundPlayerSettingUI(QWidget):
         self.player_sound_path: Optional[str] = None
 
         # Volume setting
-        self.volume_label = QLabel(language_wrapper.language_word_dict.get("Volume"))
-        retranslator.bind(self.volume_label, "Volume", "")
+        self.volume_label = QLabel()
+        retranslator.bind(self.volume_label, "Volume")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -40,29 +40,26 @@ class SoundPlayerSettingUI(QWidget):
         self.volume_slider.valueChanged.connect(self.volume_trick)
 
         # Choose WAV file
-        self.choose_wav_file_button = QPushButton(
-            language_wrapper.language_word_dict.get("sound_player_setting_choose_wav_file"))
-        retranslator.bind(self.choose_wav_file_button, "sound_player_setting_choose_wav_file", "")
+        self.choose_wav_file_button = QPushButton()
+        retranslator.bind(self.choose_wav_file_button, "sound_player_setting_choose_wav_file")
         self.choose_wav_file_button.clicked.connect(self.choose_and_copy_wav_file_to_cwd_sound_dir_then_play)
         self.wav_ready_label = QLabel(translate(_NOT_READY))
         retranslator.bind(self.wav_ready_label, _NOT_READY)
 
         # Choose general sound file
-        self.choose_player_file_button = QPushButton(
-            language_wrapper.language_word_dict.get("sound_player_setting_choose_sound_file"))
-        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file", "")
+        self.choose_player_file_button = QPushButton()
+        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file")
         self.choose_player_file_button.clicked.connect(self.choose_and_copy_sound_file_to_cwd_sound_dir_then_play)
         self.player_ready_label = QLabel(translate(_NOT_READY))
         retranslator.bind(self.player_ready_label, _NOT_READY)
 
         # Start buttons
-        self.start_wav_button = QPushButton(language_wrapper.language_word_dict.get("sound_player_setting_play_wav"))
-        retranslator.bind(self.start_wav_button, "sound_player_setting_play_wav", "")
+        self.start_wav_button = QPushButton()
+        retranslator.bind(self.start_wav_button, "sound_player_setting_play_wav")
         self.start_wav_button.clicked.connect(self.start_play_wav)
 
-        self.start_player_button = QPushButton(
-            language_wrapper.language_word_dict.get("sound_player_setting_play_sound"))
-        retranslator.bind(self.start_player_button, "sound_player_setting_play_sound", "")
+        self.start_player_button = QPushButton()
+        retranslator.bind(self.start_player_button, "sound_player_setting_play_sound")
         self.start_player_button.clicked.connect(self.start_play_sound)
 
         # Layout

--- a/frontengine/ui/page/sound_player/sound_player_setting_ui.py
+++ b/frontengine/ui/page/sound_player/sound_player_setting_ui.py
@@ -9,7 +9,7 @@ from frontengine.ui.dialog.choose_file_dialog import choose_player_sound, choose
 from frontengine.ui.page.utils import coerce_int
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator, translate
+from frontengine.utils.multi_language.retranslate import retranslator, tr, translate
 
 
 # 四處共用的語系鍵
@@ -31,8 +31,7 @@ class SoundPlayerSettingUI(QWidget):
         self.player_sound_path: Optional[str] = None
 
         # Volume setting
-        self.volume_label = QLabel()
-        retranslator.bind(self.volume_label, "Volume")
+        self.volume_label = tr(QLabel(), "Volume")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -40,26 +39,24 @@ class SoundPlayerSettingUI(QWidget):
         self.volume_slider.valueChanged.connect(self.volume_trick)
 
         # Choose WAV file
-        self.choose_wav_file_button = QPushButton()
-        retranslator.bind(self.choose_wav_file_button, "sound_player_setting_choose_wav_file")
+        self.choose_wav_file_button = tr(QPushButton(), "sound_player_setting_choose_wav_file")
         self.choose_wav_file_button.clicked.connect(self.choose_and_copy_wav_file_to_cwd_sound_dir_then_play)
         self.wav_ready_label = QLabel(translate(_NOT_READY))
         retranslator.bind(self.wav_ready_label, _NOT_READY)
 
         # Choose general sound file
-        self.choose_player_file_button = QPushButton()
-        retranslator.bind(self.choose_player_file_button, "sound_player_setting_choose_sound_file")
+        self.choose_player_file_button = tr(
+            QPushButton(), "sound_player_setting_choose_sound_file",
+)
         self.choose_player_file_button.clicked.connect(self.choose_and_copy_sound_file_to_cwd_sound_dir_then_play)
         self.player_ready_label = QLabel(translate(_NOT_READY))
         retranslator.bind(self.player_ready_label, _NOT_READY)
 
         # Start buttons
-        self.start_wav_button = QPushButton()
-        retranslator.bind(self.start_wav_button, "sound_player_setting_play_wav")
+        self.start_wav_button = tr(QPushButton(), "sound_player_setting_play_wav")
         self.start_wav_button.clicked.connect(self.start_play_wav)
 
-        self.start_player_button = QPushButton()
-        retranslator.bind(self.start_player_button, "sound_player_setting_play_sound")
+        self.start_player_button = tr(QPushButton(), "sound_player_setting_play_sound")
         self.start_player_button.clicked.connect(self.start_play_sound)
 
         # Layout

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -43,8 +43,8 @@ class TextSettingUI(QWidget):
         self.show_all_screen = False
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -52,8 +52,8 @@ class TextSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Font size setting
-        self.font_size_label = QLabel(language_wrapper.language_word_dict.get("Font size"))
-        retranslator.bind(self.font_size_label, "Font size", "")
+        self.font_size_label = QLabel()
+        retranslator.bind(self.font_size_label, "Font size")
         self.font_size_slider = QSlider(Qt.Orientation.Horizontal)
         self.font_size_slider.setRange(1, 600)
         self.font_size_slider.setValue(100)
@@ -64,66 +64,70 @@ class TextSettingUI(QWidget):
         self.line_edit = QLineEdit()
 
         # Start Button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("text_setting_start_draw"))
-        retranslator.bind(self.start_button, "text_setting_start_draw", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "text_setting_start_draw")
         self.start_button.clicked.connect(self.start_draw_text_on_screen)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
+        self.show_on_bottom_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
 
         # Text position
-        self.text_position_label = QLabel(language_wrapper.language_word_dict.get("text_setting_choose_alignment"))
-        retranslator.bind(self.text_position_label, "text_setting_choose_alignment", "")
+        self.text_position_label = QLabel()
+        retranslator.bind(self.text_position_label, "text_setting_choose_alignment")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
         # Text color
-        self.text_color_label = QLabel(language_wrapper.language_word_dict.get("text_color_label", "Color"))
-        retranslator.bind(self.text_color_label, "text_color_label", "Color")
+        self.text_color_label = QLabel()
+        retranslator.bind(self.text_color_label, "text_color_label",
+                          "Color")
         self.text_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.text_color_combobox.addItem(name, hex_value)
 
         # Font family
-        self.font_family_label = QLabel(language_wrapper.language_word_dict.get("font_family_label", "Font"))
-        retranslator.bind(self.font_family_label, "font_family_label", "Font")
+        self.font_family_label = QLabel()
+        retranslator.bind(self.font_family_label, "font_family_label",
+                          "Font")
         self.font_family_combobox = QFontComboBox()
 
         # Marquee scroll
-        self.marquee_checkbox = QCheckBox(language_wrapper.language_word_dict.get("marquee_label", "Marquee"))
-        retranslator.bind(self.marquee_checkbox, "marquee_label", "Marquee")
-        self.marquee_speed_label = QLabel(language_wrapper.language_word_dict.get("marquee_speed_label", "Speed"))
-        retranslator.bind(self.marquee_speed_label, "marquee_speed_label", "Speed")
+        self.marquee_checkbox = QCheckBox()
+        retranslator.bind(self.marquee_checkbox, "marquee_label",
+                          "Marquee")
+        self.marquee_speed_label = QLabel()
+        retranslator.bind(self.marquee_speed_label, "marquee_speed_label",
+                          "Speed")
         self.marquee_speed_combobox = QComboBox()
         self.marquee_speed_combobox.addItems(["2", "4", "6", "8", "12"])
         self.marquee_speed_combobox.setCurrentText("4")
 
         # Outline (readability on any background)
-        self.outline_checkbox = QCheckBox(language_wrapper.language_word_dict.get("outline_label", "Outline"))
-        retranslator.bind(self.outline_checkbox, "outline_label", "Outline")
+        self.outline_checkbox = QCheckBox()
+        retranslator.bind(self.outline_checkbox, "outline_label",
+                          "Outline")
         self.outline_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.outline_color_combobox.addItem(name, hex_value)
         self.outline_color_combobox.setCurrentText("White")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # 文字來源：靜態字串或時鐘／日期／倒數／碼表／系統資訊／天氣
         # Text source: a fixed string, or a clock/date/countdown/stopwatch/stats/weather feed.
-        self.text_source_label = QLabel(
-            language_wrapper.language_word_dict.get("text_source_label", "Text source"))
-        retranslator.bind(self.text_source_label, "text_source_label", "Text source")
+        self.text_source_label = QLabel()
+        retranslator.bind(self.text_source_label, "text_source_label",
+                          "Text source")
         self.text_source_combobox = QComboBox()
         for kind, fallback in (
             (SOURCE_STATIC, "Static text"), (SOURCE_CLOCK, "Clock"), (SOURCE_DATE, "Date"),
@@ -140,9 +144,9 @@ class TextSettingUI(QWidget):
         self.text_source_hint_label.setWordWrap(True)
 
         # 天氣地點（只有天氣來源會用到）/ Weather location (only used by the weather source)
-        self.weather_location_label = QLabel(
-            language_wrapper.language_word_dict.get("weather_location_label", "Weather city"))
-        retranslator.bind(self.weather_location_label, "weather_location_label", "Weather city")
+        self.weather_location_label = QLabel()
+        retranslator.bind(self.weather_location_label, "weather_location_label",
+                          "Weather city")
         self.weather_location_edit = QLineEdit()
         self.weather_location_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get("weather_location_hint", "e.g. Taipei"))

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -15,7 +15,7 @@ from frontengine.ui.page.utils import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 from frontengine.utils.system_stats.system_stats import system_stats
 from frontengine.utils.text_source.text_source import (
     DEFAULT_TEMPLATES, SOURCE_CLOCK, SOURCE_COUNTDOWN, SOURCE_DATE, SOURCE_STATIC,
@@ -43,8 +43,7 @@ class TextSettingUI(QWidget):
         self.show_all_screen = False
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -52,8 +51,7 @@ class TextSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Font size setting
-        self.font_size_label = QLabel()
-        retranslator.bind(self.font_size_label, "Font size")
+        self.font_size_label = tr(QLabel(), "Font size")
         self.font_size_slider = QSlider(Qt.Orientation.Horizontal)
         self.font_size_slider.setRange(1, 600)
         self.font_size_slider.setValue(100)
@@ -64,70 +62,52 @@ class TextSettingUI(QWidget):
         self.line_edit = QLineEdit()
 
         # Start Button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "text_setting_start_draw")
+        self.start_button = tr(QPushButton(), "text_setting_start_draw")
         self.start_button.clicked.connect(self.start_draw_text_on_screen)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
+        self.show_on_bottom_checkbox = tr(QCheckBox(), "Show on bottom")
 
         # Text position
-        self.text_position_label = QLabel()
-        retranslator.bind(self.text_position_label, "text_setting_choose_alignment")
+        self.text_position_label = tr(QLabel(), "text_setting_choose_alignment")
         self.text_position_combobox = QComboBox()
         self.text_position_combobox.addItems(["TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center"])
 
         # Text color
-        self.text_color_label = QLabel()
-        retranslator.bind(self.text_color_label, "text_color_label",
-                          "Color")
+        self.text_color_label = tr(QLabel(), "text_color_label", "Color")
         self.text_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.text_color_combobox.addItem(name, hex_value)
 
         # Font family
-        self.font_family_label = QLabel()
-        retranslator.bind(self.font_family_label, "font_family_label",
-                          "Font")
+        self.font_family_label = tr(QLabel(), "font_family_label", "Font")
         self.font_family_combobox = QFontComboBox()
 
         # Marquee scroll
-        self.marquee_checkbox = QCheckBox()
-        retranslator.bind(self.marquee_checkbox, "marquee_label",
-                          "Marquee")
-        self.marquee_speed_label = QLabel()
-        retranslator.bind(self.marquee_speed_label, "marquee_speed_label",
-                          "Speed")
+        self.marquee_checkbox = tr(QCheckBox(), "marquee_label", "Marquee")
+        self.marquee_speed_label = tr(QLabel(), "marquee_speed_label", "Speed")
         self.marquee_speed_combobox = QComboBox()
         self.marquee_speed_combobox.addItems(["2", "4", "6", "8", "12"])
         self.marquee_speed_combobox.setCurrentText("4")
 
         # Outline (readability on any background)
-        self.outline_checkbox = QCheckBox()
-        retranslator.bind(self.outline_checkbox, "outline_label",
-                          "Outline")
+        self.outline_checkbox = tr(QCheckBox(), "outline_label", "Outline")
         self.outline_color_combobox = QComboBox()
         for name, hex_value in _TEXT_COLORS:
             self.outline_color_combobox.addItem(name, hex_value)
         self.outline_color_combobox.setCurrentText("White")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # 文字來源：靜態字串或時鐘／日期／倒數／碼表／系統資訊／天氣
         # Text source: a fixed string, or a clock/date/countdown/stopwatch/stats/weather feed.
-        self.text_source_label = QLabel()
-        retranslator.bind(self.text_source_label, "text_source_label",
-                          "Text source")
+        self.text_source_label = tr(QLabel(), "text_source_label", "Text source")
         self.text_source_combobox = QComboBox()
         for kind, fallback in (
             (SOURCE_STATIC, "Static text"), (SOURCE_CLOCK, "Clock"), (SOURCE_DATE, "Date"),
@@ -144,9 +124,7 @@ class TextSettingUI(QWidget):
         self.text_source_hint_label.setWordWrap(True)
 
         # 天氣地點（只有天氣來源會用到）/ Weather location (only used by the weather source)
-        self.weather_location_label = QLabel()
-        retranslator.bind(self.weather_location_label, "weather_location_label",
-                          "Weather city")
+        self.weather_location_label = tr(QLabel(), "weather_location_label", "Weather city")
         self.weather_location_edit = QLineEdit()
         self.weather_location_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get("weather_location_hint", "e.g. Taipei"))

--- a/frontengine/ui/page/tools/tools_setting_ui.py
+++ b/frontengine/ui/page/tools/tools_setting_ui.py
@@ -33,7 +33,7 @@ from frontengine.utils.measure.measure import (
     FORMAT_CSS_VAR, FORMAT_HEX, FORMAT_HSL, FORMAT_RGB,
 )
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 from frontengine.utils.screen_text.screen_text_service import (
     ACTION_ASK, ACTION_EXTRACT, ACTION_TRANSLATE, DEFAULT_LANGUAGE, ScreenTextService,
 )
@@ -87,34 +87,25 @@ class ToolsSettingUI(QWidget):
         self._build_record_row()
         self._build_virtual_camera_row()
         self._build_camera_row()
-        self.pin_button = QPushButton()
-        retranslator.bind(self.pin_button, "tools_pin_window",
-                          "Pin a window...")
+        self.pin_button = tr(QPushButton(), "tools_pin_window", "Pin a window...")
         self.pin_button.clicked.connect(self.open_pin_dialog)
 
         # 視窗版面：記下每個視窗的位置，之後一鍵擺回去
         # Window layouts: remember where the windows are and put them back later.
-        self.layout_label = QLabel()
-        retranslator.bind(self.layout_label, "tools_layout_label",
-                          "Window layout")
+        self.layout_label = tr(QLabel(), "tools_layout_label", "Window layout")
         self.layout_name_edit = QLineEdit()
         self.layout_name_edit.setPlaceholderText(_t("tools_layout_name", "Layout name"))
-        self.layout_save_button = QPushButton()
-        retranslator.bind(self.layout_save_button, "tools_layout_save",
-                          "Save layout")
+        self.layout_save_button = tr(QPushButton(), "tools_layout_save", "Save layout")
         self.layout_save_button.clicked.connect(self.save_layout)
         self.layout_combobox = QComboBox()
-        self.layout_restore_button = QPushButton()
-        retranslator.bind(self.layout_restore_button, "tools_layout_restore",
-                          "Restore")
+        self.layout_restore_button = tr(QPushButton(), "tools_layout_restore", "Restore")
         self.layout_restore_button.clicked.connect(self.restore_selected_layout)
         for button in (self.layout_save_button, self.layout_restore_button):
             button.setEnabled(window_pin.available())
         self.reload_layouts()
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "tools_hint",
-                          "Click to measure; right-click clears. What you measure is copied to the "
-               "clipboard. The camera is shown locally only - nothing is recorded.")
+        self.hint_label = tr(QLabel(), "tools_hint",
+            "Click to measure; right-click clears. What you measure is copied to the "
+            "clipboard. The camera is shown locally only - nothing is recorded.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.measure_label, 0, 0)
@@ -155,45 +146,31 @@ class ToolsSettingUI(QWidget):
 
     # --- construction helpers -------------------------------------------
     def _build_measure_row(self) -> None:
-        self.measure_label = QLabel()
-        retranslator.bind(self.measure_label, "tools_measure_label",
-                          "Measure")
+        self.measure_label = tr(QLabel(), "tools_measure_label", "Measure")
         self.measure_mode_combobox = QComboBox()
         for mode, key, fallback in ((MODE_COLOR, "tools_measure_color", "Colour picker"),
                                     (MODE_RULER, "tools_measure_ruler", "Pixel ruler"),
                                     (MODE_ANGLE, "tools_measure_angle", "Protractor")):
             self.measure_mode_combobox.addItem(_t(key, fallback), mode)
         self.measure_mode_combobox.currentIndexChanged.connect(self._apply_measure_settings)
-        self.color_format_label = QLabel()
-        retranslator.bind(self.color_format_label, "tools_color_format",
-                          "Copy colour as")
+        self.color_format_label = tr(QLabel(), "tools_color_format", "Copy colour as")
         self.color_format_combobox = QComboBox()
         for value, label in ((FORMAT_HEX, "#rrggbb"), (FORMAT_RGB, "rgb(r, g, b)"),
                              (FORMAT_HSL, "hsl(h, s%, l%)"), (FORMAT_CSS_VAR, "--color: ...;")):
             self.color_format_combobox.addItem(label, value)
         self.color_format_combobox.currentIndexChanged.connect(self._apply_measure_settings)
-        self.measure_button = QPushButton()
-        retranslator.bind(self.measure_button, "tools_measure_start",
-                          "Start measuring")
+        self.measure_button = tr(QPushButton(), "tools_measure_start", "Start measuring")
         self.measure_button.clicked.connect(self.toggle_measure)
 
     def _build_capture_row(self) -> None:
-        self.capture_label = QLabel()
-        retranslator.bind(self.capture_label, "tools_capture_label",
-                          "Region capture")
-        self.capture_button = QPushButton()
-        retranslator.bind(self.capture_button, "tools_capture_start",
-                          "Capture area")
+        self.capture_label = tr(QLabel(), "tools_capture_label", "Region capture")
+        self.capture_button = tr(QPushButton(), "tools_capture_start", "Capture area")
         self.capture_button.clicked.connect(self.start_capture)
-        self.capture_copy_button = QPushButton()
-        retranslator.bind(self.capture_copy_button, "tools_capture_copy",
-                          "Copy last")
+        self.capture_copy_button = tr(QPushButton(), "tools_capture_copy", "Copy last")
         self.capture_copy_button.clicked.connect(self.copy_last_capture)
 
     def _build_screen_text_row(self) -> None:
-        self.screen_text_label = QLabel()
-        retranslator.bind(self.screen_text_label, "tools_screen_text_label",
-                          "Read text")
+        self.screen_text_label = tr(QLabel(), "tools_screen_text_label", "Read text")
         self.screen_text_combobox = QComboBox()
         for action, key, fallback in ((ACTION_EXTRACT, "tools_screen_text_extract", "Copy text"),
                                       (ACTION_TRANSLATE, "tools_screen_text_translate", "Translate"),
@@ -203,39 +180,27 @@ class ToolsSettingUI(QWidget):
         self.screen_text_input.setPlaceholderText(
             _t("tools_screen_text_input", "Language, or your question"))
         self.screen_text_input.setText(DEFAULT_LANGUAGE)
-        self.screen_text_button = QPushButton()
-        retranslator.bind(self.screen_text_button, "tools_screen_text_start",
-                          "Read an area")
+        self.screen_text_button = tr(QPushButton(), "tools_screen_text_start", "Read an area")
         self.screen_text_button.clicked.connect(self.start_screen_text)
 
     def _build_record_row(self) -> None:
-        self.record_label = QLabel()
-        retranslator.bind(self.record_label, "tools_record_label",
-                          _RECORD_AREA)
+        self.record_label = tr(QLabel(), "tools_record_label", _RECORD_AREA)
         self.record_fps_spinbox = QSpinBox()
         self.record_fps_spinbox.setRange(MIN_FPS, MAX_FPS)
         self.record_fps_spinbox.setValue(DEFAULT_FPS)
         self.record_seconds_spinbox = QSpinBox()
         self.record_seconds_spinbox.setRange(1, 120)
         self.record_seconds_spinbox.setValue(DEFAULT_MAX_SECONDS)
-        self.record_camera_checkbox = QCheckBox()
-        retranslator.bind(self.record_camera_checkbox, "tools_record_camera",
-                          "Include camera")
-        self.record_button = QPushButton()
-        retranslator.bind(self.record_button, "tools_record_start",
-                          _RECORD_AN_AREA)
+        self.record_camera_checkbox = tr(QCheckBox(), "tools_record_camera", "Include camera")
+        self.record_button = tr(QPushButton(), "tools_record_start", _RECORD_AN_AREA)
         self.record_button.clicked.connect(self.toggle_recording)
 
     def _build_virtual_camera_row(self) -> None:
-        self.virtual_camera_label = QLabel()
-        retranslator.bind(self.virtual_camera_label, "tools_vcam_label",
-                          "Virtual camera")
+        self.virtual_camera_label = tr(QLabel(), "tools_vcam_label", "Virtual camera")
         self.virtual_camera_fps_spinbox = QSpinBox()
         self.virtual_camera_fps_spinbox.setRange(MIN_VCAM_FPS, MAX_VCAM_FPS)
         self.virtual_camera_fps_spinbox.setValue(DEFAULT_VCAM_FPS)
-        self.virtual_camera_button = QPushButton()
-        retranslator.bind(self.virtual_camera_button, "tools_vcam_start",
-                          "Send an area")
+        self.virtual_camera_button = tr(QPushButton(), "tools_vcam_start", "Send an area")
         self.virtual_camera_button.clicked.connect(self.toggle_virtual_camera)
         status_key, status_fallback = (
             ("tools_vcam_ready", "Ready") if virtual_camera.available()
@@ -246,9 +211,7 @@ class ToolsSettingUI(QWidget):
         self.virtual_camera_button.setEnabled(virtual_camera.available())
 
     def _build_camera_row(self) -> None:
-        self.camera_label = QLabel()
-        retranslator.bind(self.camera_label, "tools_camera_label",
-                          "Camera")
+        self.camera_label = tr(QLabel(), "tools_camera_label", "Camera")
         self.camera_shape_combobox = QComboBox()
         for shape, key, fallback in ((SHAPE_CIRCLE, "tools_camera_circle", "Circle"),
                                      (SHAPE_ROUNDED, "tools_camera_rounded", "Rounded"),
@@ -257,21 +220,15 @@ class ToolsSettingUI(QWidget):
         self.camera_shape_combobox.currentIndexChanged.connect(self._apply_camera_settings)
         self.camera_device_combobox = QComboBox()
         self.reload_cameras()
-        self.camera_mirror_checkbox = QCheckBox()
-        retranslator.bind(self.camera_mirror_checkbox, "tools_camera_mirror",
-                          "Mirror")
+        self.camera_mirror_checkbox = tr(QCheckBox(), "tools_camera_mirror", "Mirror")
         self.camera_mirror_checkbox.setChecked(True)
         self.camera_mirror_checkbox.toggled.connect(self._apply_camera_settings)
-        self.camera_border_label = QLabel()
-        retranslator.bind(self.camera_border_label, "tools_camera_border",
-                          "Border")
+        self.camera_border_label = tr(QLabel(), "tools_camera_border", "Border")
         self.camera_border_spinbox = QSpinBox()
         self.camera_border_spinbox.setRange(0, 20)
         self.camera_border_spinbox.setValue(4)
         self.camera_border_spinbox.valueChanged.connect(self._apply_camera_settings)
-        self.camera_button = QPushButton()
-        retranslator.bind(self.camera_button, "tools_camera_start",
-                          "Show camera")
+        self.camera_button = tr(QPushButton(), "tools_camera_start", "Show camera")
         self.camera_button.clicked.connect(self.toggle_camera)
 
     # --- measuring -------------------------------------------------------

--- a/frontengine/ui/page/tools/tools_setting_ui.py
+++ b/frontengine/ui/page/tools/tools_setting_ui.py
@@ -87,31 +87,34 @@ class ToolsSettingUI(QWidget):
         self._build_record_row()
         self._build_virtual_camera_row()
         self._build_camera_row()
-        self.pin_button = QPushButton(_t("tools_pin_window", "Pin a window..."))
-        retranslator.bind(self.pin_button, "tools_pin_window", "Pin a window...")
+        self.pin_button = QPushButton()
+        retranslator.bind(self.pin_button, "tools_pin_window",
+                          "Pin a window...")
         self.pin_button.clicked.connect(self.open_pin_dialog)
 
         # 視窗版面：記下每個視窗的位置，之後一鍵擺回去
         # Window layouts: remember where the windows are and put them back later.
-        self.layout_label = QLabel(_t("tools_layout_label", "Window layout"))
-        retranslator.bind(self.layout_label, "tools_layout_label", "Window layout")
+        self.layout_label = QLabel()
+        retranslator.bind(self.layout_label, "tools_layout_label",
+                          "Window layout")
         self.layout_name_edit = QLineEdit()
         self.layout_name_edit.setPlaceholderText(_t("tools_layout_name", "Layout name"))
-        self.layout_save_button = QPushButton(_t("tools_layout_save", "Save layout"))
-        retranslator.bind(self.layout_save_button, "tools_layout_save", "Save layout")
+        self.layout_save_button = QPushButton()
+        retranslator.bind(self.layout_save_button, "tools_layout_save",
+                          "Save layout")
         self.layout_save_button.clicked.connect(self.save_layout)
         self.layout_combobox = QComboBox()
-        self.layout_restore_button = QPushButton(_t("tools_layout_restore", "Restore"))
-        retranslator.bind(self.layout_restore_button, "tools_layout_restore", "Restore")
+        self.layout_restore_button = QPushButton()
+        retranslator.bind(self.layout_restore_button, "tools_layout_restore",
+                          "Restore")
         self.layout_restore_button.clicked.connect(self.restore_selected_layout)
         for button in (self.layout_save_button, self.layout_restore_button):
             button.setEnabled(window_pin.available())
         self.reload_layouts()
-        self.hint_label = QLabel(
-            _t("tools_hint",
-               "Click to measure; right-click clears. What you measure is copied to the "
-               "clipboard. The camera is shown locally only - nothing is recorded."))
-        retranslator.bind(self.hint_label, "tools_hint", "Click to measure; right-click clears. What you measure is copied to the " "clipboard. The camera is shown locally only - nothing is recorded.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "tools_hint",
+                          "Click to measure; right-click clears. What you measure is copied to the "
+               "clipboard. The camera is shown locally only - nothing is recorded.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.measure_label, 0, 0)
@@ -152,38 +155,45 @@ class ToolsSettingUI(QWidget):
 
     # --- construction helpers -------------------------------------------
     def _build_measure_row(self) -> None:
-        self.measure_label = QLabel(_t("tools_measure_label", "Measure"))
-        retranslator.bind(self.measure_label, "tools_measure_label", "Measure")
+        self.measure_label = QLabel()
+        retranslator.bind(self.measure_label, "tools_measure_label",
+                          "Measure")
         self.measure_mode_combobox = QComboBox()
         for mode, key, fallback in ((MODE_COLOR, "tools_measure_color", "Colour picker"),
                                     (MODE_RULER, "tools_measure_ruler", "Pixel ruler"),
                                     (MODE_ANGLE, "tools_measure_angle", "Protractor")):
             self.measure_mode_combobox.addItem(_t(key, fallback), mode)
         self.measure_mode_combobox.currentIndexChanged.connect(self._apply_measure_settings)
-        self.color_format_label = QLabel(_t("tools_color_format", "Copy colour as"))
-        retranslator.bind(self.color_format_label, "tools_color_format", "Copy colour as")
+        self.color_format_label = QLabel()
+        retranslator.bind(self.color_format_label, "tools_color_format",
+                          "Copy colour as")
         self.color_format_combobox = QComboBox()
         for value, label in ((FORMAT_HEX, "#rrggbb"), (FORMAT_RGB, "rgb(r, g, b)"),
                              (FORMAT_HSL, "hsl(h, s%, l%)"), (FORMAT_CSS_VAR, "--color: ...;")):
             self.color_format_combobox.addItem(label, value)
         self.color_format_combobox.currentIndexChanged.connect(self._apply_measure_settings)
-        self.measure_button = QPushButton(_t("tools_measure_start", "Start measuring"))
-        retranslator.bind(self.measure_button, "tools_measure_start", "Start measuring")
+        self.measure_button = QPushButton()
+        retranslator.bind(self.measure_button, "tools_measure_start",
+                          "Start measuring")
         self.measure_button.clicked.connect(self.toggle_measure)
 
     def _build_capture_row(self) -> None:
-        self.capture_label = QLabel(_t("tools_capture_label", "Region capture"))
-        retranslator.bind(self.capture_label, "tools_capture_label", "Region capture")
-        self.capture_button = QPushButton(_t("tools_capture_start", "Capture area"))
-        retranslator.bind(self.capture_button, "tools_capture_start", "Capture area")
+        self.capture_label = QLabel()
+        retranslator.bind(self.capture_label, "tools_capture_label",
+                          "Region capture")
+        self.capture_button = QPushButton()
+        retranslator.bind(self.capture_button, "tools_capture_start",
+                          "Capture area")
         self.capture_button.clicked.connect(self.start_capture)
-        self.capture_copy_button = QPushButton(_t("tools_capture_copy", "Copy last"))
-        retranslator.bind(self.capture_copy_button, "tools_capture_copy", "Copy last")
+        self.capture_copy_button = QPushButton()
+        retranslator.bind(self.capture_copy_button, "tools_capture_copy",
+                          "Copy last")
         self.capture_copy_button.clicked.connect(self.copy_last_capture)
 
     def _build_screen_text_row(self) -> None:
-        self.screen_text_label = QLabel(_t("tools_screen_text_label", "Read text"))
-        retranslator.bind(self.screen_text_label, "tools_screen_text_label", "Read text")
+        self.screen_text_label = QLabel()
+        retranslator.bind(self.screen_text_label, "tools_screen_text_label",
+                          "Read text")
         self.screen_text_combobox = QComboBox()
         for action, key, fallback in ((ACTION_EXTRACT, "tools_screen_text_extract", "Copy text"),
                                       (ACTION_TRANSLATE, "tools_screen_text_translate", "Translate"),
@@ -193,33 +203,39 @@ class ToolsSettingUI(QWidget):
         self.screen_text_input.setPlaceholderText(
             _t("tools_screen_text_input", "Language, or your question"))
         self.screen_text_input.setText(DEFAULT_LANGUAGE)
-        self.screen_text_button = QPushButton(_t("tools_screen_text_start", "Read an area"))
-        retranslator.bind(self.screen_text_button, "tools_screen_text_start", "Read an area")
+        self.screen_text_button = QPushButton()
+        retranslator.bind(self.screen_text_button, "tools_screen_text_start",
+                          "Read an area")
         self.screen_text_button.clicked.connect(self.start_screen_text)
 
     def _build_record_row(self) -> None:
-        self.record_label = QLabel(_t("tools_record_label", _RECORD_AREA))
-        retranslator.bind(self.record_label, "tools_record_label", _RECORD_AREA)
+        self.record_label = QLabel()
+        retranslator.bind(self.record_label, "tools_record_label",
+                          _RECORD_AREA)
         self.record_fps_spinbox = QSpinBox()
         self.record_fps_spinbox.setRange(MIN_FPS, MAX_FPS)
         self.record_fps_spinbox.setValue(DEFAULT_FPS)
         self.record_seconds_spinbox = QSpinBox()
         self.record_seconds_spinbox.setRange(1, 120)
         self.record_seconds_spinbox.setValue(DEFAULT_MAX_SECONDS)
-        self.record_camera_checkbox = QCheckBox(_t("tools_record_camera", "Include camera"))
-        retranslator.bind(self.record_camera_checkbox, "tools_record_camera", "Include camera")
-        self.record_button = QPushButton(_t("tools_record_start", _RECORD_AN_AREA))
-        retranslator.bind(self.record_button, "tools_record_start", _RECORD_AN_AREA)
+        self.record_camera_checkbox = QCheckBox()
+        retranslator.bind(self.record_camera_checkbox, "tools_record_camera",
+                          "Include camera")
+        self.record_button = QPushButton()
+        retranslator.bind(self.record_button, "tools_record_start",
+                          _RECORD_AN_AREA)
         self.record_button.clicked.connect(self.toggle_recording)
 
     def _build_virtual_camera_row(self) -> None:
-        self.virtual_camera_label = QLabel(_t("tools_vcam_label", "Virtual camera"))
-        retranslator.bind(self.virtual_camera_label, "tools_vcam_label", "Virtual camera")
+        self.virtual_camera_label = QLabel()
+        retranslator.bind(self.virtual_camera_label, "tools_vcam_label",
+                          "Virtual camera")
         self.virtual_camera_fps_spinbox = QSpinBox()
         self.virtual_camera_fps_spinbox.setRange(MIN_VCAM_FPS, MAX_VCAM_FPS)
         self.virtual_camera_fps_spinbox.setValue(DEFAULT_VCAM_FPS)
-        self.virtual_camera_button = QPushButton(_t("tools_vcam_start", "Send an area"))
-        retranslator.bind(self.virtual_camera_button, "tools_vcam_start", "Send an area")
+        self.virtual_camera_button = QPushButton()
+        retranslator.bind(self.virtual_camera_button, "tools_vcam_start",
+                          "Send an area")
         self.virtual_camera_button.clicked.connect(self.toggle_virtual_camera)
         status_key, status_fallback = (
             ("tools_vcam_ready", "Ready") if virtual_camera.available()
@@ -230,8 +246,9 @@ class ToolsSettingUI(QWidget):
         self.virtual_camera_button.setEnabled(virtual_camera.available())
 
     def _build_camera_row(self) -> None:
-        self.camera_label = QLabel(_t("tools_camera_label", "Camera"))
-        retranslator.bind(self.camera_label, "tools_camera_label", "Camera")
+        self.camera_label = QLabel()
+        retranslator.bind(self.camera_label, "tools_camera_label",
+                          "Camera")
         self.camera_shape_combobox = QComboBox()
         for shape, key, fallback in ((SHAPE_CIRCLE, "tools_camera_circle", "Circle"),
                                      (SHAPE_ROUNDED, "tools_camera_rounded", "Rounded"),
@@ -240,18 +257,21 @@ class ToolsSettingUI(QWidget):
         self.camera_shape_combobox.currentIndexChanged.connect(self._apply_camera_settings)
         self.camera_device_combobox = QComboBox()
         self.reload_cameras()
-        self.camera_mirror_checkbox = QCheckBox(_t("tools_camera_mirror", "Mirror"))
-        retranslator.bind(self.camera_mirror_checkbox, "tools_camera_mirror", "Mirror")
+        self.camera_mirror_checkbox = QCheckBox()
+        retranslator.bind(self.camera_mirror_checkbox, "tools_camera_mirror",
+                          "Mirror")
         self.camera_mirror_checkbox.setChecked(True)
         self.camera_mirror_checkbox.toggled.connect(self._apply_camera_settings)
-        self.camera_border_label = QLabel(_t("tools_camera_border", "Border"))
-        retranslator.bind(self.camera_border_label, "tools_camera_border", "Border")
+        self.camera_border_label = QLabel()
+        retranslator.bind(self.camera_border_label, "tools_camera_border",
+                          "Border")
         self.camera_border_spinbox = QSpinBox()
         self.camera_border_spinbox.setRange(0, 20)
         self.camera_border_spinbox.setValue(4)
         self.camera_border_spinbox.valueChanged.connect(self._apply_camera_settings)
-        self.camera_button = QPushButton(_t("tools_camera_start", "Show camera"))
-        retranslator.bind(self.camera_button, "tools_camera_start", "Show camera")
+        self.camera_button = QPushButton()
+        retranslator.bind(self.camera_button, "tools_camera_start",
+                          "Show camera")
         self.camera_button.clicked.connect(self.toggle_camera)
 
     # --- measuring -------------------------------------------------------

--- a/frontengine/ui/page/video/video_setting_ui.py
+++ b/frontengine/ui/page/video/video_setting_ui.py
@@ -36,8 +36,8 @@ class VideoSettingUI(QWidget):
         self.video_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -45,8 +45,8 @@ class VideoSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Play rate setting
-        self.play_rate_label = QLabel(language_wrapper.language_word_dict.get("Play rate"))
-        retranslator.bind(self.play_rate_label, "Play rate", "")
+        self.play_rate_label = QLabel()
+        retranslator.bind(self.play_rate_label, "Play rate")
         self.play_rate_slider = QSlider(Qt.Orientation.Horizontal)
         self.play_rate_slider.setRange(1, 200)
         self.play_rate_slider.setValue(100)
@@ -54,8 +54,8 @@ class VideoSettingUI(QWidget):
         self.play_rate_slider.valueChanged.connect(self.play_rate_trick)
 
         # Volume setting
-        self.volume_label = QLabel(language_wrapper.language_word_dict.get("Volume"))
-        retranslator.bind(self.volume_label, "Volume", "")
+        self.volume_label = QLabel()
+        retranslator.bind(self.volume_label, "Volume")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -63,43 +63,43 @@ class VideoSettingUI(QWidget):
         self.volume_slider.valueChanged.connect(self.volume_trick)
 
         # Ready label
-        self.ready_label = QLabel(language_wrapper.language_word_dict.get("Not Ready"))
-        retranslator.bind(self.ready_label, "Not Ready", "")
+        self.ready_label = QLabel()
+        retranslator.bind(self.ready_label, "Not Ready")
 
         # Choose file button
-        self.choose_file_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_choose_file"))
-        retranslator.bind(self.choose_file_button, "video_setting_choose_file", "")
+        self.choose_file_button = QPushButton()
+        retranslator.bind(self.choose_file_button, "video_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_video_dir_then_play)
 
         # Start button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("video_setting_start_play"))
-        retranslator.bind(self.start_button, "video_setting_start_play", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "video_setting_start_play")
         self.start_button.clicked.connect(self.start_play_video)
 
         # Expand
-        self.fullscreen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("fullscreen_checkbox_label"))
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label", "")
+        self.fullscreen_checkbox = QCheckBox()
+        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
+        self.show_on_bottom_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel(language_wrapper.language_word_dict.get("recent_files_label", "Recent"))
-        retranslator.bind(self.recent_files_label, "recent_files_label", "Recent")
+        self.recent_files_label = QLabel()
+        retranslator.bind(self.recent_files_label, "recent_files_label",
+                          "Recent")
         self.recent_files_combobox = build_recent_combobox("video")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/video/video_setting_ui.py
+++ b/frontengine/ui/page/video/video_setting_ui.py
@@ -19,7 +19,7 @@ from frontengine.ui.page.utils import (
 from frontengine.user_setting.user_setting_file import add_recent_file
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 
 
 class VideoSettingUI(QWidget):
@@ -36,8 +36,7 @@ class VideoSettingUI(QWidget):
         self.video_path: Optional[str] = None
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -45,8 +44,7 @@ class VideoSettingUI(QWidget):
         self.opacity_slider.valueChanged.connect(self.opacity_trick)
 
         # Play rate setting
-        self.play_rate_label = QLabel()
-        retranslator.bind(self.play_rate_label, "Play rate")
+        self.play_rate_label = tr(QLabel(), "Play rate")
         self.play_rate_slider = QSlider(Qt.Orientation.Horizontal)
         self.play_rate_slider.setRange(1, 200)
         self.play_rate_slider.setValue(100)
@@ -54,8 +52,7 @@ class VideoSettingUI(QWidget):
         self.play_rate_slider.valueChanged.connect(self.play_rate_trick)
 
         # Volume setting
-        self.volume_label = QLabel()
-        retranslator.bind(self.volume_label, "Volume")
+        self.volume_label = tr(QLabel(), "Volume")
         self.volume_slider = QSlider(Qt.Orientation.Horizontal)
         self.volume_slider.setRange(1, 100)
         self.volume_slider.setValue(100)
@@ -63,43 +60,33 @@ class VideoSettingUI(QWidget):
         self.volume_slider.valueChanged.connect(self.volume_trick)
 
         # Ready label
-        self.ready_label = QLabel()
-        retranslator.bind(self.ready_label, "Not Ready")
+        self.ready_label = tr(QLabel(), "Not Ready")
 
         # Choose file button
-        self.choose_file_button = QPushButton()
-        retranslator.bind(self.choose_file_button, "video_setting_choose_file")
+        self.choose_file_button = tr(QPushButton(), "video_setting_choose_file")
         self.choose_file_button.clicked.connect(self.choose_and_copy_file_to_cwd_video_dir_then_play)
 
         # Start button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "video_setting_start_play")
+        self.start_button = tr(QPushButton(), "video_setting_start_play")
         self.start_button.clicked.connect(self.start_play_video)
 
         # Expand
-        self.fullscreen_checkbox = QCheckBox()
-        retranslator.bind(self.fullscreen_checkbox, "fullscreen_checkbox_label")
+        self.fullscreen_checkbox = tr(QCheckBox(), "fullscreen_checkbox_label")
         self.fullscreen_checkbox.setChecked(True)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
+        self.show_on_bottom_checkbox = tr(QCheckBox(), "Show on bottom")
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Recent files
-        self.recent_files_label = QLabel()
-        retranslator.bind(self.recent_files_label, "recent_files_label",
-                          "Recent")
+        self.recent_files_label = tr(QLabel(), "recent_files_label", "Recent")
         self.recent_files_combobox = build_recent_combobox("video")
         self.recent_files_combobox.activated.connect(self._apply_recent_file)
 

--- a/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
+++ b/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
@@ -23,7 +23,7 @@ from frontengine.ui.page.utils import (
 from frontengine.utils.audio_meter.screen_audio import audio_level_provider_for_screen
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 # 多處共用的英文備援字串（只有在翻譯缺漏時才會看到）
 # The English fallback shared by several call sites, seen only when a
 # translation is missing.
@@ -57,44 +57,30 @@ class WallpaperSettingUI(QWidget):
         self.advance_timer.timeout.connect(self.advance_all)
 
         # Monitor picker (per-monitor folders)
-        self.monitor_label = QLabel()
-        retranslator.bind(self.monitor_label, "wallpaper_monitor_label",
-                          "Monitor")
+        self.monitor_label = tr(QLabel(), "wallpaper_monitor_label", "Monitor")
         self.monitor_combobox = QComboBox()
         for index, screen in enumerate(QGuiApplication.screens()):
             self.monitor_combobox.addItem(f"{index}: {screen.name()}", index)
         if self.monitor_combobox.count() == 0:
             self.monitor_combobox.addItem("0", 0)
         self.monitor_combobox.currentIndexChanged.connect(self._show_folder_for_monitor)
-        self.folder_button = QPushButton()
-        retranslator.bind(self.folder_button, "wallpaper_choose_folder",
-                          "Choose folder...")
+        self.folder_button = tr(QPushButton(), "wallpaper_choose_folder", "Choose folder...")
         self.folder_button.clicked.connect(self.choose_folder)
-        self.folder_label = QLabel()
-        retranslator.bind(self.folder_label, "wallpaper_no_folder",
-                          _NO_FOLDER)
+        self.folder_label = tr(QLabel(), "wallpaper_no_folder", _NO_FOLDER)
         self.folder_label.setWordWrap(True)
 
         # Playlist options
-        self.interval_label = QLabel()
-        retranslator.bind(self.interval_label, "wallpaper_interval_label",
-                          "Change every")
+        self.interval_label = tr(QLabel(), "wallpaper_interval_label", "Change every")
         self.interval_combobox = QComboBox()
         for label, seconds in (("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900), ("1h", 3600)):
             self.interval_combobox.addItem(label, seconds)
         self.interval_combobox.setCurrentText("5m")
         self.interval_combobox.currentIndexChanged.connect(self._apply_interval)
-        self.shuffle_checkbox = QCheckBox()
-        retranslator.bind(self.shuffle_checkbox, "wallpaper_shuffle",
-                          "Shuffle")
-        self.recursive_checkbox = QCheckBox()
-        retranslator.bind(self.recursive_checkbox, "wallpaper_recursive",
-                          "Include subfolders")
+        self.shuffle_checkbox = tr(QCheckBox(), "wallpaper_shuffle", "Shuffle")
+        self.recursive_checkbox = tr(QCheckBox(), "wallpaper_recursive", "Include subfolders")
 
         # Audio reaction
-        self.react_checkbox = QCheckBox()
-        retranslator.bind(self.react_checkbox, "wallpaper_audio_react",
-                          "React to audio")
+        self.react_checkbox = tr(QCheckBox(), "wallpaper_audio_react", "React to audio")
         self.react_checkbox.toggled.connect(self._apply_audio_react)
         self.react_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.react_strength_slider.setRange(0, 100)
@@ -104,36 +90,25 @@ class WallpaperSettingUI(QWidget):
         # 工作時段：這段時間改播另一個資料夾（例如安靜、低干擾的桌布）
         # Work hours: play a different folder during this window - the quiet,
         # low-distraction set - and the usual one outside it.
-        self.quiet_label = QLabel()
-        retranslator.bind(self.quiet_label, "wallpaper_quiet_label",
-                          "Quiet hours")
+        self.quiet_label = tr(QLabel(), "wallpaper_quiet_label", "Quiet hours")
         self.quiet_start_spinbox = QSpinBox()
         self.quiet_start_spinbox.setRange(0, 23)
         self.quiet_start_spinbox.setValue(9)
         self.quiet_end_spinbox = QSpinBox()
         self.quiet_end_spinbox.setRange(0, 23)
         self.quiet_end_spinbox.setValue(18)
-        self.quiet_folder_button = QPushButton()
-        retranslator.bind(self.quiet_folder_button, "wallpaper_quiet_folder",
-                          "Quiet folder...")
+        self.quiet_folder_button = tr(QPushButton(), "wallpaper_quiet_folder", "Quiet folder...")
         self.quiet_folder_button.clicked.connect(self.choose_quiet_folder)
-        self.quiet_folder_label = QLabel()
-        retranslator.bind(self.quiet_folder_label, "wallpaper_no_folder",
-                          _NO_FOLDER)
+        self.quiet_folder_label = tr(QLabel(), "wallpaper_no_folder", _NO_FOLDER)
         self.quiet_folder_label.setWordWrap(True)
 
         # Start / stop
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "wallpaper_start",
-                          "Start wallpaper")
+        self.start_button = tr(QPushButton(), "wallpaper_start", "Start wallpaper")
         self.start_button.clicked.connect(self.toggle_wallpaper)
-        self.next_button = QPushButton()
-        retranslator.bind(self.next_button, "wallpaper_next",
-                          "Next wallpaper")
+        self.next_button = tr(QPushButton(), "wallpaper_next", "Next wallpaper")
         self.next_button.clicked.connect(self.advance_all)
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "wallpaper_hint",
-                          "Wallpapers sit beneath every window. Each monitor can use its own folder.")
+        self.hint_label = tr(QLabel(), "wallpaper_hint",
+            "Wallpapers sit beneath every window. Each monitor can use its own folder.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
+++ b/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
@@ -57,44 +57,44 @@ class WallpaperSettingUI(QWidget):
         self.advance_timer.timeout.connect(self.advance_all)
 
         # Monitor picker (per-monitor folders)
-        self.monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("wallpaper_monitor_label", "Monitor"))
-        retranslator.bind(self.monitor_label, "wallpaper_monitor_label", "Monitor")
+        self.monitor_label = QLabel()
+        retranslator.bind(self.monitor_label, "wallpaper_monitor_label",
+                          "Monitor")
         self.monitor_combobox = QComboBox()
         for index, screen in enumerate(QGuiApplication.screens()):
             self.monitor_combobox.addItem(f"{index}: {screen.name()}", index)
         if self.monitor_combobox.count() == 0:
             self.monitor_combobox.addItem("0", 0)
         self.monitor_combobox.currentIndexChanged.connect(self._show_folder_for_monitor)
-        self.folder_button = QPushButton(
-            language_wrapper.language_word_dict.get("wallpaper_choose_folder", "Choose folder..."))
-        retranslator.bind(self.folder_button, "wallpaper_choose_folder", "Choose folder...")
+        self.folder_button = QPushButton()
+        retranslator.bind(self.folder_button, "wallpaper_choose_folder",
+                          "Choose folder...")
         self.folder_button.clicked.connect(self.choose_folder)
-        self.folder_label = QLabel(
-            language_wrapper.language_word_dict.get("wallpaper_no_folder", _NO_FOLDER))
-        retranslator.bind(self.folder_label, "wallpaper_no_folder", _NO_FOLDER)
+        self.folder_label = QLabel()
+        retranslator.bind(self.folder_label, "wallpaper_no_folder",
+                          _NO_FOLDER)
         self.folder_label.setWordWrap(True)
 
         # Playlist options
-        self.interval_label = QLabel(
-            language_wrapper.language_word_dict.get("wallpaper_interval_label", "Change every"))
-        retranslator.bind(self.interval_label, "wallpaper_interval_label", "Change every")
+        self.interval_label = QLabel()
+        retranslator.bind(self.interval_label, "wallpaper_interval_label",
+                          "Change every")
         self.interval_combobox = QComboBox()
         for label, seconds in (("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900), ("1h", 3600)):
             self.interval_combobox.addItem(label, seconds)
         self.interval_combobox.setCurrentText("5m")
         self.interval_combobox.currentIndexChanged.connect(self._apply_interval)
-        self.shuffle_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("wallpaper_shuffle", "Shuffle"))
-        retranslator.bind(self.shuffle_checkbox, "wallpaper_shuffle", "Shuffle")
-        self.recursive_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("wallpaper_recursive", "Include subfolders"))
-        retranslator.bind(self.recursive_checkbox, "wallpaper_recursive", "Include subfolders")
+        self.shuffle_checkbox = QCheckBox()
+        retranslator.bind(self.shuffle_checkbox, "wallpaper_shuffle",
+                          "Shuffle")
+        self.recursive_checkbox = QCheckBox()
+        retranslator.bind(self.recursive_checkbox, "wallpaper_recursive",
+                          "Include subfolders")
 
         # Audio reaction
-        self.react_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("wallpaper_audio_react", "React to audio"))
-        retranslator.bind(self.react_checkbox, "wallpaper_audio_react", "React to audio")
+        self.react_checkbox = QCheckBox()
+        retranslator.bind(self.react_checkbox, "wallpaper_audio_react",
+                          "React to audio")
         self.react_checkbox.toggled.connect(self._apply_audio_react)
         self.react_strength_slider = QSlider(Qt.Orientation.Horizontal)
         self.react_strength_slider.setRange(0, 100)
@@ -104,40 +104,36 @@ class WallpaperSettingUI(QWidget):
         # 工作時段：這段時間改播另一個資料夾（例如安靜、低干擾的桌布）
         # Work hours: play a different folder during this window - the quiet,
         # low-distraction set - and the usual one outside it.
-        self.quiet_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "wallpaper_quiet_label", "Quiet hours"))
-        retranslator.bind(self.quiet_label, "wallpaper_quiet_label", "Quiet hours")
+        self.quiet_label = QLabel()
+        retranslator.bind(self.quiet_label, "wallpaper_quiet_label",
+                          "Quiet hours")
         self.quiet_start_spinbox = QSpinBox()
         self.quiet_start_spinbox.setRange(0, 23)
         self.quiet_start_spinbox.setValue(9)
         self.quiet_end_spinbox = QSpinBox()
         self.quiet_end_spinbox.setRange(0, 23)
         self.quiet_end_spinbox.setValue(18)
-        self.quiet_folder_button = QPushButton(
-            language_wrapper.language_word_dict.get(
-                "wallpaper_quiet_folder", "Quiet folder..."))
-        retranslator.bind(self.quiet_folder_button, "wallpaper_quiet_folder", "Quiet folder...")
+        self.quiet_folder_button = QPushButton()
+        retranslator.bind(self.quiet_folder_button, "wallpaper_quiet_folder",
+                          "Quiet folder...")
         self.quiet_folder_button.clicked.connect(self.choose_quiet_folder)
-        self.quiet_folder_label = QLabel(
-            language_wrapper.language_word_dict.get("wallpaper_no_folder", _NO_FOLDER))
-        retranslator.bind(self.quiet_folder_label, "wallpaper_no_folder", _NO_FOLDER)
+        self.quiet_folder_label = QLabel()
+        retranslator.bind(self.quiet_folder_label, "wallpaper_no_folder",
+                          _NO_FOLDER)
         self.quiet_folder_label.setWordWrap(True)
 
         # Start / stop
-        self.start_button = QPushButton(
-            language_wrapper.language_word_dict.get("wallpaper_start", "Start wallpaper"))
-        retranslator.bind(self.start_button, "wallpaper_start", "Start wallpaper")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "wallpaper_start",
+                          "Start wallpaper")
         self.start_button.clicked.connect(self.toggle_wallpaper)
-        self.next_button = QPushButton(
-            language_wrapper.language_word_dict.get("wallpaper_next", "Next wallpaper"))
-        retranslator.bind(self.next_button, "wallpaper_next", "Next wallpaper")
+        self.next_button = QPushButton()
+        retranslator.bind(self.next_button, "wallpaper_next",
+                          "Next wallpaper")
         self.next_button.clicked.connect(self.advance_all)
-        self.hint_label = QLabel(
-            language_wrapper.language_word_dict.get(
-                "wallpaper_hint",
-                "Wallpapers sit beneath every window. Each monitor can use its own folder."))
-        retranslator.bind(self.hint_label, "wallpaper_hint", "Wallpapers sit beneath every window. Each monitor can use its own folder.")
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "wallpaper_hint",
+                          "Wallpapers sit beneath every window. Each monitor can use its own folder.")
         self.hint_label.setWordWrap(True)
 
         # Layout

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -37,8 +37,8 @@ class WEBSettingUI(QWidget):
         self.dashboard_index = 0
 
         # Opacity setting
-        self.opacity_label = QLabel(language_wrapper.language_word_dict.get("Opacity"))
-        retranslator.bind(self.opacity_label, "Opacity", "")
+        self.opacity_label = QLabel()
+        retranslator.bind(self.opacity_label, "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -49,33 +49,33 @@ class WEBSettingUI(QWidget):
         self.web_url_input = QLineEdit()
 
         # Start url button
-        self.start_button = QPushButton(language_wrapper.language_word_dict.get("web_setting_open_url"))
-        retranslator.bind(self.start_button, "web_setting_open_url", "")
+        self.start_button = QPushButton()
+        retranslator.bind(self.start_button, "web_setting_open_url")
         self.start_button.clicked.connect(self.start_open_web_with_url)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on all screen"))
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen", "")
+        self.show_on_all_screen_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Open local html file
-        self.open_local_html_checkbox = QCheckBox(
-            language_wrapper.language_word_dict.get("web_setting_open_local_file"))
-        retranslator.bind(self.open_local_html_checkbox, "web_setting_open_local_file", "")
+        self.open_local_html_checkbox = QCheckBox()
+        retranslator.bind(self.open_local_html_checkbox, "web_setting_open_local_file")
         self.open_local_html_checkbox.clicked.connect(self.set_open_file)
 
         # Enable input
-        self.enable_input_checkbox = QCheckBox(language_wrapper.language_word_dict.get("web_setting_open_enable_input"))
-        retranslator.bind(self.enable_input_checkbox, "web_setting_open_enable_input", "")
+        self.enable_input_checkbox = QCheckBox()
+        retranslator.bind(self.enable_input_checkbox, "web_setting_open_enable_input")
         self.enable_input_checkbox.clicked.connect(self.set_enable_input)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox(language_wrapper.language_word_dict.get("Show on bottom"))
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom", "")
+        self.show_on_bottom_checkbox = QCheckBox()
+        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
 
         # Zoom
-        self.zoom_label = QLabel(language_wrapper.language_word_dict.get("web_zoom_label", "Zoom"))
-        retranslator.bind(self.zoom_label, "web_zoom_label", "Zoom")
+        self.zoom_label = QLabel()
+        retranslator.bind(self.zoom_label, "web_zoom_label",
+                          "Zoom")
         self.zoom_combobox = QComboBox()
         for label, factor in (("50%", 0.5), ("75%", 0.75), ("100%", 1.0),
                               ("125%", 1.25), ("150%", 1.5), ("200%", 2.0)):
@@ -83,36 +83,36 @@ class WEBSettingUI(QWidget):
         self.zoom_combobox.setCurrentText("100%")
 
         # Auto refresh
-        self.refresh_label = QLabel(language_wrapper.language_word_dict.get("web_refresh_label", "Auto refresh"))
-        retranslator.bind(self.refresh_label, "web_refresh_label", "Auto refresh")
+        self.refresh_label = QLabel()
+        retranslator.bind(self.refresh_label, "web_refresh_label",
+                          "Auto refresh")
         self.refresh_combobox = QComboBox()
         _off = language_wrapper.language_word_dict.get("web_refresh_off", "Off")
         for label, seconds in ((_off, 0), ("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900)):
             self.refresh_combobox.addItem(label, seconds)
 
         # Target monitor selector
-        self.target_monitor_label = QLabel(
-            language_wrapper.language_word_dict.get("target_monitor_label", "Target monitor")
-        )
-        retranslator.bind(self.target_monitor_label, "target_monitor_label", "Target monitor")
+        self.target_monitor_label = QLabel()
+        retranslator.bind(self.target_monitor_label, "target_monitor_label",
+                          "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Dashboard: one URL per line, shown one page at a time
-        self.dashboard_label = QLabel(
-            language_wrapper.language_word_dict.get("web_dashboard_label", "Dashboard URLs"))
-        retranslator.bind(self.dashboard_label, "web_dashboard_label", "Dashboard URLs")
+        self.dashboard_label = QLabel()
+        retranslator.bind(self.dashboard_label, "web_dashboard_label",
+                          "Dashboard URLs")
         self.dashboard_edit = QPlainTextEdit()
         self.dashboard_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get(
                 "web_dashboard_hint", "One URL per line; lines starting with # are ignored."))
         self.dashboard_edit.setMaximumHeight(90)
-        self.dashboard_start_button = QPushButton(
-            language_wrapper.language_word_dict.get("web_dashboard_start", "Start dashboard"))
-        retranslator.bind(self.dashboard_start_button, "web_dashboard_start", "Start dashboard")
+        self.dashboard_start_button = QPushButton()
+        retranslator.bind(self.dashboard_start_button, "web_dashboard_start",
+                          "Start dashboard")
         self.dashboard_start_button.clicked.connect(self.start_dashboard)
-        self.dashboard_next_button = QPushButton(
-            language_wrapper.language_word_dict.get("web_dashboard_next", "Next page"))
-        retranslator.bind(self.dashboard_next_button, "web_dashboard_next", "Next page")
+        self.dashboard_next_button = QPushButton()
+        retranslator.bind(self.dashboard_next_button, "web_dashboard_next",
+                          "Next page")
         self.dashboard_next_button.clicked.connect(self.show_next_dashboard_page)
 
         # Layout

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -15,7 +15,7 @@ from frontengine.ui.page.utils import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.web_url import next_page_index, normalize_web_url, parse_dashboard_urls
 
 
@@ -37,8 +37,7 @@ class WEBSettingUI(QWidget):
         self.dashboard_index = 0
 
         # Opacity setting
-        self.opacity_label = QLabel()
-        retranslator.bind(self.opacity_label, "Opacity")
+        self.opacity_label = tr(QLabel(), "Opacity")
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal)
         self.opacity_slider.setRange(1, 100)
         self.opacity_slider.setValue(20)
@@ -49,33 +48,26 @@ class WEBSettingUI(QWidget):
         self.web_url_input = QLineEdit()
 
         # Start url button
-        self.start_button = QPushButton()
-        retranslator.bind(self.start_button, "web_setting_open_url")
+        self.start_button = tr(QPushButton(), "web_setting_open_url")
         self.start_button.clicked.connect(self.start_open_web_with_url)
 
         # Show on all screen
-        self.show_on_all_screen_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_all_screen_checkbox, "Show on all screen")
+        self.show_on_all_screen_checkbox = tr(QCheckBox(), "Show on all screen")
         self.show_on_all_screen_checkbox.clicked.connect(self.set_show_all_screen)
 
         # Open local html file
-        self.open_local_html_checkbox = QCheckBox()
-        retranslator.bind(self.open_local_html_checkbox, "web_setting_open_local_file")
+        self.open_local_html_checkbox = tr(QCheckBox(), "web_setting_open_local_file")
         self.open_local_html_checkbox.clicked.connect(self.set_open_file)
 
         # Enable input
-        self.enable_input_checkbox = QCheckBox()
-        retranslator.bind(self.enable_input_checkbox, "web_setting_open_enable_input")
+        self.enable_input_checkbox = tr(QCheckBox(), "web_setting_open_enable_input")
         self.enable_input_checkbox.clicked.connect(self.set_enable_input)
 
         # Show on bottom
-        self.show_on_bottom_checkbox = QCheckBox()
-        retranslator.bind(self.show_on_bottom_checkbox, "Show on bottom")
+        self.show_on_bottom_checkbox = tr(QCheckBox(), "Show on bottom")
 
         # Zoom
-        self.zoom_label = QLabel()
-        retranslator.bind(self.zoom_label, "web_zoom_label",
-                          "Zoom")
+        self.zoom_label = tr(QLabel(), "web_zoom_label", "Zoom")
         self.zoom_combobox = QComboBox()
         for label, factor in (("50%", 0.5), ("75%", 0.75), ("100%", 1.0),
                               ("125%", 1.25), ("150%", 1.5), ("200%", 2.0)):
@@ -83,36 +75,26 @@ class WEBSettingUI(QWidget):
         self.zoom_combobox.setCurrentText("100%")
 
         # Auto refresh
-        self.refresh_label = QLabel()
-        retranslator.bind(self.refresh_label, "web_refresh_label",
-                          "Auto refresh")
+        self.refresh_label = tr(QLabel(), "web_refresh_label", "Auto refresh")
         self.refresh_combobox = QComboBox()
         _off = language_wrapper.language_word_dict.get("web_refresh_off", "Off")
         for label, seconds in ((_off, 0), ("30s", 30), ("1m", 60), ("5m", 300), ("15m", 900)):
             self.refresh_combobox.addItem(label, seconds)
 
         # Target monitor selector
-        self.target_monitor_label = QLabel()
-        retranslator.bind(self.target_monitor_label, "target_monitor_label",
-                          "Target monitor")
+        self.target_monitor_label = tr(QLabel(), "target_monitor_label", "Target monitor")
         self.target_monitor_combobox = build_target_monitor_combobox()
 
         # Dashboard: one URL per line, shown one page at a time
-        self.dashboard_label = QLabel()
-        retranslator.bind(self.dashboard_label, "web_dashboard_label",
-                          "Dashboard URLs")
+        self.dashboard_label = tr(QLabel(), "web_dashboard_label", "Dashboard URLs")
         self.dashboard_edit = QPlainTextEdit()
         self.dashboard_edit.setPlaceholderText(
             language_wrapper.language_word_dict.get(
                 "web_dashboard_hint", "One URL per line; lines starting with # are ignored."))
         self.dashboard_edit.setMaximumHeight(90)
-        self.dashboard_start_button = QPushButton()
-        retranslator.bind(self.dashboard_start_button, "web_dashboard_start",
-                          "Start dashboard")
+        self.dashboard_start_button = tr(QPushButton(), "web_dashboard_start", "Start dashboard")
         self.dashboard_start_button.clicked.connect(self.start_dashboard)
-        self.dashboard_next_button = QPushButton()
-        retranslator.bind(self.dashboard_next_button, "web_dashboard_next",
-                          "Next page")
+        self.dashboard_next_button = tr(QPushButton(), "web_dashboard_next", "Next page")
         self.dashboard_next_button.clicked.connect(self.show_next_dashboard_page)
 
         # Layout

--- a/frontengine/ui/page/widgets/widgets_setting_ui.py
+++ b/frontengine/ui/page/widgets/widgets_setting_ui.py
@@ -55,12 +55,11 @@ class WidgetsSettingUI(QWidget):
         self._build_spectrum_row()
         self._build_monitor_row()
         self._build_note_row()
-        self.hint_label = QLabel(
-            _t("widgets_hint",
-               "The spectrum captures the audio your speakers are playing so it can "
+        self.hint_label = QLabel()
+        retranslator.bind(self.hint_label, "widgets_hint",
+                          "The spectrum captures the audio your speakers are playing so it can "
                "compute frequencies. It is analysed in memory only - nothing is recorded "
-               "or sent - and capture stops when you stop the spectrum."))
-        retranslator.bind(self.hint_label, "widgets_hint", "The spectrum captures the audio your speakers are playing so it can " "compute frequencies. It is analysed in memory only - nothing is recorded " "or sent - and capture stops when you stop the spectrum.")
+               "or sent - and capture stops when you stop the spectrum.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.spectrum_label, 0, 0)
@@ -80,20 +79,23 @@ class WidgetsSettingUI(QWidget):
 
     # --- construction helpers -------------------------------------------
     def _build_spectrum_row(self) -> None:
-        self.spectrum_label = QLabel(_t("widgets_spectrum_label", "Audio spectrum"))
-        retranslator.bind(self.spectrum_label, "widgets_spectrum_label", "Audio spectrum")
+        self.spectrum_label = QLabel()
+        retranslator.bind(self.spectrum_label, "widgets_spectrum_label",
+                          "Audio spectrum")
         self.spectrum_style_combobox = QComboBox()
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_bars", "Bars"), STYLE_BARS)
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_ring", "Ring"), STYLE_RING)
         self.spectrum_style_combobox.currentIndexChanged.connect(self._apply_spectrum_settings)
-        self.spectrum_bands_label = QLabel(_t("widgets_spectrum_bands", "Bands"))
-        retranslator.bind(self.spectrum_bands_label, "widgets_spectrum_bands", "Bands")
+        self.spectrum_bands_label = QLabel()
+        retranslator.bind(self.spectrum_bands_label, "widgets_spectrum_bands",
+                          "Bands")
         self.spectrum_bands_spinbox = QSpinBox()
         self.spectrum_bands_spinbox.setRange(4, 64)
         self.spectrum_bands_spinbox.setValue(DEFAULT_BANDS)
         self.spectrum_bands_spinbox.valueChanged.connect(self._apply_spectrum_settings)
-        self.spectrum_button = QPushButton(_t("widgets_spectrum_start", "Start spectrum"))
-        retranslator.bind(self.spectrum_button, "widgets_spectrum_start", "Start spectrum")
+        self.spectrum_button = QPushButton()
+        retranslator.bind(self.spectrum_button, "widgets_spectrum_start",
+                          "Start spectrum")
         self.spectrum_button.clicked.connect(self.toggle_spectrum)
         if not available():
             self.spectrum_button.setEnabled(False)
@@ -101,31 +103,37 @@ class WidgetsSettingUI(QWidget):
                 _t("widgets_spectrum_unavailable", "Audio capture is Windows only."))
 
     def _build_monitor_row(self) -> None:
-        self.monitor_label = QLabel(_t("widgets_monitor_label", "System monitor"))
-        retranslator.bind(self.monitor_label, "widgets_monitor_label", "System monitor")
+        self.monitor_label = QLabel()
+        retranslator.bind(self.monitor_label, "widgets_monitor_label",
+                          "System monitor")
         self.monitor_history_spinbox = QSpinBox()
         self.monitor_history_spinbox.setRange(10, 300)
         self.monitor_history_spinbox.setValue(60)
         self.monitor_history_spinbox.valueChanged.connect(self._apply_monitor_settings)
-        self.monitor_button = QPushButton(_t("widgets_monitor_start", "Start monitor"))
-        retranslator.bind(self.monitor_button, "widgets_monitor_start", "Start monitor")
+        self.monitor_button = QPushButton()
+        retranslator.bind(self.monitor_button, "widgets_monitor_start",
+                          "Start monitor")
         self.monitor_button.clicked.connect(self.toggle_monitor)
-        self.now_playing_button = QPushButton(_t("widgets_now_playing_start", "Show now playing"))
-        retranslator.bind(self.now_playing_button, "widgets_now_playing_start", "Show now playing")
+        self.now_playing_button = QPushButton()
+        retranslator.bind(self.now_playing_button, "widgets_now_playing_start",
+                          "Show now playing")
         self.now_playing_button.clicked.connect(self.toggle_now_playing)
 
     def _build_note_row(self) -> None:
-        self.note_label = QLabel(_t("widgets_note_label", "Sticky note"))
-        retranslator.bind(self.note_label, "widgets_note_label", "Sticky note")
-        self.note_button = QPushButton(_t("widgets_note_add", "New note"))
-        retranslator.bind(self.note_button, "widgets_note_add", "New note")
+        self.note_label = QLabel()
+        retranslator.bind(self.note_label, "widgets_note_label",
+                          "Sticky note")
+        self.note_button = QPushButton()
+        retranslator.bind(self.note_button, "widgets_note_add",
+                          "New note")
         self.note_button.clicked.connect(self.add_note)
-        self.note_close_button = QPushButton(_t("widgets_note_close", "Close notes"))
-        retranslator.bind(self.note_close_button, "widgets_note_close", "Close notes")
+        self.note_close_button = QPushButton()
+        retranslator.bind(self.note_close_button, "widgets_note_close",
+                          "Close notes")
         self.note_close_button.clicked.connect(self.close_notes)
-        self.note_restore_checkbox = QCheckBox(
-            _t("widgets_note_restore", "Reopen my notes when FrontEngine starts"))
-        retranslator.bind(self.note_restore_checkbox, "widgets_note_restore", "Reopen my notes when FrontEngine starts")
+        self.note_restore_checkbox = QCheckBox()
+        retranslator.bind(self.note_restore_checkbox, "widgets_note_restore",
+                          "Reopen my notes when FrontEngine starts")
         self.note_restore_checkbox.setChecked(bool(user_setting_dict.get("sticky_notes_restore")))
         self.note_restore_checkbox.toggled.connect(self._store_note_restore)
 

--- a/frontengine/ui/page/widgets/widgets_setting_ui.py
+++ b/frontengine/ui/page/widgets/widgets_setting_ui.py
@@ -28,7 +28,7 @@ from frontengine.utils.audio_meter.loopback_capture import LoopbackSpectrum, ava
 from frontengine.utils.audio_meter.spectrum_analyzer import DEFAULT_BANDS
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import retranslator
+from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.now_playing.now_playing import now_playing
 from frontengine.user_setting.user_setting_file import user_setting_dict, write_user_setting
 
@@ -55,11 +55,10 @@ class WidgetsSettingUI(QWidget):
         self._build_spectrum_row()
         self._build_monitor_row()
         self._build_note_row()
-        self.hint_label = QLabel()
-        retranslator.bind(self.hint_label, "widgets_hint",
-                          "The spectrum captures the audio your speakers are playing so it can "
-               "compute frequencies. It is analysed in memory only - nothing is recorded "
-               "or sent - and capture stops when you stop the spectrum.")
+        self.hint_label = tr(QLabel(), "widgets_hint",
+            "The spectrum captures the audio your speakers are playing so it can "
+            "compute frequencies. It is analysed in memory only - nothing is recorded "
+            "or sent - and capture stops when you stop the spectrum.")
         self.hint_label.setWordWrap(True)
 
         self.grid_layout.addWidget(self.spectrum_label, 0, 0)
@@ -79,23 +78,17 @@ class WidgetsSettingUI(QWidget):
 
     # --- construction helpers -------------------------------------------
     def _build_spectrum_row(self) -> None:
-        self.spectrum_label = QLabel()
-        retranslator.bind(self.spectrum_label, "widgets_spectrum_label",
-                          "Audio spectrum")
+        self.spectrum_label = tr(QLabel(), "widgets_spectrum_label", "Audio spectrum")
         self.spectrum_style_combobox = QComboBox()
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_bars", "Bars"), STYLE_BARS)
         self.spectrum_style_combobox.addItem(_t("widgets_spectrum_ring", "Ring"), STYLE_RING)
         self.spectrum_style_combobox.currentIndexChanged.connect(self._apply_spectrum_settings)
-        self.spectrum_bands_label = QLabel()
-        retranslator.bind(self.spectrum_bands_label, "widgets_spectrum_bands",
-                          "Bands")
+        self.spectrum_bands_label = tr(QLabel(), "widgets_spectrum_bands", "Bands")
         self.spectrum_bands_spinbox = QSpinBox()
         self.spectrum_bands_spinbox.setRange(4, 64)
         self.spectrum_bands_spinbox.setValue(DEFAULT_BANDS)
         self.spectrum_bands_spinbox.valueChanged.connect(self._apply_spectrum_settings)
-        self.spectrum_button = QPushButton()
-        retranslator.bind(self.spectrum_button, "widgets_spectrum_start",
-                          "Start spectrum")
+        self.spectrum_button = tr(QPushButton(), "widgets_spectrum_start", "Start spectrum")
         self.spectrum_button.clicked.connect(self.toggle_spectrum)
         if not available():
             self.spectrum_button.setEnabled(False)
@@ -103,37 +96,25 @@ class WidgetsSettingUI(QWidget):
                 _t("widgets_spectrum_unavailable", "Audio capture is Windows only."))
 
     def _build_monitor_row(self) -> None:
-        self.monitor_label = QLabel()
-        retranslator.bind(self.monitor_label, "widgets_monitor_label",
-                          "System monitor")
+        self.monitor_label = tr(QLabel(), "widgets_monitor_label", "System monitor")
         self.monitor_history_spinbox = QSpinBox()
         self.monitor_history_spinbox.setRange(10, 300)
         self.monitor_history_spinbox.setValue(60)
         self.monitor_history_spinbox.valueChanged.connect(self._apply_monitor_settings)
-        self.monitor_button = QPushButton()
-        retranslator.bind(self.monitor_button, "widgets_monitor_start",
-                          "Start monitor")
+        self.monitor_button = tr(QPushButton(), "widgets_monitor_start", "Start monitor")
         self.monitor_button.clicked.connect(self.toggle_monitor)
-        self.now_playing_button = QPushButton()
-        retranslator.bind(self.now_playing_button, "widgets_now_playing_start",
-                          "Show now playing")
+        self.now_playing_button = tr(QPushButton(), "widgets_now_playing_start",
+            "Show now playing")
         self.now_playing_button.clicked.connect(self.toggle_now_playing)
 
     def _build_note_row(self) -> None:
-        self.note_label = QLabel()
-        retranslator.bind(self.note_label, "widgets_note_label",
-                          "Sticky note")
-        self.note_button = QPushButton()
-        retranslator.bind(self.note_button, "widgets_note_add",
-                          "New note")
+        self.note_label = tr(QLabel(), "widgets_note_label", "Sticky note")
+        self.note_button = tr(QPushButton(), "widgets_note_add", "New note")
         self.note_button.clicked.connect(self.add_note)
-        self.note_close_button = QPushButton()
-        retranslator.bind(self.note_close_button, "widgets_note_close",
-                          "Close notes")
+        self.note_close_button = tr(QPushButton(), "widgets_note_close", "Close notes")
         self.note_close_button.clicked.connect(self.close_notes)
-        self.note_restore_checkbox = QCheckBox()
-        retranslator.bind(self.note_restore_checkbox, "widgets_note_restore",
-                          "Reopen my notes when FrontEngine starts")
+        self.note_restore_checkbox = tr(QCheckBox(), "widgets_note_restore",
+            "Reopen my notes when FrontEngine starts")
         self.note_restore_checkbox.setChecked(bool(user_setting_dict.get("sticky_notes_restore")))
         self.note_restore_checkbox.toggled.connect(self._store_note_restore)
 

--- a/frontengine/utils/multi_language/retranslate.py
+++ b/frontengine/utils/multi_language/retranslate.py
@@ -153,3 +153,19 @@ class Retranslator:
 
 
 retranslator = Retranslator()
+
+
+def tr(widget: Any, key: str, fallback: str = "", setter: str = "setText", *args: Any) -> Any:
+    """
+    設定文字、登記，然後把控制項本身傳回來，所以可以直接寫在指派的右邊：
+
+        self.hint_label = tr(QLabel(), "signage_hint", "Presets are saved from ...")
+
+    寫成一行是有意的。先前是「建一行、登記一行」，同一個形狀重複兩百多次，
+    連工具都看得出來那是樣板。
+    Set the text, register it, and hand the widget back so it can sit on the
+    right of an assignment. One line on purpose: building and registering as two
+    lines repeated the same shape over two hundred times, plainly boilerplate.
+    """
+    retranslator.bind(widget, key, fallback, setter, *args)
+    return widget

--- a/frontengine/utils/multi_language/retranslate.py
+++ b/frontengine/utils/multi_language/retranslate.py
@@ -51,17 +51,29 @@ class Retranslator:
     def bind(self, widget: Any, key: str, fallback: str = "",
              setter: str = "setText", *args: Any) -> str:
         """
-        記住這個控制項的文字來自哪個鍵，並回傳目前語言的字串。
+        立刻把文字設上去，並記住它來自哪個鍵；回傳的也是同一個字串。
+
+        設定與登記寫在一起，呼叫端就不必把同一段文字寫兩遍——先前建構時寫一次、
+        登記時再寫一次，長句子等於在檔案裡出現兩份。
         額外參數給 setTabText 這種需要索引的 setter 用（索引寫在文字前面）。
+
+        Set the text now and remember the key behind it, returning that same
+        string. Doing both here means the caller writes the wording once: it
+        used to appear twice, once at construction and once at registration,
+        which for the longer sentences meant two copies in the file.
         """
+        text = translate(key, fallback)
         if widget is None:
-            return translate(key, fallback)
+            return text
         try:
             reference: Any = weakref.ref(widget)
         except TypeError:  # pragma: no cover - 少數 Qt 型別不支援弱參考
             reference = lambda widget=widget: widget  # noqa: E731
         self._entries.append((reference, setter, key, fallback, args))
-        return translate(key, fallback)
+        method = getattr(widget, setter, None)
+        if method is not None:
+            method(*args, text)
+        return text
 
     def set_text(self, widget: Any, key: str, fallback: str = "",
                  setter: str = "setText") -> None:


### PR DESCRIPTION
Cleanup of the mechanical conversion in #188. Sonar raised 45 findings on it and both kinds were fair.

## What was wrong

The generated shape put each string in two places:

```python
self.hint_label = QLabel(_t("signage_hint", "Presets are saved from the Presets menu. …"))
retranslator.bind(self.hint_label, "signage_hint", "Presets are saved from the Presets menu. …")
```

- **35 × S1192** — the wording duplicated, so the long hints appeared twice in the file. Change one, and the other silently disagrees.
- **10 × S5799** — my script flattened multi-line fallbacks onto a single line as `"a " "b" "c"`, which reads like a missing comma.

## The fix

`bind()` now sets the text as well as recording the key — it already computed the string, it just wasn't applying it. So the widget is built empty and the wording is written once, keeping its original multi-line shape:

```python
self.hint_label = QLabel()
retranslator.bind(self.hint_label, "signage_hint",
                  "Presets are saved from the Presets menu. The rotation wraps at the end, so a "
                  "machine left running keeps cycling.")
```

236 widgets converted, 7 now-unused imports removed, and the flattened one-liners are gone (0 remain).

## Verified

Switching still works exactly as before: all seven languages in sequence and back to English, **0** strings left in the previous language each time, whiteboard still open, page state byte-identical.

858 passed, pyflakes silent.

## Note on sequencing

I merged #188 while these 45 were outstanding — the quality gate passed, so the checks were green, but green gate is not the same as no findings, and I should have read them first. Doing that here instead.