### PR TITLE
Fix defects found in a project-wide audit

### DIFF
--- a/frontengine/show/base_widget.py
+++ b/frontengine/show/base_widget.py
@@ -26,6 +26,21 @@ class BaseWidget(QWidget):
         # Locked means click-through; unlocked overlays can be dragged into place.
         self.overlay_locked: bool = True
         self.overlay_lockable: bool = True
+        # 自己處理滑鼠的覆蓋層（畫筆、白板、框選、量尺、寵物）要把這個關掉。
+        # 不關的話，使用者一在上面拖曳，基底的「拖曳擺位」就把整個視窗一起搬走：
+        # 畫布滑出畫面，框選還會擷取到跟選取範圍不同的區域。
+        # Overlays that handle the mouse themselves - pen, whiteboard, region
+        # select, ruler, pet - switch this off. Otherwise dragging to draw also
+        # drags the window: the canvas slides off screen, and region capture
+        # grabs an area other than the one that was selected.
+        self.overlay_draggable: bool = True
+        # 位置記憶是以類別名稱為鍵的，也就是「同一類共用一份」。每個實例位置
+        # 各異的（便利貼、寵物）要關掉，否則會全部被拉到同一個位置與大小。
+        # The remembered geometry is keyed by class name, i.e. shared by every
+        # instance of that kind. Overlays whose instances each have their own
+        # place - sticky notes, the pet - switch it off, or they all snap to one
+        # position and size.
+        self.overlay_remembers_geometry: bool = True
         self.overlay_show_on_bottom: bool = False
         # 綠幕背景色：設了就以不透明色填滿背景，方便 OBS 去背
         # Chroma key colour: fills the background opaquely so OBS can key it out.
@@ -94,12 +109,13 @@ class BaseWidget(QWidget):
 
     # --- drag to position (only while unlocked) --------------------------
     def mousePressEvent(self, event) -> None:
-        if not self.overlay_locked and event.button() == Qt.MouseButton.LeftButton:
+        if self.overlay_draggable and not self.overlay_locked \
+                and event.button() == Qt.MouseButton.LeftButton:
             self._drag_origin = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event) -> None:
-        if not self.overlay_locked and self._drag_origin is not None:
+        if self.overlay_draggable and not self.overlay_locked and self._drag_origin is not None:
             self.move(event.globalPosition().toPoint() - self._drag_origin)
         super().mouseMoveEvent(event)
 
@@ -111,6 +127,8 @@ class BaseWidget(QWidget):
 
     def remember_geometry(self) -> None:
         """記住目前位置與大小，之後同類覆蓋層會開在同一處。"""
+        if not self.overlay_remembers_geometry:
+            return
         geometry = self.geometry()
         front_engine_logger.info(
             f"{self.__class__.__name__} remember_geometry | {geometry.x()},{geometry.y()} "
@@ -129,12 +147,19 @@ class BaseWidget(QWidget):
 
     def restore_saved_geometry(self) -> None:
         """若這類覆蓋層有記住的位置就套用（使用者拖曳過才會有）。"""
+        if not self.overlay_remembers_geometry:
+            return
         saved = get_overlay_geometry(self.__class__.__name__)
         if not saved:
             return
         try:
             if self.isFullScreen():
-                self.showNormal()
+                # 使用者這次明講要全螢幕（含「顯示在所有螢幕」），就別拿記住的
+                # 位置把它拉回視窗模式——那會讓每台螢幕的覆蓋層全擠到同一格。
+                # The caller explicitly asked for fullscreen (this is also how
+                # "show on all screens" presents each one). Dragging it back to a
+                # remembered rect would pile every screen's overlay onto one spot.
+                return
             self.setGeometry(*saved)
         except RuntimeError:  # pragma: no cover - widget closed mid-callback
             return

--- a/frontengine/show/camera/camera_widget.py
+++ b/frontengine/show/camera/camera_widget.py
@@ -138,6 +138,16 @@ class CameraWidget(BaseWidget):
                 self._camera.stop()
             except RuntimeError:  # pragma: no cover - already torn down
                 pass
+        # sink 的 parent 是這個 widget，所以只把 Python 參考設成 None 不會銷毀它。
+        # 每次重新 start()（例如換攝影機）都會多留一個還連著 _on_frame 的孤兒。
+        # The sink is parented to this widget, so dropping the Python reference
+        # does not destroy it: every restart - switching camera, say - leaves
+        # another orphan still connected to _on_frame.
+        if self._sink is not None:
+            try:
+                self._sink.deleteLater()
+            except RuntimeError:  # pragma: no cover - already torn down
+                pass
         self._camera = None
         self._session = None
         self._sink = None

--- a/frontengine/show/canvas/whiteboard_widget.py
+++ b/frontengine/show/canvas/whiteboard_widget.py
@@ -79,6 +79,11 @@ class WhiteboardWidget(BaseWidget):
         self.pen_width = max(1, int(width))
         self.opacity = 1.0
         self.overlay_lockable = False
+        # 白板自己處理拖曳（畫線與平移），基底的拖曳擺位會把整塊畫布搬走
+        # The whiteboard handles its own dragging - strokes and panning - and the
+        # base class's drag-to-position would carry the whole canvas off with it.
+        self.overlay_draggable = False
+        self.overlay_remembers_geometry = False
         self.strokes: List[Dict[str, Any]] = []
         self.zoom = 1.0
         self.offset = [0.0, 0.0]

--- a/frontengine/show/capture/region_capture.py
+++ b/frontengine/show/capture/region_capture.py
@@ -65,6 +65,13 @@ class RegionCaptureWidget(BaseWidget):
         super().__init__()
         self.opacity = 1.0
         self.overlay_lockable = False
+        # 框選的拖曳就是選取範圍本身。讓基底也跟著搬視窗的話，事件座標會跟著
+        # 位移，最後擷取到的不是使用者框起來的那一塊。
+        # Here the drag is the selection. Letting the base class move the window
+        # too shifts the event coordinates, so what gets grabbed is not the area
+        # the user framed.
+        self.overlay_draggable = False
+        self.overlay_remembers_geometry = False
         self.origin: Optional[QPoint] = None
         self.current: Optional[QPoint] = None
         self.captured: Optional[QPixmap] = None

--- a/frontengine/show/focus_shield/focus_shield_widget.py
+++ b/frontengine/show/focus_shield/focus_shield_widget.py
@@ -84,12 +84,30 @@ class DimBackgroundWidget(BaseWidget):
         geometry = self.geometry()
         return (geometry.x(), geometry.y(), geometry.width(), geometry.height())
 
+    def _to_logical(self, rect: Optional[Tuple[int, int, int, int]]):
+        """
+        把 Win32 的視窗矩形換算成 Qt 的邏輯座標。GetWindowRect 給的是實體像素，
+        screen_rect() 給的是邏輯像素，顯示縮放不是 100% 時兩者對不起來：在 150%
+        的螢幕上，最大化的視窗會算成比整個螢幕還大，結果一塊都不壓暗。
+        Convert a Win32 window rect into Qt's logical coordinates. GetWindowRect
+        reports physical pixels while screen_rect() is logical, and the two
+        disagree at any scaling other than 100%: on a 150% display a maximised
+        window measures larger than the whole screen, so nothing gets dimmed.
+        """
+        if rect is None:
+            return None
+        ratio = self.devicePixelRatio() or 1.0
+        if ratio == 1.0:
+            return rect
+        return tuple(int(round(value / ratio)) for value in rect)
+
     def refresh(self) -> None:
         """重新計算要壓暗的區塊。"""
         try:
             active = self._window_provider()
         except Exception:  # pragma: no cover - defensive around providers
             active = None
+        active = self._to_logical(active)
         rects = surrounding_rects(self.screen_rect(), active)
         origin_x, origin_y = self.x(), self.y()
         # 換算成本視窗的座標系 / Convert to this widget's own coordinates

--- a/frontengine/show/focus_shield/focus_shield_widget.py
+++ b/frontengine/show/focus_shield/focus_shield_widget.py
@@ -97,8 +97,6 @@ class DimBackgroundWidget(BaseWidget):
         if rect is None:
             return None
         ratio = self.devicePixelRatio() or 1.0
-        if ratio == 1.0:
-            return rect
         return tuple(int(round(value / ratio)) for value in rect)
 
     def refresh(self) -> None:

--- a/frontengine/show/gif/paint_gif.py
+++ b/frontengine/show/gif/paint_gif.py
@@ -39,6 +39,12 @@ class GifWidget(BaseWidget):
         self.speed = speed
         self.movie.setSpeed(self.speed)
 
+    def closeEvent(self, event) -> None:
+        # 關掉之後還在解碼就是白燒 CPU，畫面早就不見了
+        # A movie still decoding after the overlay is gone is pure wasted CPU.
+        self.movie.stop()
+        super().closeEvent(event)
+
     def draw_content(self, painter: QPainter) -> None:
         current_gif_frame = self.movie.currentPixmap()
         painter.drawPixmap(

--- a/frontengine/show/image/paint_image.py
+++ b/frontengine/show/image/paint_image.py
@@ -18,10 +18,14 @@ class ImageWidget(BaseWidget):
     def __init__(self, image_path: str, draw_location_x: int = 0, draw_location_y: int = 0):
         super().__init__(draw_location_x, draw_location_y)
         self.image_path: Path = Path(image_path)
+        # 先給一張空圖，路徑失效時 paintEvent 才不會撞上未定義的屬性
+        # Start from an empty image so a bad path cannot leave paintEvent
+        # facing an attribute that was never assigned.
+        self.image: QImage = QImage()
 
         if self.image_path.exists() and self.image_path.is_file():
             front_engine_logger.info(f"Loading image file: {self.image_path}")
-            self.image: QImage = QImage(str(self.image_path))
+            self.image = QImage(str(self.image_path))
             self.resize(self.image.size())
         else:
             message_box: QMessageBox = QMessageBox(self)
@@ -45,6 +49,8 @@ class ImageWidget(BaseWidget):
         return True
 
     def draw_content(self, painter: QPainter) -> None:
+        if self.image.isNull():
+            return
         painter.drawImage(
             QRect(self.draw_location_x, self.draw_location_y, self.width(), self.height()),
             self.image

--- a/frontengine/show/load/load_someone_make_ui.py
+++ b/frontengine/show/load/load_someone_make_ui.py
@@ -1,11 +1,29 @@
 from typing import Optional, List
 
-from PySide6.QtGui import QScreen
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtWidgets import QWidget
 
 from frontengine.utils.exception.exceptions import FrontEngineLoadUIException
 from frontengine.utils.logging.loggin_instance import front_engine_logger
+
+# 載入的視窗沒有 parent，Python 這邊不留參考就會立刻被回收，視窗根本不會出現。
+# A loaded window has no parent, so without a reference on the Python side it is
+# collected the moment this function returns and never appears at all.
+_loaded_ui_widgets: List[QWidget] = []
+
+
+def _forget_closed_ui() -> None:
+    """把已被 Qt 銷毀的視窗從清單剔除，免得一直累積。"""
+    alive: List[QWidget] = []
+    for widget in _loaded_ui_widgets:
+        try:
+            widget.isVisible()
+        except RuntimeError:  # 底層 C++ 物件已消滅 / underlying C++ object is gone
+            continue
+        alive.append(widget)
+    _loaded_ui_widgets[:] = alive
 
 
 def load_extend_ui_file(ui_path: str, show_all_screen: bool = False) -> None:
@@ -19,19 +37,24 @@ def load_extend_ui_file(ui_path: str, show_all_screen: bool = False) -> None:
     front_engine_logger.info(
         f"[load_extend_ui_file] ui_path={ui_path}, show_all_screen={show_all_screen}"
     )
-
-    ui: QWidget = load_ui_file(ui_path)
+    _forget_closed_ui()
 
     if show_all_screen:
-        ui.showFullScreen()
+        # 一個 widget 不可能同時待在多台螢幕上，每台各載入一份
+        # One widget cannot sit on several screens at once, so load one per screen.
+        for screen in QGuiApplication.screens():
+            _present_ui(load_ui_file(ui_path), screen.availableGeometry().topLeft())
     else:
-        # 取得所有螢幕並在每個螢幕上顯示 UI
-        # Get all monitors and display UI on each
-        monitors: List[QScreen] = QScreen.virtualSiblings(ui.screen())
-        for screen in monitors:
-            monitor_geometry = screen.availableGeometry()
-            ui.move(monitor_geometry.left(), monitor_geometry.top())
-            ui.showFullScreen()
+        _present_ui(load_ui_file(ui_path), None)
+
+
+def _present_ui(ui: QWidget, top_left) -> None:
+    """全螢幕顯示一個載入好的視窗，並保留參考直到它被關閉。"""
+    ui.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+    if top_left is not None:
+        ui.move(top_left)
+    ui.showFullScreen()
+    _loaded_ui_widgets.append(ui)
 
 
 def load_ui_file(ui_path: str) -> QWidget:

--- a/frontengine/show/measure/measure_widget.py
+++ b/frontengine/show/measure/measure_widget.py
@@ -67,6 +67,10 @@ class MeasureWidget(BaseWidget):
         self.color_format = color_format
         self.opacity = 1.0
         self.overlay_lockable = False
+        # 量測靠的是螢幕座標，覆蓋層一被拖走就量錯
+        # Measuring is in screen coordinates; dragging the overlay falsifies it.
+        self.overlay_draggable = False
+        self.overlay_remembers_geometry = False
         self.points: List[QPoint] = []
         self.cursor_point = QPoint(0, 0)
         self.picked_color: Optional[QColor] = None
@@ -138,13 +142,21 @@ class MeasureWidget(BaseWidget):
             self.readout = self.color_text(color)
             self.update()
             return self.readout
-        self.points.append(QPoint(point))
         needed = 2 if self.mode == MODE_RULER else 3
+        if len(self.points) >= needed:
+            # 上一次已經量完了，這一下是新一次量測的第一點。先前的寫法是把新的
+            # 點加進去、拿舊的點算完再截掉，等於每一次新點擊都重算並重新複製
+            # 同一個舊結果——量尺變成只能用一次。
+            # The previous measurement is finished, so this click starts the next
+            # one. The old code appended the new point, measured the *old* ones
+            # and truncated the new one away, so every later click recomputed and
+            # re-copied the same stale result: the ruler worked exactly once.
+            self.points.clear()
+        self.points.append(QPoint(point))
         if len(self.points) < needed:
             self.update()
             return None
         self.readout = self._finish_measurement()
-        self.points = self.points[:needed]
         self.update()
         return self.readout
 

--- a/frontengine/show/notes/sticky_note_widget.py
+++ b/frontengine/show/notes/sticky_note_widget.py
@@ -91,6 +91,12 @@ class StickyNoteWidget(BaseWidget):
         # 要打字就不能點擊穿透，也就不提供鎖定
         # Typing needs the mouse and keyboard, so this one is never lockable.
         self.overlay_lockable = False
+        # 便利貼可以拖，但每張各有各的位置，所以不用「同類共用一份」的位置記憶。
+        # 每張的位置與大小是由 note_state() 各自存的。
+        # Notes are draggable, but each has its own place, so the class-wide
+        # geometry memory does not apply: note_state() persists each note's own
+        # position and size.
+        self.overlay_remembers_geometry = False
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
 
         self.text_edit = QTextEdit(self)

--- a/frontengine/show/overlay_factory.py
+++ b/frontengine/show/overlay_factory.py
@@ -11,7 +11,14 @@ from frontengine.show.video.video_player import VideoWidget
 from frontengine.show.web.webview import WebWidget
 
 
-def _normalize_opacity(value: Optional[Any], default: float = 0.2) -> float:
+def _normalize_percent(value: Optional[Any], default: float) -> float:
+    """
+    場景 JSON 裡的百分比欄位（不透明度、音量、播放速率）轉成 0.0-1.0。
+    沒填就用 default——default 已經是最終比例，不要再除以 100。
+    Turn a percentage field from the scene JSON (opacity, volume, play rate)
+    into a 0.0-1.0 ratio. A missing field falls back to `default`, which is
+    already the final ratio and must not be divided again.
+    """
     try:
         return float(value) / 100 if value is not None else default
     except (ValueError, TypeError):
@@ -25,11 +32,18 @@ def _normalize_int(value: Optional[Any], default: int) -> int:
         return default
 
 
-def _normalize_float(value: Optional[Any], default: float) -> float:
-    try:
-        return float(value) if value is not None else default
-    except (ValueError, TypeError):
-        return default
+def _require(setting_dict: Dict[str, Any], key: str, kind: str) -> str:
+    """
+    取出必要欄位。場景 JSON 是使用者自己編輯／外部提供的，缺欄位就明講，
+    不要把 None 一路送進 Path() 或 QWebEngineView.load() 才炸在深處。
+    Fetch a required field. Scene JSON is hand-edited or third-party, so say
+    what is missing here instead of letting None reach Path() or
+    QWebEngineView.load() and blow up somewhere deeper.
+    """
+    value = setting_dict.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Scene entry of type '{kind}' is missing a valid '{key}'")
+    return value
 
 
 class OverlayFactory(ABC):
@@ -46,31 +60,30 @@ class OverlayFactory(ABC):
 
 class ImageOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = ImageWidget(setting_dict.get("file_path"))
-        widget.set_ui_variable(_normalize_opacity(setting_dict.get("opacity")))
+        widget = ImageWidget(_require(setting_dict, "file_path", "image"))
+        widget.set_ui_variable(_normalize_percent(setting_dict.get("opacity"), 0.2))
         return widget
 
 
 class GifOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = GifWidget(setting_dict.get("file_path"))
+        widget = GifWidget(_require(setting_dict, "file_path", "gif"))
         widget.set_gif_variable(_normalize_int(setting_dict.get("speed"), 100))
-        widget.set_ui_variable(_normalize_opacity(setting_dict.get("opacity")))
+        widget.set_ui_variable(_normalize_percent(setting_dict.get("opacity"), 0.2))
         return widget
 
 
 class SoundOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = SoundPlayer(setting_dict.get("file_path"))
-        volume = _normalize_float(setting_dict.get("volume"), 1.0) / 100
-        widget.set_player_variable(volume)
+        widget = SoundPlayer(_require(setting_dict, "file_path", "sound"))
+        widget.set_player_variable(_normalize_percent(setting_dict.get("volume"), 1.0))
         return widget
 
 
 class TextOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = TextWidget(setting_dict.get("text"))
-        widget.set_ui_variable(_normalize_opacity(setting_dict.get("opacity")))
+        widget = TextWidget(_require(setting_dict, "text", "text"))
+        widget.set_ui_variable(_normalize_percent(setting_dict.get("opacity"), 0.2))
         widget.set_font_variable(_normalize_int(setting_dict.get("font_size"), 100))
         widget.set_alignment(setting_dict.get("alignment", "Center"))
         return widget
@@ -78,19 +91,19 @@ class TextOverlayFactory(OverlayFactory):
 
 class VideoOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = VideoWidget(setting_dict.get("file_path"))
-        opacity = _normalize_opacity(setting_dict.get("opacity"))
-        volume = _normalize_float(setting_dict.get("volume"), 1.0) / 100
-        play_rate = _normalize_float(setting_dict.get("play_rate"), 1.0) / 100
-        widget.set_ui_variable(opacity)
-        widget.set_player_variable(play_rate, volume)
+        widget = VideoWidget(_require(setting_dict, "file_path", "video"))
+        widget.set_ui_variable(_normalize_percent(setting_dict.get("opacity"), 0.2))
+        widget.set_player_variable(
+            _normalize_percent(setting_dict.get("play_rate"), 1.0),
+            _normalize_percent(setting_dict.get("volume"), 1.0),
+        )
         return widget
 
 
 class WebOverlayFactory(OverlayFactory):
     def create(self, setting_dict: Dict[str, Any]) -> QWidget:
-        widget = WebWidget(setting_dict.get("url"))
-        widget.set_ui_variable(_normalize_opacity(setting_dict.get("opacity")))
+        widget = WebWidget(_require(setting_dict, "url", "web"))
+        widget.set_ui_variable(_normalize_percent(setting_dict.get("opacity"), 0.2))
         return widget
 
 

--- a/frontengine/show/particle/particle_ui.py
+++ b/frontengine/show/particle/particle_ui.py
@@ -15,7 +15,7 @@ from OpenGL.GL import (
     glTexCoord2f, glTexImage2D, glTexParameteri, glTranslatef, glVertex2f, glViewport,
 )
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QSurfaceFormat, QPixmap
+from PySide6.QtGui import QImage, QSurfaceFormat, QPixmap
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
 
 from frontengine.show.window_helpers import apply_overlay_window_flags, load_overlay_icon
@@ -48,6 +48,7 @@ class ParticleOpenGLWidget(QOpenGLWidget):
 
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setAutoFillBackground(False)
         load_overlay_icon(self)
 
@@ -61,7 +62,13 @@ class ParticleOpenGLWidget(QOpenGLWidget):
             Qt.AspectRatioMode.KeepAspectRatio,
             Qt.TransformationMode.SmoothTransformation
         )
-        self.image = scaled_pixmap.toImage()
+        # QPixmap.toImage() 給的是 ARGB32（記憶體順序 BGRA），直接當成 GL_RGBA 上傳
+        # 會把紅藍對調。轉成 RGBA8888 才和下面的 glTexImage2D 對得起來，
+        # 順帶去掉預乘 alpha，符合 GL_SRC_ALPHA 混色的預期。
+        # toImage() hands back ARGB32, i.e. BGRA in memory; uploading that as
+        # GL_RGBA swaps red and blue. RGBA8888 matches the glTexImage2D call
+        # below and is un-premultiplied, which is what GL_SRC_ALPHA expects.
+        self.image = scaled_pixmap.toImage().convertToFormat(QImage.Format.Format_RGBA8888)
 
         self.particle_count = particle_count
         self.particle_direction = particle_direction
@@ -98,6 +105,11 @@ class ParticleOpenGLWidget(QOpenGLWidget):
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         glEnable(GL_TEXTURE_2D)
+
+        if self.image.isNull():
+            # 沒有材質就別上傳 0x0 的貼圖，畫的時候直接跳過
+            # No texture: skip the 0x0 upload and let paintGL bail out.
+            return
 
         w, h = self.image.width(), self.image.height()
 
@@ -144,6 +156,9 @@ class ParticleOpenGLWidget(QOpenGLWidget):
         glClearColor(0, 0, 0, 0)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
+        if self.texture_id is None:
+            return
+
         glBindTexture(GL_TEXTURE_2D, self.texture_id)
         glColor4f(1, 1, 1, self.opacity)
 
@@ -175,3 +190,10 @@ class ParticleOpenGLWidget(QOpenGLWidget):
 
     def set_ui_window_flag(self, show_on_bottom: bool = False) -> None:
         apply_overlay_window_flags(self, show_on_bottom=show_on_bottom)
+
+    def closeEvent(self, event) -> None:
+        # 關掉之後還在跑 60Hz 更新上萬顆粒子，畫面卻早就沒了
+        # Without this the 60 Hz update keeps churning through every particle
+        # long after the overlay has gone from the screen.
+        self.timer.stop()
+        super().closeEvent(event)

--- a/frontengine/show/pet/desktop_pet.py
+++ b/frontengine/show/pet/desktop_pet.py
@@ -1094,6 +1094,16 @@ class DesktopPetWidget(BaseWidget):
         )
         super().__init__()
         self.opacity = 1.0
+        # 寵物自己處理拖曳，位置與大小也由 PetMotion 決定。交給基底記憶的話，
+        # 拖過一次之後那個「位置＋大小」會套到之後每一隻寵物身上——尺寸下拉選單
+        # 就等於失效：新寵物被悄悄縮回舊尺寸，碰撞判定卻還用新的大小。
+        # The pet drags itself and PetMotion owns its geometry. Letting the base
+        # class remember it means one drag pins that position and size onto every
+        # later pet - which silently disables the size combobox: a new pet is
+        # resized back while its collision box still uses the size that was asked
+        # for.
+        self.overlay_draggable = False
+        self.overlay_remembers_geometry = False
         # 基礎尺寸依已存等級放大 / Base size grown by the persisted level.
         self._base_size: int = max(16, int(size))
         self._growth = PetGrowth(user_setting_dict.get("pet_affection", 0))
@@ -1189,7 +1199,9 @@ class DesktopPetWidget(BaseWidget):
         self.clone_action.triggered.connect(self.clone_requested.emit)
         self.menu.addAction(self.clone_action)
         self.feed_action = QAction(language_wrapper.language_word_dict.get("pet_feed", "Feed"), self)
-        self.feed_action.triggered.connect(self.feed)
+        # triggered 會送出 checked(bool)，直接接的話 feed 收到的 kind 是 False
+        # triggered emits checked(bool), which would arrive as feed's `kind`.
+        self.feed_action.triggered.connect(lambda: self.feed())
         self.menu.addAction(self.feed_action)
         self.status_action = QAction(language_wrapper.language_word_dict.get("pet_status", "Status"), self)
         self.status_action.triggered.connect(self.show_status)
@@ -1659,9 +1671,15 @@ class DesktopPetWidget(BaseWidget):
         else:
             self._pending_chat_reply = language_wrapper.language_word_dict.get(
                 "pet_chat_failed", "I couldn't reach my thoughts just now.")
-        # 回覆可能在背景執行緒抵達，透過計時器回到 UI 執行緒再顯示
+        # 回覆可能在背景執行緒抵達，透過計時器回到 UI 執行緒再顯示。
+        # 一定要傳 context 物件（這裡是 self）：兩個參數的 singleShot 會把計時器
+        # 建在呼叫端那條執行緒上，而那條執行緒沒有事件迴圈，計時器永遠不會觸發
+        # ——寵物就一直停在「讓我想想…」，回覆再也不會出現。
         # The reply may arrive off-thread; hop back to the UI thread to show it.
-        QTimer.singleShot(0, self._say_pending_chat_reply)
+        # The context object (self) is essential: the two-argument singleShot
+        # creates the timer on the calling thread, which has no event loop, so it
+        # never fires - the pet stays on "let me think..." and the answer is lost.
+        QTimer.singleShot(0, self, self._say_pending_chat_reply)
 
     def _say_pending_chat_reply(self) -> None:
         if self._pending_chat_reply:

--- a/frontengine/show/presentation/annotation_overlay.py
+++ b/frontengine/show/presentation/annotation_overlay.py
@@ -67,6 +67,14 @@ class AnnotationOverlay(BaseWidget):
         front_engine_logger.info(f"[AnnotationOverlay] Init | tool={tool}, color={color}, width={width}")
         super().__init__()
         self.opacity = 1.0
+        # 這一層的滑鼠是拿來畫畫的：不能被基底拖走，也不能被「鎖定覆蓋層」
+        # 變成點擊穿透——那會讓畫筆整個失效，而畫好的線還留在畫面上。
+        # The mouse here is the pen: the base class must not drag the window with
+        # it, and "lock overlays" must not make it click-through - that kills the
+        # pen outright while the strokes stay frozen on screen.
+        self.overlay_lockable = False
+        self.overlay_draggable = False
+        self.overlay_remembers_geometry = False
         self.tool = tool if tool in TOOLS else TOOL_PEN
         self.pen_color = color
         self.pen_width = clamp_width(width)

--- a/frontengine/show/presentation/cursor_effects.py
+++ b/frontengine/show/presentation/cursor_effects.py
@@ -111,7 +111,14 @@ class CursorEffectWidget(BaseWidget):
 
     def add_ripple(self, point: Optional[QPoint] = None) -> None:
         """在指定位置（預設為目前游標）加一圈點擊漣漪。"""
-        self.ripples.append({"point": QPoint(point or self.cursor_point), "step": 0})
+        # QPoint 的真值判斷是 isNull()，所以 bool(QPoint(0, 0)) 是 False：
+        # 用 `point or ...` 的話，剛好點在覆蓋層左上角的那一下會被當成沒給座標，
+        # 漣漪畫到上一次輪詢到的游標位置去。
+        # QPoint's truthiness is isNull(), so bool(QPoint(0, 0)) is False: with
+        # `point or ...` a click exactly on the overlay's top-left corner reads as
+        # "no point given" and the ripple lands on the last polled cursor spot.
+        origin = self.cursor_point if point is None else point
+        self.ripples.append({"point": QPoint(origin), "step": 0})
         self.update()
 
     def tick(self) -> None:

--- a/frontengine/show/presentation/keystroke_display.py
+++ b/frontengine/show/presentation/keystroke_display.py
@@ -128,12 +128,20 @@ class KeystrokeDisplayWidget(BaseWidget):
         return "   ".join(visible_keys(self.entries, self._now(), self.hold_seconds))
 
     def _expire(self) -> None:
-        before = len(visible_keys(self.entries, self._now(), self.hold_seconds))
-        if before != len(self.entries):
-            self.entries = [
-                (text, stamp) for text, stamp in self.entries
-                if self._now() - stamp <= self.hold_seconds
-            ]
+        # 拿還沒過期的「全部」數量來比，不要用 visible_keys——它只回傳最多
+        # MAX_KEYS_SHOWN 筆，一旦按超過那個數量，這個比較就永遠不相等，
+        # 每 100ms 都會重建清單並重畫一次，其實什麼都沒過期。
+        # Compare against the full count of unexpired entries, not visible_keys:
+        # that returns at most MAX_KEYS_SHOWN, so past that many keys the test is
+        # never equal and every 100 ms tick rebuilds the list and repaints with
+        # nothing actually having expired.
+        now = self._now()
+        fresh = [
+            (text, stamp) for text, stamp in self.entries
+            if now - stamp <= self.hold_seconds
+        ]
+        if len(fresh) != len(self.entries):
+            self.entries = fresh
             self.update()
 
     def draw_content(self, painter: QPainter) -> None:

--- a/frontengine/show/presentation/magnifier.py
+++ b/frontengine/show/presentation/magnifier.py
@@ -86,14 +86,26 @@ class MagnifierWidget(BaseWidget):
 
     @staticmethod
     def _grab_screen(rect: QRect) -> Optional[QPixmap]:
-        """用 Qt 擷取指定螢幕區域；沒有可用螢幕時回傳 None。"""
-        screen = QGuiApplication.primaryScreen()
+        """
+        擷取指定的螢幕區域。要用「那塊區域所在的那台螢幕」去擷取，不是主螢幕：
+        放大鏡可以被指定開在副螢幕上，寫死主螢幕的話，游標移到另一台時擷取到的
+        是完全不相干的位置。
+        Grab a screen region using the screen that region is actually on, not the
+        primary one: the magnifier can be placed on a secondary display, and
+        hard-coding the primary grabs somewhere else entirely once the cursor
+        moves across.
+        """
+        screen = QGuiApplication.screenAt(rect.center()) or QGuiApplication.primaryScreen()
         if screen is None:
             return None
         return screen.grabWindow(0, rect.x(), rect.y(), rect.width(), rect.height())
 
-    def screen_bounds(self) -> Tuple[int, int, int, int]:
-        screen = self.screen() or QGuiApplication.primaryScreen()
+    def screen_bounds(self, position=None) -> Tuple[int, int, int, int]:
+        """游標所在螢幕的範圍（沒給座標就用放大鏡自己那一台）。"""
+        screen = None
+        if position is not None:
+            screen = QGuiApplication.screenAt(position)
+        screen = screen or self.screen() or QGuiApplication.primaryScreen()
         if screen is None:
             return (0, 0, 1920, 1080)
         geometry = screen.geometry()
@@ -104,7 +116,7 @@ class MagnifierWidget(BaseWidget):
         try:
             position = self._cursor_provider()
             rect = source_rect((position.x(), position.y()), self.view_size, self.zoom,
-                               self.screen_bounds())
+                               self.screen_bounds(position))
             self.captured = self._grabber(rect)
         except Exception as error:  # pragma: no cover - capture boundary
             front_engine_logger.debug(f"[MagnifierWidget] capture failed: {error!r}")

--- a/frontengine/show/scene/scene.py
+++ b/frontengine/show/scene/scene.py
@@ -45,3 +45,22 @@ class SceneManager:
 
     def add_web(self, setting_dict: Dict) -> QGraphicsProxyWidget:
         return self._add("web", setting_dict)
+
+    def clear(self) -> None:
+        """
+        真的把場景清空。只清 widget_list 不夠：項目還掛在 QGraphicsScene 上，
+        音效會在沒有視窗的情況下繼續播，重開場景還會把舊的疊上來。
+        Actually empty the scene. Clearing widget_list alone is not enough --
+        the items stay in the QGraphicsScene, so sound keeps playing with no
+        window on screen and restarting the scene stacks the old items on top.
+        """
+        front_engine_logger.info("[SceneManager] clear")
+        for proxy_widget in self.widget_list:
+            try:
+                widget = proxy_widget.widget()
+                if widget is not None:
+                    widget.close()
+            except RuntimeError:  # pragma: no cover - proxy already deleted
+                continue
+        self.graphic_scene.clear_scene()
+        self.widget_list.clear()

--- a/frontengine/show/sound_player/sound_effect.py
+++ b/frontengine/show/sound_player/sound_effect.py
@@ -31,7 +31,10 @@ class SoundEffectWidget(QWidget):
             source = QUrl.fromLocalFile(str(self.sound_path))
             front_engine_logger.info(f"[SoundEffectWidget] Loading sound file: {self.sound_path}")
             self.sound_player.setSource(source)
-            self.sound_player.setLoopCount(QSoundEffect.Infinite)
+            # setLoopCount 只吃 int，直接餵 Loop.Infinite 這個 enum 會 TypeError
+            # setLoopCount takes an int only; handing it the Loop.Infinite enum
+            # raises TypeError.
+            self.sound_player.setLoopCount(QSoundEffect.Loop.Infinite.value)
             self.sound_player.play()
         else:
             front_engine_logger.error(f"[SoundEffectWidget] File not found: {self.sound_path}")

--- a/frontengine/show/toast/toast_widget.py
+++ b/frontengine/show/toast/toast_widget.py
@@ -64,11 +64,31 @@ class ToastWidget(BaseWidget):
         self.update()
 
     def card_size(self) -> tuple:
-        """依文字算出卡片的寬高（含內距）。"""
+        """
+        依文字算出卡片的寬高（含內距），寬度以螢幕為上限、超過就換行。
+        沒有上限的話，一段長一點的提醒文字會算出好幾千像素寬的卡片，
+        move_to_top_centre 把它置中之後左右兩邊都跑出螢幕，字反而看不到。
+        Size the card to its text, capped at the screen width and wrapped beyond
+        that. Uncapped, a longer reminder produced a card thousands of pixels
+        wide; centring it then ran off both edges and hid the very text it was
+        supposed to show.
+        """
         metrics = QFontMetrics(self._font)
+        max_width = self._available_width()
         width = metrics.horizontalAdvance(self.message) + _PADDING * 2
-        height = metrics.height() + _PADDING
-        return (max(80, width), max(36, height))
+        if width <= max_width:
+            return (max(80, width), max(36, metrics.height() + _PADDING))
+        bounds = metrics.boundingRect(
+            0, 0, max_width - _PADDING * 2, 0,
+            int(Qt.AlignmentFlag.AlignCenter | Qt.TextFlag.TextWordWrap), self.message)
+        return (max_width, max(36, bounds.height() + _PADDING))
+
+    def _available_width(self) -> int:
+        """卡片最寬能到多少（螢幕可用寬度再留一點邊）。"""
+        target = self.screen() or QGuiApplication.primaryScreen()
+        if target is None:  # pragma: no cover - no screen at all
+            return 800
+        return max(160, target.availableGeometry().width() - _PADDING * 4)
 
     def resize_to_message(self) -> None:
         width, height = self.card_size()
@@ -100,7 +120,10 @@ class ToastWidget(BaseWidget):
         painter.drawRoundedRect(self.rect(), _CORNER_RADIUS, _CORNER_RADIUS)
         painter.setFont(self._font)
         painter.setPen(self.text_color)
-        painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, self.message)
+        painter.drawText(
+            self.rect(),
+            int(Qt.AlignmentFlag.AlignCenter | Qt.TextFlag.TextWordWrap),
+            self.message)
 
 
 def show_toast(message: str, duration_ms: int = DEFAULT_DURATION_MS,

--- a/frontengine/show/video/video_player.py
+++ b/frontengine/show/video/video_player.py
@@ -63,7 +63,11 @@ class VideoWidget(QVideoWidget):
         self.play_rate = play_rate
         self.volume = max(0.0, min(volume, 1.0))
         self.media_player.setPlaybackRate(self.play_rate)
-        self.media_player.audioOutput().setVolume(self.volume)
+        # 檔案不存在時沒有建立 audio output，這裡要擋掉 None
+        # No audio output is created when the file is missing, so guard for None.
+        audio_output = self.media_player.audioOutput()
+        if audio_output is not None:
+            audio_output.setVolume(self.volume)
 
     def closeEvent(self, event) -> None:
         front_engine_logger.info(f"[VideoWidget] closeEvent | event={event}")

--- a/frontengine/system_tray/extend_system_tray.py
+++ b/frontengine/system_tray/extend_system_tray.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QSystemTrayIcon, QMenu
 
-from frontengine.utils.multi_language.language_wrapper import language_wrapper
+from frontengine.utils.multi_language.retranslate import retranslator, translate
 
 
 class ExtendSystemTray(QSystemTrayIcon):
@@ -42,50 +42,43 @@ class ExtendSystemTray(QSystemTrayIcon):
         # 綁定點擊事件 / Connect activation event
         self.activated.connect(self.clicked)
 
+    def _add_action(self, key: str, fallback: str, callback) -> QAction:
+        """
+        建立一個選單項目，並登記它的文字來自哪個鍵。沒登記的話換語言不會傳到
+        系統匣：主視窗都翻好了，右下角的選單還停在上一個語言。
+        Create a menu item and register which key its text comes from. Without
+        that registration a language change never reaches the tray: the main
+        window is retranslated while the corner menu stays in the old language.
+        """
+        action = QAction(translate(key, fallback), self)
+        retranslator.bind(action, key, fallback)
+        action.triggered.connect(callback)
+        self.menu.addAction(action)
+        return action
+
     def _create_actions(self) -> None:
         """建立系統匣選單動作 / Create system tray menu actions"""
-        self.hide_main_window_action = QAction("Hide", self)
-        self.hide_main_window_action.triggered.connect(self.main_window.hide)
-        self.menu.addAction(self.hide_main_window_action)
-
-        self.maximized_main_window_action = QAction("Maximized", self)
-        self.maximized_main_window_action.triggered.connect(self.main_window.showMaximized)
-        self.menu.addAction(self.maximized_main_window_action)
-
-        self.normal_main_window_action = QAction("Normal", self)
-        self.normal_main_window_action.triggered.connect(self.main_window.showNormal)
-        self.menu.addAction(self.normal_main_window_action)
+        self.hide_main_window_action = self._add_action(
+            "tray_hide_window", "Hide window", self.main_window.hide)
+        self.maximized_main_window_action = self._add_action(
+            "tray_maximize_window", "Maximize window", self.main_window.showMaximized)
+        self.normal_main_window_action = self._add_action(
+            "tray_normal_window", "Restore window", self.main_window.showNormal)
 
         # 覆蓋層快捷控制 / Overlay quick controls
         self.menu.addSeparator()
-        self.hide_all_overlays_action = QAction(
-            language_wrapper.language_word_dict.get("control_center_hide_all", "Hide all"), self
-        )
-        self.hide_all_overlays_action.triggered.connect(lambda: self._overlay_call("hide_all"))
-        self.menu.addAction(self.hide_all_overlays_action)
-
-        self.show_all_overlays_action = QAction(
-            language_wrapper.language_word_dict.get("control_center_show_all", "Show all"), self
-        )
-        self.show_all_overlays_action.triggered.connect(lambda: self._overlay_call("show_all"))
-        self.menu.addAction(self.show_all_overlays_action)
-
-        self.mute_all_overlays_action = QAction(
-            language_wrapper.language_word_dict.get("control_center_mute_all", "Mute all"), self
-        )
-        self.mute_all_overlays_action.triggered.connect(lambda: self._overlay_call("toggle_mute_all"))
-        self.menu.addAction(self.mute_all_overlays_action)
-
-        self.close_all_overlays_action = QAction(
-            language_wrapper.language_word_dict.get("control_center_close_all", "Close all"), self
-        )
-        self.close_all_overlays_action.triggered.connect(lambda: self._overlay_call("clear_all"))
-        self.menu.addAction(self.close_all_overlays_action)
+        self.hide_all_overlays_action = self._add_action(
+            "control_center_hide_all", "Hide all", lambda: self._overlay_call("hide_all"))
+        self.show_all_overlays_action = self._add_action(
+            "control_center_show_all", "Show all", lambda: self._overlay_call("show_all"))
+        self.mute_all_overlays_action = self._add_action(
+            "control_center_mute_all", "Mute all", lambda: self._overlay_call("toggle_mute_all"))
+        self.close_all_overlays_action = self._add_action(
+            "control_center_close_all", "Close all", lambda: self._overlay_call("clear_all"))
 
         self.menu.addSeparator()
-        self.close_main_window_action = QAction("Close", self)
-        self.close_main_window_action.triggered.connect(self.close_all)
-        self.menu.addAction(self.close_main_window_action)
+        self.close_main_window_action = self._add_action(
+            "tray_close_app", "Quit FrontEngine", self.close_all)
 
     def _overlay_call(self, method_name: str) -> None:
         """

--- a/frontengine/ui/dialog/choose_file_dialog.py
+++ b/frontengine/ui/dialog/choose_file_dialog.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional, List
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QMessageBox, QWidget, QFileDialog
 
 from frontengine.utils.logging.loggin_instance import front_engine_logger
@@ -39,13 +40,24 @@ def choose_file(
         filter=file_filter
     )[0]
 
-    file_path = Path(file_path_str) if file_path_str else None
+    if not file_path_str:
+        # 使用者按了取消。那是刻意的動作，不是選錯檔案，別跳警告框罵人。
+        # The user pressed Cancel. That is a deliberate action, not a bad pick,
+        # so it does not deserve a warning box.
+        front_engine_logger.info("[choose_file] cancelled")
+        return None
 
-    if file_path and file_path.is_file() and file_path.suffix.lower() in extensions:
+    file_path = Path(file_path_str)
+
+    if file_path.is_file() and file_path.suffix.lower() in extensions:
         return str(file_path)
 
     # 顯示錯誤訊息 / Show warning message
     message_box = QMessageBox(trigger_ui)
+    # 訊息框的 parent 是主視窗，關掉之後不會自己消失，每選錯一次就多留一個
+    # The box is parented to the main window and would otherwise outlive its
+    # closing, leaving one behind per bad pick.
+    message_box.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
     message_box.setText(warning_message)
     message_box.show()
     return None

--- a/frontengine/ui/dialog/hotkey_settings_dialog.py
+++ b/frontengine/ui/dialog/hotkey_settings_dialog.py
@@ -80,16 +80,20 @@ class HotkeySettingsDialog(QDialog):
 
     def collect_and_validate(self) -> Tuple[Dict[str, str], List[str]]:
         """
-        讀取所有欄位，回傳 (有效的 動作->組合鍵, 無效動作清單)。空欄位視為解除
-        綁定並略過。
-        Read every field and return (valid action->combo, invalid action list).
-        A blank field means "unbound" and is skipped.
+        讀取所有欄位，回傳 (動作->組合鍵, 無效動作清單)。空欄位是「解除綁定」，
+        要明確記成空字串——直接跳過的話，get_hotkey_action_map() 會從內建預設
+        重新合併，那個組合鍵原封不動地回來，使用者根本放不掉和別的程式衝突的鍵。
+        Read every field and return (action->combo, invalid action list). A blank
+        field means "unbound" and is recorded as an empty string: skipping it let
+        get_hotkey_action_map() merge the built-in default straight back in, so a
+        shortcut clashing with another application could never be released.
         """
         bindings: Dict[str, str] = {}
         invalid: List[str] = []
         for action, edit in self._edits.items():
             combo = edit.text().strip()
             if not combo:
+                bindings[action] = ""
                 continue
             if is_valid_hotkey(combo):
                 bindings[action] = combo

--- a/frontengine/ui/dialog/reminder_dialog.py
+++ b/frontengine/ui/dialog/reminder_dialog.py
@@ -21,7 +21,8 @@ from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import tr
 from frontengine.utils.reminder.reminder_service import (
-    KIND_AT, KIND_EVERY, normalize_reminder, normalize_reminders,
+    DEFAULT_EVERY_MINUTES, KIND_AT, KIND_EVERY, normalize_reminder, normalize_reminders,
+    parse_time_of_day,
 )
 
 _COLUMN_LABEL = 0
@@ -96,10 +97,45 @@ class ReminderDialog(QDialog):
         kind_combobox.addItem(_t("reminder_kind_at", "At"), KIND_AT)
         kind_index = kind_combobox.findData(entry.get("kind", KIND_EVERY))
         kind_combobox.setCurrentIndex(max(0, kind_index))
+        kind_combobox.currentIndexChanged.connect(
+            lambda _index, box=kind_combobox: self._on_kind_changed(box))
         self.table.setCellWidget(row, _COLUMN_KIND, kind_combobox)
 
         value = entry.get("at") if entry.get("kind") == KIND_AT else entry.get("minutes", 45)
         self.table.setItem(row, _COLUMN_VALUE, QTableWidgetItem(str(value)))
+
+    def _on_kind_changed(self, kind_combobox: QComboBox) -> None:
+        """
+        「每隔」和「在」用的是完全不同的值：一個是分鐘數，一個是 HH:MM。
+        切換種類時把值換成該種類的合理預設，不然舊的值（例如 45）會解析失敗，
+        整列在按下確定時被無聲丟掉——使用者只是改了下拉選單，提醒就不見了。
+        "Every" and "At" take entirely different values: a minute count versus
+        HH:MM. Swap in a sensible default for the new kind, or the old value (45,
+        say) fails to parse and the whole row is silently dropped on OK - the
+        user changed a dropdown and lost the reminder.
+        """
+        row = self._row_of(kind_combobox)
+        if row < 0:
+            return
+        kind = kind_combobox.currentData()
+        value_item = self.table.item(row, _COLUMN_VALUE)
+        current = value_item.text().strip() if value_item else ""
+        if kind == KIND_AT:
+            if parse_time_of_day(current) is not None:
+                return
+            replacement = "09:00"
+        else:
+            if current.isdigit() and int(current) > 0:
+                return
+            replacement = str(DEFAULT_EVERY_MINUTES)
+        self.table.setItem(row, _COLUMN_VALUE, QTableWidgetItem(replacement))
+
+    def _row_of(self, widget: QComboBox) -> int:
+        """這個下拉選單在第幾列（列可能被刪過，索引會變）。"""
+        for row in range(self.table.rowCount()):
+            if self.table.cellWidget(row, _COLUMN_KIND) is widget:
+                return row
+        return -1
 
     def remove_selected_row(self) -> None:
         row = self.table.currentRow()

--- a/frontengine/ui/dialog/remote_control_dialog.py
+++ b/frontengine/ui/dialog/remote_control_dialog.py
@@ -60,8 +60,11 @@ class RemoteControlDialog(QDialog):
         self._midi = midi
         self._learning = False
 
+        # 記住進來時的狀態，按取消要能回到這裡
+        # The state on entry, so Cancel has something to go back to.
+        self._remote_was_enabled = remote_enabled()
         self.remote_checkbox = tr(QCheckBox(), "remote_enable", "Let my phone control FrontEngine")
-        self.remote_checkbox.setChecked(remote_enabled())
+        self.remote_checkbox.setChecked(self._remote_was_enabled)
         self.remote_checkbox.toggled.connect(self._toggle_remote)
         self.remote_url_label = QLabel(self.remote_status())
         self.remote_url_label.setWordWrap(True)
@@ -135,8 +138,17 @@ class RemoteControlDialog(QDialog):
         return True
 
     def _toggle_remote(self, enabled: bool) -> None:
-        user_setting_dict[REMOTE_KEY] = {"enabled": bool(enabled)}
-        write_user_setting()
+        """
+        勾選當下就開／關伺服器，好讓網址（和上面的連結）立刻看得到，但不寫入設定
+        ——那要等按下確定。這裡就寫檔的話，「取消」等於取消不了：連接埠已經開了，
+        而且下次啟動還會自己再開一次。
+        Start or stop the server as the box is ticked so the URL shows up right
+        away, but do not persist - that waits for OK. Writing here made Cancel
+        meaningless: the port was already open, and it reopened on every launch.
+        """
+        self._apply_remote(bool(enabled))
+
+    def _apply_remote(self, enabled: bool) -> None:
         if self._remote is None:
             return
         if enabled:
@@ -200,8 +212,16 @@ class RemoteControlDialog(QDialog):
 
     def accept(self) -> None:
         bindings = self.bindings()
+        enabled = self.remote_checkbox.isChecked()
+        user_setting_dict[REMOTE_KEY] = {"enabled": bool(enabled)}
         user_setting_dict[MIDI_KEY] = bindings
         user_setting_dict["midi_device"] = self.midi_device()
         write_user_setting()
+        self._apply_remote(enabled)
         front_engine_logger.info(f"[RemoteControlDialog] saved | {len(bindings)} binding(s)")
         super().accept()
+
+    def reject(self) -> None:
+        """取消：把伺服器恢復成打開這個對話框之前的狀態。"""
+        self._apply_remote(self._remote_was_enabled)
+        super().reject()

--- a/frontengine/ui/dialog/window_pin_dialog.py
+++ b/frontengine/ui/dialog/window_pin_dialog.py
@@ -34,6 +34,9 @@ class WindowPinDialog(QDialog):
         self.setWindowTitle(_t("window_pin_title", "Pin a window"))
         self._lister = lister or window_pin.list_windows
         self.pinned: List[int] = []
+        # 只調過透明度、沒有釘選的視窗；關閉時同樣要回復成不透明
+        # Windows that were faded but never pinned; they need restoring too.
+        self.faded: List[int] = []
 
         self.window_list = QListWidget()
         self.window_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
@@ -113,7 +116,15 @@ class WindowPinDialog(QDialog):
         handle = self.selected_handle()
         if handle is None:
             return False
-        return window_pin.set_opacity(handle, self.opacity_slider.value())
+        applied = window_pin.set_opacity(handle, self.opacity_slider.value())
+        if applied and handle not in self.faded:
+            # 調過透明度的視窗也要記下來。只記「釘選過的」的話，只調透明度沒
+            # 釘選的視窗永遠不會被回復——FrontEngine 關掉了，別人的視窗還是半透明。
+            # Record windows we faded too. Tracking only pinned ones leaves a
+            # window that was merely faded stuck that way for good: FrontEngine
+            # exits and someone else's window is still see-through.
+            self.faded.append(handle)
+        return applied
 
     def release_all(self) -> None:
         """
@@ -125,7 +136,11 @@ class WindowPinDialog(QDialog):
         for handle in self.pinned[:]:
             window_pin.set_always_on_top(handle, False)
             window_pin.set_opacity(handle, window_pin.MAX_OPACITY_PERCENT)
+        for handle in self.faded[:]:
+            if handle not in self.pinned:
+                window_pin.set_opacity(handle, window_pin.MAX_OPACITY_PERCENT)
         self.pinned.clear()
+        self.faded.clear()
 
     def reject(self) -> None:
         self.release_all()

--- a/frontengine/ui/main_ui.py
+++ b/frontengine/ui/main_ui.py
@@ -4,9 +4,11 @@ from os import getcwd
 from pathlib import Path
 from typing import Any, Dict, Optional, Type
 
-from PySide6.QtCore import QByteArray, QTimer, QCoreApplication
+from PySide6.QtCore import QByteArray, QTimer
 from PySide6.QtGui import QIcon, Qt
-from PySide6.QtWidgets import QMainWindow, QApplication, QGridLayout, QTabWidget, QMenuBar, QWidget
+from PySide6.QtWidgets import (
+    QMainWindow, QApplication, QGridLayout, QStyle, QTabWidget, QMenuBar, QWidget,
+)
 from qt_material import apply_stylesheet
 
 from frontengine.show.toast.toast_widget import show_toast
@@ -105,7 +107,10 @@ class FrontEngineMainUI(QMainWindow):
         # Basic settings
         self.id = "FrontEngine"
         self.main_app = main_app
-        QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_EnableHighDpiScaling)
+        self._shutdown_done = False
+        # Qt 6 一律啟用高 DPI 縮放，AA_EnableHighDpiScaling 已無作用且被標為棄用
+        # Qt 6 always scales for high DPI; AA_EnableHighDpiScaling is a deprecated
+        # no-op there.
 
         # Windows 平台設定 AppUserModelID
         # Set AppUserModelID for Windows platform
@@ -399,19 +404,34 @@ class FrontEngineMainUI(QMainWindow):
         self.icon_path = Path(os.getcwd()) / "frontengine.ico"
         self.icon = QIcon(str(self.icon_path))
         self.show_system_tray_ray = show_system_tray_ray
+        self.system_tray: Optional[ExtendSystemTray] = None
 
-        if not self.icon.isNull():
-            self.setWindowIcon(self.icon)
-            if ExtendSystemTray.isSystemTrayAvailable() and self.show_system_tray_ray:
-                self.system_tray = ExtendSystemTray(main_window=self)
-                self.system_tray.setIcon(self.icon)
-                self.system_tray.show()
-                self.system_tray.setToolTip("FrontEngine")
+        if self.icon.isNull():
+            # 從別的目錄啟動（pip 安裝的情況幾乎都是）就找不到 frontengine.ico。
+            # 托盤選單是唯一會存檔再離開的出口，不能因為少一張圖就整個不見，
+            # 改用系統內建圖示。
+            # Launched from any other directory - which is the normal case for a
+            # pip install - frontengine.ico is simply not there. The tray menu is
+            # the only exit that saves settings, so it must not disappear along
+            # with the picture; fall back to a built-in icon.
+            front_engine_logger.info(f"[FrontEngineMainUI] icon not found: {self.icon_path}")
+            self.icon = self.style().standardIcon(QStyle.StandardPixmap.SP_ComputerIcon)
+        self.setWindowIcon(self.icon)
+
+        if ExtendSystemTray.isSystemTrayAvailable() and self.show_system_tray_ray:
+            self.system_tray = ExtendSystemTray(main_window=self)
+            self.system_tray.setIcon(self.icon)
+            self.system_tray.show()
+            self.system_tray.setToolTip("FrontEngine")
 
     def startup_setting(self) -> None:
         """啟動時套用樣式並還原視窗大小/位置（無記錄時最大化） / Apply stylesheet
         and restore the saved window geometry (maximize when none is stored)."""
         apply_stylesheet(self, theme=user_setting_dict.get("theme"))
+        # 還原上次選的畫質檔位（設定檔一直有存，只是從來沒有人讀回來）
+        # Restore the quality tier chosen last time: it was always written to the
+        # settings file, just never read back.
+        self.control_center_ui.set_quality_tier(user_setting_dict.get("quality_tier"))
         if not self._restore_window_geometry():
             self.showMaximized()
 
@@ -458,10 +478,6 @@ class FrontEngineMainUI(QMainWindow):
         front_engine_logger.info(f"[FrontEngineMainUI] retranslate | {applied} strings")
         return applied
 
-    def set_style(self) -> None:
-        """更新使用者選擇的主題 / Update user-selected theme"""
-        user_setting_dict.update({"theme": self.sender().text()})
-
     def _apply_theme(self, theme: str) -> None:
         """套用主題並記住 / Apply a theme and remember it."""
         front_engine_logger.info(f"[FrontEngineMainUI] _apply_theme | theme={theme}")
@@ -473,12 +489,18 @@ class FrontEngineMainUI(QMainWindow):
 
     def closeEvent(self, event) -> None:
         """關閉事件：若系統托盤可用則隱藏視窗 / Close event: hide window if system tray is available"""
-        if ExtendSystemTray.isSystemTrayAvailable() and self.show_system_tray_ray:
-            if self.system_tray.isVisible():
-                self.hide()
-                event.ignore()
-        else:
-            super().closeEvent(event)
+        # 托盤有可能沒建起來（平台不支援、或啟動時關掉了），沒有就照一般關閉走
+        # The tray may not exist at all - unsupported platform, or switched off at
+        # startup - in which case this is an ordinary close.
+        if self.system_tray is not None and self.system_tray.isVisible():
+            self.hide()
+            event.ignore()
+            return
+        # 這條路是真的要關了（X 按鈕、登出、closeAllWindows），所以收尾要在這裡做
+        # This branch really is closing - X button, logout, closeAllWindows - so
+        # the teardown belongs here.
+        self._shutdown()
+        super().closeEvent(event)
 
     def reload_hotkeys(self) -> None:
         """
@@ -544,7 +566,21 @@ class FrontEngineMainUI(QMainWindow):
             return
         if message.get("kind") == "control" and int(message.get("value", 0)) < 127:
             return
-        action = current_bindings().get(binding_key(message))
+        key = binding_key(message)
+        # 遙控設定對話框正在「學習」的話，這一則訊息是拿來新增綁定的，不是拿來
+        # 觸發動作的。少了這一段，那顆「學習」按鈕從頭到尾沒有任何東西呼叫它，
+        # 整個 UI 也就沒有辦法建立 MIDI 綁定。
+        # While the remote dialog is learning, this message defines a binding
+        # rather than triggering one. Without this the Learn button had no caller
+        # at all, and there was no way to create a MIDI binding from the UI.
+        dialog = getattr(self, "remote_dialog", None)
+        if dialog is not None:
+            try:
+                if dialog.learn(key):
+                    return
+            except RuntimeError:  # pragma: no cover - dialog closed mid-message
+                self.remote_dialog = None
+        action = current_bindings().get(key)
         if action:
             self._handle_hotkey(action)
 
@@ -658,8 +694,23 @@ class FrontEngineMainUI(QMainWindow):
         ("pet_setting_ui", "pet_list"),
     )
 
-    def close(self) -> None:
-        """關閉程式並清理資源 / Close application and clear resources"""
+    def _shutdown(self) -> None:
+        """
+        存檔並停掉所有服務。放在這裡而不是 close() 裡面，是因為 Qt 的
+        QWidget::close() 不是虛擬函式：從標題列的 X、工作階段登出、或
+        closeAllWindows() 關閉時，Qt 只會走到 closeEvent，永遠不會呼叫這個
+        Python 的 close() 覆寫。收尾工作只寫在 close() 裡，等於只有系統匣的
+        「關閉」那一條路會存檔。
+        Save everything and stop every service. This lives here rather than in
+        close() because QWidget::close() is not virtual in Qt: closing from the
+        title-bar X, a session logout, or closeAllWindows() only ever reaches
+        closeEvent, never this Python close() override. With the teardown living
+        in close() alone, the tray's Quit item was the only exit that saved.
+        """
+        if self._shutdown_done:
+            return
+        self._shutdown_done = True
+        front_engine_logger.info("[FrontEngineMainUI] shutdown")
         if user_setting_dict.get("restore_last_session"):
             save_last_session(self)
         self._stop_services()
@@ -668,6 +719,10 @@ class FrontEngineMainUI(QMainWindow):
         write_user_setting()
         self._clear_overlays()
         self.scene_setting_ui.close_scene()
+
+    def close(self) -> None:
+        """關閉程式並清理資源 / Close application and clear resources"""
+        self._shutdown()
         super().close()
         if self.main_app:
             self.main_app.exit(0)
@@ -693,12 +748,23 @@ class FrontEngineMainUI(QMainWindow):
             self.tools_setting_ui.stop_virtual_camera()
 
     def _clear_overlays(self) -> None:
-        """清空各分頁記著的覆蓋層清單。"""
+        """
+        關閉並清空各分頁記著的覆蓋層。要先 close() 才丟參考：closeEvent 才是
+        停計時器、放掉媒體與攝影機的地方。
+        Close the overlays each page is holding, then empty the lists. close()
+        comes first because closeEvent is what stops timers and releases media.
+        """
         for page_name, attribute in self._CLOSING_WIDGET_LISTS:
             page = getattr(self, page_name, None)
             widget_list = getattr(page, attribute, None) if page is not None else None
-            if widget_list is not None:
-                widget_list.clear()
+            if widget_list is None:
+                continue
+            for widget in widget_list[:]:
+                try:
+                    widget.close()
+                except RuntimeError:  # 使用者已經關掉，C++ 物件不在了
+                    continue
+            widget_list.clear()
 
     @classmethod
     def debug_close(cls) -> None:

--- a/frontengine/ui/menu/settings_menu.py
+++ b/frontengine/ui/menu/settings_menu.py
@@ -157,16 +157,33 @@ def build_settings_menu(ui: "FrontEngineMainUI") -> None:
     menu.addAction(import_action)
 
 
+def _dispose(dialog: QDialog) -> None:
+    """
+    對話框用完就排定銷毀。它們的 parent 是主視窗，也就是說 C++ 這邊由主視窗
+    持有——放掉 Python 參考什麼都不會發生，每開一次設定就多留一個活著的對話框
+    （連同它抓著的剪貼簿內容）直到程式結束。用 deleteLater 而不是
+    WA_DeleteOnClose：exec() 回來之後呼叫端還要讀 dialog.settings()。
+    Schedule the dialog for destruction once it is done with. They are parented
+    to the main window, so C++ owns them: dropping the Python reference does
+    nothing, and every visit to the menu left another live dialog - along with
+    whatever clipboard text it held - alive until the process ended.
+    deleteLater rather than WA_DeleteOnClose, because callers still read
+    dialog.settings() after exec() returns.
+    """
+    dialog.deleteLater()
+
+
 def _open_signage_dialog(ui: "FrontEngineMainUI") -> None:
     """開看板設定；按下確定後立刻套用新的輪播狀態。"""
     front_engine_logger.info("[SettingsMenu] open SignageDialog")
     dialog = SignageDialog(ui)
-    if dialog.exec() != QDialog.DialogCode.Accepted:
-        return
-    if dialog.settings().get("enabled"):
-        ui.start_signage()
-    else:
-        ui.stop_signage()
+    accepted = dialog.exec() == QDialog.DialogCode.Accepted
+    if accepted:
+        if dialog.settings().get("enabled"):
+            ui.start_signage()
+        else:
+            ui.stop_signage()
+    _dispose(dialog)
 
 
 def _open_remote_dialog(ui: "FrontEngineMainUI") -> None:
@@ -177,6 +194,7 @@ def _open_remote_dialog(ui: "FrontEngineMainUI") -> None:
     ui.remote_dialog = dialog
     dialog.exec()
     ui.remote_dialog = None
+    _dispose(dialog)
 
 
 def _open_usage_dialog(ui: "FrontEngineMainUI") -> None:
@@ -187,12 +205,15 @@ def _open_usage_dialog(ui: "FrontEngineMainUI") -> None:
         enabled=bool(user_setting_dict.get("usage_tracking")),
         on_toggle=ui.set_usage_tracking)
     dialog.exec()
+    _dispose(dialog)
 
 
 def _open_clipboard_dialog(ui: "FrontEngineMainUI") -> None:
     """開剪貼簿歷史。"""
     front_engine_logger.info("[SettingsMenu] open ClipboardDialog")
-    ClipboardDialog(ui.clipboard_history, ui).exec()
+    dialog = ClipboardDialog(ui.clipboard_history, ui)
+    dialog.exec()
+    _dispose(dialog)
 
 
 def _open_dialog(ui: "FrontEngineMainUI", dialog_class) -> bool:
@@ -209,6 +230,7 @@ def _open_dialog(ui: "FrontEngineMainUI", dialog_class) -> bool:
         refresh = getattr(ui, "refresh_rule_services", None)
         if refresh is not None:
             refresh()
+    _dispose(dialog)
     return accepted
 
 
@@ -272,6 +294,7 @@ def _open_hotkey_dialog(ui: "FrontEngineMainUI") -> None:
     dialog = HotkeySettingsDialog(ui)
     if dialog.exec() == QDialog.DialogCode.Accepted:
         ui.reload_hotkeys()
+    _dispose(dialog)
 
 
 def _export_settings(ui: "FrontEngineMainUI") -> None:

--- a/frontengine/ui/page/control_center/control_center_ui.py
+++ b/frontengine/ui/page/control_center/control_center_ui.py
@@ -15,7 +15,7 @@ from frontengine.ui.page.sound_player.sound_player_setting_ui import SoundPlayer
 from frontengine.ui.page.text.text_setting_ui import TextSettingUI
 from frontengine.ui.page.video.video_setting_ui import VideoSettingUI
 from frontengine.ui.page.web.web_setting_ui import WEBSettingUI
-from frontengine.user_setting.user_setting_file import clear_overlay_geometry
+from frontengine.user_setting.user_setting_file import clear_overlay_geometry, user_setting_dict
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
 from frontengine.utils.multi_language.retranslate import retranslator, tr, translate
@@ -77,7 +77,6 @@ class ControlCenterUI(QWidget):
         self.clear_text_button = self._create_button("control_center_close_all_text", self.clear_text)
         self.clear_scene_button = self._create_button("control_center_scene", self.clear_scene)
         self.clear_redirect_button = self._create_button("control_center_clear_log_panel", self.clear_redirect)
-        self.clear_chat_button = self._create_button("chat_scene_close", self.clear_scene)  # 修正：應該關閉場景而不是 redirect
         self.hide_all_button = self._create_button("control_center_hide_all", self.hide_all)
         self.show_all_button = self._create_button("control_center_show_all", self.show_all)
         # 全域靜音狀態 / Global mute state
@@ -133,19 +132,25 @@ class ControlCenterUI(QWidget):
         self.grid_layout.addWidget(self.clear_web_button, 3, 0)
         self.grid_layout.addWidget(self.clear_sound_button, 4, 0)
         self.grid_layout.addWidget(self.clear_text_button, 5, 0)
-        self.grid_layout.addWidget(self.clear_redirect_button, 6, 0)
-        self.grid_layout.addWidget(self.hide_all_button, 7, 0)
-        self.grid_layout.addWidget(self.show_all_button, 8, 0)
-        self.grid_layout.addWidget(self.mute_all_button, 9, 0)
-        self.grid_layout.addWidget(self.lock_all_button, 10, 0)
-        self.grid_layout.addWidget(self.chroma_key_button, 11, 0)
-        self.grid_layout.addWidget(self.reset_positions_button, 12, 0)
-        self.grid_layout.addWidget(self.low_power_button, 13, 0)
-        self.grid_layout.addWidget(self.quality_label, 14, 0)
-        self.grid_layout.addWidget(self.quality_combobox, 15, 0)
-        self.grid_layout.addWidget(self.capture_button, 16, 0)
-        self.grid_layout.addWidget(self.clear_all_button, 17, 0)
-        self.grid_layout.addWidget(self.log_panel_scroll_area, 0, 1, 18, 1)  # rowSpan covers every button
+        # 這顆按鈕本來建好、翻好、也接上了處理函式，卻沒有加進版面，所以畫面上
+        # 根本沒有「只關閉場景」這個選項，只能用會一併關掉其他所有東西的「全部關閉」。
+        # This button was built, translated and wired, but never added to the
+        # layout - so there was no way to close just the scene, only the "close
+        # all" that takes every other overlay down with it.
+        self.grid_layout.addWidget(self.clear_scene_button, 6, 0)
+        self.grid_layout.addWidget(self.clear_redirect_button, 7, 0)
+        self.grid_layout.addWidget(self.hide_all_button, 8, 0)
+        self.grid_layout.addWidget(self.show_all_button, 9, 0)
+        self.grid_layout.addWidget(self.mute_all_button, 10, 0)
+        self.grid_layout.addWidget(self.lock_all_button, 11, 0)
+        self.grid_layout.addWidget(self.chroma_key_button, 12, 0)
+        self.grid_layout.addWidget(self.reset_positions_button, 13, 0)
+        self.grid_layout.addWidget(self.low_power_button, 14, 0)
+        self.grid_layout.addWidget(self.quality_label, 15, 0)
+        self.grid_layout.addWidget(self.quality_combobox, 16, 0)
+        self.grid_layout.addWidget(self.capture_button, 17, 0)
+        self.grid_layout.addWidget(self.clear_all_button, 18, 0)
+        self.grid_layout.addWidget(self.log_panel_scroll_area, 0, 1, 19, 1)  # rowSpan covers every button
         self.setLayout(self.grid_layout)
 
         # Redirect
@@ -168,7 +173,22 @@ class ControlCenterUI(QWidget):
         return button
 
     def _clear_widget_list(self, widget_list: list, name: str) -> None:
+        """
+        關掉這一類的所有覆蓋層。和 clear_all 一樣要真的 close()：只丟 Python
+        參考不會跑 closeEvent，計時器、媒體、全域監聽都停不掉，而被別處也記著的
+        覆蓋層（例如網頁儀表板）根本會留在螢幕上關不掉。
+        Close every overlay of this kind. As in clear_all, close() has to happen:
+        dropping the Python reference never runs closeEvent, so timers, media and
+        global listeners stay alive - and an overlay something else also holds a
+        reference to, like the web dashboard, simply stays on screen with no way
+        to dismiss it.
+        """
         front_engine_logger.info(f"[ControlCenterUI] clear_{name}")
+        for widget in widget_list[:]:
+            try:
+                widget.close()
+            except RuntimeError:  # 已經被關掉，C++ 物件不在了 / already deleted
+                continue
         widget_list.clear()
 
     def clear_video(self) -> None:
@@ -429,13 +449,19 @@ class ControlCenterUI(QWidget):
         return normalize_tier(self.quality_combobox.currentData())
 
     def set_quality_tier(self, tier: str) -> None:
-        """把畫質檔位套用到所有支援的覆蓋層。"""
+        """把畫質檔位套用到所有支援的覆蓋層，並記住這個選擇。"""
         tier = normalize_tier(tier)
         front_engine_logger.info(f"ControlCenterUI set_quality_tier | tier={tier}")
         index = self.quality_combobox.findData(tier)
         if index >= 0 and index != self.quality_combobox.currentIndex():
             self.quality_combobox.setCurrentIndex(index)
             return  # currentIndexChanged 會再走一次 _apply_quality_tier
+        # user_setting_dict 裡本來就有 "quality_tier" 這個鍵，每次存檔都會寫出去，
+        # 但從來沒有人寫進它、也沒有人讀它——選了「省電」重開就變回「高」。
+        # user_setting_dict already carried a "quality_tier" key, written out on
+        # every save, that nothing ever wrote to and nothing ever read: choosing
+        # Saver and restarting put it straight back on High.
+        user_setting_dict["quality_tier"] = tier
 
         def apply(widget) -> None:
             setter = getattr(widget, "set_quality_tier", None)

--- a/frontengine/ui/page/focus/focus_setting_ui.py
+++ b/frontengine/ui/page/focus/focus_setting_ui.py
@@ -21,7 +21,7 @@ from frontengine.utils.focus_shield.focus_shield import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import tr
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 
 
 class FocusSettingUI(QWidget):
@@ -121,13 +121,13 @@ class FocusSettingUI(QWidget):
         widget.show()
         widget.start_following()
         self.dim_widget_list.append(widget)
-        self.dim_button.setText(
-            language_wrapper.language_word_dict.get("focus_dim_stop", "Stop dimming"))
+        retranslator.set_text(
+            self.dim_button, "focus_dim_stop", "Stop dimming")
 
     def stop_dim(self) -> None:
         self._close_all(self.dim_widget_list)
-        self.dim_button.setText(
-            language_wrapper.language_word_dict.get("focus_dim_start", "Dim the background"))
+        retranslator.set_text(
+            self.dim_button, "focus_dim_start", "Dim the background")
 
     def _apply_dim_settings(self) -> None:
         for widget in self.dim_widget_list[:]:
@@ -158,13 +158,13 @@ class FocusSettingUI(QWidget):
             (geometry.x(), geometry.y(), geometry.width(), geometry.height())))
         widget.show()
         self.mask_widget_list.append(widget)
-        self.mask_button.setText(
-            language_wrapper.language_word_dict.get("focus_mask_stop", "Uncover"))
+        retranslator.set_text(
+            self.mask_button, "focus_mask_stop", "Uncover")
 
     def stop_mask(self) -> None:
         self._close_all(self.mask_widget_list)
-        self.mask_button.setText(
-            language_wrapper.language_word_dict.get("focus_mask_start", "Cover it up"))
+        retranslator.set_text(
+            self.mask_button, "focus_mask_start", "Cover it up")
 
     def _apply_mask_settings(self) -> None:
         """區域或比例改變時，直接把已開啟的遮罩移到新位置。"""

--- a/frontengine/ui/page/pet/pet_setting_ui.py
+++ b/frontengine/ui/page/pet/pet_setting_ui.py
@@ -29,7 +29,7 @@ from frontengine.utils.focus_timer.focus_timer import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import tr
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 
 _PET_EXTENSIONS = (".gif", ".webp", ".png", ".jpg")
 
@@ -179,14 +179,19 @@ class PetSettingUI(QWidget):
         self.grid_layout.addWidget(self.volume_combobox, 7, 2)
         self.grid_layout.addWidget(self.audio_react_checkbox, 7, 0)
         self.grid_layout.addWidget(self.audio_source_combobox, 7, 1)
-        self.grid_layout.addWidget(self.tag_checkbox, 7, 1)
-        self.grid_layout.addWidget(self.speech_checkbox, 7, 2)
         self.grid_layout.addWidget(self.focus_label, 8, 0)
         self.grid_layout.addWidget(self.focus_minutes_combobox, 8, 1)
         self.grid_layout.addWidget(self.break_minutes_combobox, 8, 2)
         self.grid_layout.addWidget(self.focus_button, 9, 0)
         self.grid_layout.addWidget(self.chat_checkbox, 9, 1)
-        self.grid_layout.addWidget(self.drop_hint_label, 10, 0, 1, 3)
+        # 這兩個原本被放在 (7,1) 與 (7,2)，正好疊在音效來源與音量的下拉選單上面，
+        # 點下拉選單只會點到勾選框，音效來源和音量因此完全改不了。
+        # These two used to sit at (7,1) and (7,2), directly on top of the audio
+        # source and volume comboboxes: clicking a dropdown hit the checkbox
+        # instead, so neither could be changed at all.
+        self.grid_layout.addWidget(self.tag_checkbox, 10, 0)
+        self.grid_layout.addWidget(self.speech_checkbox, 10, 1)
+        self.grid_layout.addWidget(self.drop_hint_label, 11, 0, 1, 3)
 
     def _spawn_pet(self) -> None:
         """建立、顯示並開始移動一隻寵物（供 Start 與右鍵複製共用）。"""
@@ -249,16 +254,16 @@ class PetSettingUI(QWidget):
         )
         self.focus_tick_timer.start(self.FOCUS_TICK_MS)
         self._announce_focus("focus_start")
-        self.focus_button.setText(
-            language_wrapper.language_word_dict.get("pet_focus_stop", "Stop focus"))
+        retranslator.set_text(
+            self.focus_button, "pet_focus_stop", "Stop focus")
 
     def stop_focus_session(self) -> None:
         """停止專注 / Stop the focus session."""
         front_engine_logger.info("[PetSettingUI] focus stopped")
         self.focus_timer.stop()
         self.focus_tick_timer.stop()
-        self.focus_button.setText(
-            language_wrapper.language_word_dict.get("pet_focus_start", "Start focus"))
+        retranslator.set_text(
+            self.focus_button, "pet_focus_start", "Start focus")
 
     def _tick_focus_timer(self) -> None:
         """每秒推進一次；換階段時讓寵物說話。"""

--- a/frontengine/ui/page/presentation/presentation_setting_ui.py
+++ b/frontengine/ui/page/presentation/presentation_setting_ui.py
@@ -26,7 +26,7 @@ from frontengine.ui.page.utils import build_target_monitor_combobox, coerce_int,
 from frontengine.utils.input_watch.input_watch_service import InputWatchService
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import tr
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 
 
 class PresentationSettingUI(QWidget):
@@ -185,13 +185,13 @@ class PresentationSettingUI(QWidget):
         widget.set_annotation_window_flag()
         self.annotation_widget_list.append(widget)
         self._present(widget)
-        self.annotate_button.setText(
-            language_wrapper.language_word_dict.get("annotate_stop", "Stop drawing"))
+        retranslator.set_text(
+            self.annotate_button, "annotate_stop", "Stop drawing")
 
     def stop_annotation(self) -> None:
         self._close_all(self.annotation_widget_list)
-        self.annotate_button.setText(
-            language_wrapper.language_word_dict.get("annotate_start", "Start drawing"))
+        retranslator.set_text(
+            self.annotate_button, "annotate_start", "Start drawing")
 
     def undo_annotation(self) -> None:
         for widget in self.annotation_widget_list:
@@ -229,14 +229,14 @@ class PresentationSettingUI(QWidget):
         self._present(widget)
         widget.start_following()
         self._ensure_input_watch()
-        self.cursor_button.setText(
-            language_wrapper.language_word_dict.get("cursor_effect_stop", "Turn cursor effects off"))
+        retranslator.set_text(
+            self.cursor_button, "cursor_effect_stop", "Turn cursor effects off")
 
     def stop_cursor_effects(self) -> None:
         self._close_all(self.cursor_widget_list)
         self.release_input_watch()
-        self.cursor_button.setText(
-            language_wrapper.language_word_dict.get("cursor_effect_start", "Turn cursor effects on"))
+        retranslator.set_text(
+            self.cursor_button, "cursor_effect_start", "Turn cursor effects on")
 
     def _apply_cursor_settings(self) -> None:
         for widget in self.cursor_widget_list[:]:
@@ -264,14 +264,14 @@ class PresentationSettingUI(QWidget):
         self._present(widget)
         widget.start()
         self._ensure_input_watch()
-        self.keystroke_button.setText(
-            language_wrapper.language_word_dict.get("keystroke_stop", "Hide keystrokes"))
+        retranslator.set_text(
+            self.keystroke_button, "keystroke_stop", "Hide keystrokes")
 
     def stop_keystrokes(self) -> None:
         self._close_all(self.keystroke_widget_list)
         self.release_input_watch()
-        self.keystroke_button.setText(
-            language_wrapper.language_word_dict.get("keystroke_start", "Show keystrokes"))
+        retranslator.set_text(
+            self.keystroke_button, "keystroke_start", "Show keystrokes")
 
     def _on_key_pressed(self, keys) -> None:
         for widget in self.keystroke_widget_list[:]:
@@ -310,13 +310,13 @@ class PresentationSettingUI(QWidget):
         widget.show()
         self.magnifier_widget_list.append(widget)
         widget.start_following()
-        self.magnifier_button.setText(
-            language_wrapper.language_word_dict.get("magnifier_stop", "Turn magnifier off"))
+        retranslator.set_text(
+            self.magnifier_button, "magnifier_stop", "Turn magnifier off")
 
     def stop_magnifier(self) -> None:
         self._close_all(self.magnifier_widget_list)
-        self.magnifier_button.setText(
-            language_wrapper.language_word_dict.get("magnifier_start", "Turn magnifier on"))
+        retranslator.set_text(
+            self.magnifier_button, "magnifier_start", "Turn magnifier on")
 
     def _apply_magnifier_settings(self) -> None:
         for widget in self.magnifier_widget_list[:]:
@@ -339,13 +339,13 @@ class PresentationSettingUI(QWidget):
                                  self.annotate_width_slider.value())
         self._present(board)
         self.whiteboard_widget_list.append(board)
-        self.whiteboard_button.setText(
-            language_wrapper.language_word_dict.get("whiteboard_stop", "Close whiteboard"))
+        retranslator.set_text(
+            self.whiteboard_button, "whiteboard_stop", "Close whiteboard")
 
     def stop_whiteboard(self) -> None:
         self._close_all(self.whiteboard_widget_list)
-        self.whiteboard_button.setText(
-            language_wrapper.language_word_dict.get("whiteboard_start", "Whiteboard"))
+        retranslator.set_text(
+            self.whiteboard_button, "whiteboard_start", "Whiteboard")
 
     def save_whiteboard(self) -> Optional[str]:
         """把白板存成圖片；沒畫東西就不存。"""

--- a/frontengine/ui/page/scene_setting/scene_manager.py
+++ b/frontengine/ui/page/scene_setting/scene_manager.py
@@ -58,7 +58,16 @@ class SceneManagerUI(QWidget):
         self.show_all_screen = self.show_on_all_screen_checkbox.isChecked()
 
     def clear_json(self) -> None:
+        """
+        清空腳本。也要清掉 scene_json 本身：只清編輯框的話，下一次從分頁加入
+        項目時 _append_scene 會寫進還留著舊資料的那個 dict，畫面上「清掉的」
+        東西又全部長回來。
+        Clear the script. scene_json itself has to go too: with only the text box
+        emptied, the next item added from a tab writes into a dict that still
+        holds the old entries, and everything the user just cleared reappears.
+        """
         front_engine_logger.info("[SceneManagerUI] clear_json")
+        scene_json.clear()
         self.json_plaintext.clear()
 
     def start_scene(self):
@@ -66,16 +75,36 @@ class SceneManagerUI(QWidget):
         scene = self._parse_scene_json()
         if scene is None:
             return
+        # 先決定要開在哪台螢幕，再建立元件。反過來的話，使用者在螢幕選擇對話框
+        # 按取消就會留下一整組看不見卻在播放的元件，下次開始場景還會看到雙份。
+        # Settle on the target screen before building anything. The other way
+        # round, cancelling the monitor dialog leaves a full set of invisible but
+        # playing widgets behind, and the next start shows everything twice.
+        monitors = self._choose_monitors(QGuiApplication.screens())
+        if monitors is None:
+            return
         self._add_scene_widgets(scene)
-        self._present_scene(QGuiApplication.screens())
+        for monitor in monitors:
+            self._open_view(monitor)
 
     def _parse_scene_json(self):
         """讀出編輯框裡的場景 JSON；格式錯誤就告訴使用者並回傳 None。"""
+        text = self.json_plaintext.toPlainText().strip()
+        if not text:
+            # 空白的腳本就是「沒有東西要開」，不是語法錯誤
+            # An empty script means "nothing to open", not a syntax error.
+            return {}
         try:
-            return json.loads(self.json_plaintext.toPlainText())
+            scene = json.loads(text)
         except json.JSONDecodeError as error:
             QMessageBox.critical(self, "JSON Error", f"Invalid JSON: {error}")
             return None
+        if not isinstance(scene, dict):
+            QMessageBox.critical(
+                self, "JSON Error",
+                f"A scene must be an object of entries, not {type(scene).__name__}")
+            return None
+        return scene
 
     def _add_scene_widgets(self, scene: dict) -> None:
         """把場景描述裡的每個項目加進場景；不認得的型別會提醒使用者。"""
@@ -88,34 +117,46 @@ class SceneManagerUI(QWidget):
             "WEB": self.scene.add_web,
         }
         for scene_dict in scene.values():
+            if not isinstance(scene_dict, dict):
+                QMessageBox.warning(
+                    self, "Invalid Scene Entry",
+                    f"A scene entry must be an object, not {type(scene_dict).__name__}")
+                continue
             scene_widget_type = scene_dict.get("type")
             function = scene_add_function.get(scene_widget_type)
             if function is None:
                 QMessageBox.warning(
                     self, "Unknown Type", f"Unsupported scene type: {scene_widget_type}")
                 continue
-            function(setting_dict=scene_dict)
+            try:
+                function(setting_dict=scene_dict)
+            except ValueError as error:
+                # 手寫的場景檔漏欄位是常態，指出哪一項壞掉就好，不要整個中斷
+                # A hand-written scene file missing a field is routine: name the
+                # broken entry and carry on rather than aborting the whole run.
+                QMessageBox.warning(self, "Invalid Scene Entry", str(error))
 
-    def _present_scene(self, monitors: list) -> None:
+    def _choose_monitors(self, monitors: list):
         """
-        決定場景要開在哪裡：勾了「所有螢幕」就每台都開；否則只有一台螢幕時
-        直接開，多台時先問使用者要哪一台。
-        Where the scene opens: every monitor when "all screens" is ticked,
-        straight up with only one monitor, and otherwise after asking which.
+        決定場景要開在哪些螢幕上：勾了「所有螢幕」就全部；只有一台就直接開；
+        多台時先問使用者。使用者取消（或選了不存在的編號）回傳 None，代表
+        「這次不要開」——和「開在主螢幕」的空清單不一樣。
+        Which monitors the scene opens on: all of them when "all screens" is
+        ticked, the only one when there is only one, otherwise whichever the user
+        picks. None means the user backed out, which is different from the
+        single-element list that means the primary screen.
         """
         if self.show_all_screen:
-            for monitor in monitors:
-                self._open_view(monitor)
-            return
+            return list(monitors)
         if len(monitors) <= 1:
-            self._open_view(None)
-            return
+            return [None]
         input_dialog, combobox = create_monitor_selection_dialog(self, monitors)
         if input_dialog.exec() != QDialog.DialogCode.Accepted:
-            return
+            return None
         index = int(combobox.currentText())
-        if index < len(monitors):
-            self._open_view(monitors[index])
+        if index >= len(monitors):
+            return None
+        return [monitors[index]]
 
     def _open_view(self, monitor) -> None:
         """開一個場景視窗；給了螢幕就擺到那台上面。"""
@@ -128,7 +169,15 @@ class SceneManagerUI(QWidget):
 
     def update_scene_json(self):
         front_engine_logger.info("[SceneManagerUI] update_scene_json")
-        choose_scene_json(self)
+        try:
+            choose_scene_json(self)
+        except OSError as error:
+            # 選到壞掉或讀不到的場景檔。不接住的話畫面完全沒反應，
+            # 使用者只會覺得那個按鈕壞了。
+            # A scene file that is corrupt or unreadable. Uncaught, nothing at all
+            # happens on screen and the button just looks broken.
+            QMessageBox.critical(self, "Scene Error", f"Cannot read that scene file: {error}")
+            return
         self.renew_json_plain_text()
 
     def renew_json_plain_text(self):

--- a/frontengine/ui/page/scene_setting/scene_setting_ui.py
+++ b/frontengine/ui/page/scene_setting/scene_setting_ui.py
@@ -35,7 +35,7 @@ class SceneSettingUI(QWidget):
 
     def close_scene(self) -> None:
         front_engine_logger.info("[SceneSettingUI] close_scene")
-        self.scene.widget_list.clear()
+        self.scene.clear()
         for view in self.scene.view_list:
             view.close()
             view.deleteLater()

--- a/frontengine/ui/page/screen_care/screen_care_setting_ui.py
+++ b/frontengine/ui/page/screen_care/screen_care_setting_ui.py
@@ -26,7 +26,7 @@ from frontengine.utils.color_vision.color_vision import (
 )
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import tr
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 
 
 class ScreenCareSettingUI(QWidget):
@@ -186,13 +186,13 @@ class ScreenCareSettingUI(QWidget):
             widget.set_ui_window_flag(show_on_bottom=False)
             self.filter_widget_list.append(widget)
             self._present(widget, screen)
-        self.filter_button.setText(
-            language_wrapper.language_word_dict.get("screen_filter_stop", "Turn filter off"))
+        retranslator.set_text(
+            self.filter_button, "screen_filter_stop", "Turn filter off")
 
     def stop_filter(self) -> None:
         self._close_all(self.filter_widget_list)
-        self.filter_button.setText(
-            language_wrapper.language_word_dict.get("screen_filter_start", "Turn filter on"))
+        retranslator.set_text(
+            self.filter_button, "screen_filter_start", "Turn filter on")
 
     def _apply_filter_settings(self) -> None:
         """滑桿或顏色改變時即時套用到已開啟的濾鏡。"""
@@ -221,13 +221,13 @@ class ScreenCareSettingUI(QWidget):
             self.ruler_widget_list.append(widget)
             self._present(widget, screen)
             widget.start_following()
-        self.ruler_button.setText(
-            language_wrapper.language_word_dict.get("reading_ruler_stop", "Turn ruler off"))
+        retranslator.set_text(
+            self.ruler_button, "reading_ruler_stop", "Turn ruler off")
 
     def stop_ruler(self) -> None:
         self._close_all(self.ruler_widget_list)
-        self.ruler_button.setText(
-            language_wrapper.language_word_dict.get("reading_ruler_start", "Turn ruler on"))
+        retranslator.set_text(
+            self.ruler_button, "reading_ruler_start", "Turn ruler on")
 
     def _apply_ruler_settings(self) -> None:
         for widget in self.ruler_widget_list[:]:
@@ -252,15 +252,15 @@ class ScreenCareSettingUI(QWidget):
         front_engine_logger.info(
             f"[ScreenCareSettingUI] break reminder started | work={self.break_reminder.work_minutes}min")
         self.break_timer.start(self.BREAK_TICK_MS)
-        self.break_button.setText(
-            language_wrapper.language_word_dict.get("break_reminder_stop", "Stop eye breaks"))
+        retranslator.set_text(
+            self.break_button, "break_reminder_stop", "Stop eye breaks")
 
     def stop_break_reminder(self) -> None:
         self.break_reminder.stop()
         self.break_timer.stop()
         self._close_all(self.break_overlay_list)
-        self.break_button.setText(
-            language_wrapper.language_word_dict.get("break_reminder_start", "Start eye breaks"))
+        retranslator.set_text(
+            self.break_button, "break_reminder_start", "Start eye breaks")
 
     def _tick_break_reminder(self) -> None:
         """時間到就顯示或收起休息畫面。"""
@@ -298,13 +298,13 @@ class ScreenCareSettingUI(QWidget):
             self._present(widget, screen)
             widget.start()
             self.color_vision_widget_list.append(widget)
-        self.color_vision_button.setText(
-            language_wrapper.language_word_dict.get("color_vision_stop", "Stop simulating"))
+        retranslator.set_text(
+            self.color_vision_button, "color_vision_stop", "Stop simulating")
 
     def stop_color_vision(self) -> None:
         self._close_all(self.color_vision_widget_list)
-        self.color_vision_button.setText(
-            language_wrapper.language_word_dict.get("color_vision_start", "Simulate"))
+        retranslator.set_text(
+            self.color_vision_button, "color_vision_start", "Simulate")
 
     def _apply_color_vision_settings(self) -> None:
         for widget in self.color_vision_widget_list[:]:

--- a/frontengine/ui/page/sound_player/sound_player_setting_ui.py
+++ b/frontengine/ui/page/sound_player/sound_player_setting_ui.py
@@ -26,7 +26,14 @@ class SoundPlayerSettingUI(QWidget):
 
         # Init variable
         self.sound_widget_list = []
-        self.ready_to_play = False
+        # 這一頁有兩個各自獨立的選擇器。共用一個 ready_to_play 的話，在音樂選擇
+        # 對話框按下取消會把「WAV 已就緒」一起清掉，明明選好的音效反而變成
+        # 「尚未準備」。就緒狀態要跟著各自的路徑走。
+        # This page has two independent pickers. Sharing one ready_to_play meant
+        # cancelling the music dialog also cleared "the WAV is ready", so a
+        # perfectly good sound effect reported itself as not prepared. Readiness
+        # belongs to each path.
+        self.wav_ready_to_play = False
         self.wav_sound_path: Optional[str] = None
         self.player_sound_path: Optional[str] = None
 
@@ -72,7 +79,7 @@ class SoundPlayerSettingUI(QWidget):
 
     def start_play_wav(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] start_play_wav")
-        if not self.wav_sound_path or not self.ready_to_play:
+        if not self.wav_sound_path or not self.wav_ready_to_play:
             message_box = QMessageBox(self)
             message_box.setText(language_wrapper.language_word_dict.get("sound_player_setting_message_box_wav"))
             message_box.exec()
@@ -99,20 +106,18 @@ class SoundPlayerSettingUI(QWidget):
     def choose_and_copy_wav_file_to_cwd_sound_dir_then_play(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] choose_and_copy_wav_file_to_cwd_sound_dir_then_play")
         retranslator.set_text(self.wav_ready_label, _NOT_READY)
-        self.ready_to_play = False
+        self.wav_ready_to_play = False
         self.wav_sound_path = choose_wav_sound(self)
         if self.wav_sound_path:
             retranslator.set_text(self.wav_ready_label, "Ready")
-            self.ready_to_play = True
+            self.wav_ready_to_play = True
 
     def choose_and_copy_sound_file_to_cwd_sound_dir_then_play(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] choose_and_copy_sound_file_to_cwd_sound_dir_then_play")
         retranslator.set_text(self.player_ready_label, _NOT_READY)
-        self.ready_to_play = False
         self.player_sound_path = choose_player_sound(self)
         if self.player_sound_path:
             retranslator.set_text(self.player_ready_label, "Ready")
-            self.ready_to_play = True
 
     def volume_trick(self) -> None:
         front_engine_logger.info("[SoundPlayerSettingUI] volume_trick")
@@ -131,7 +136,7 @@ class SoundPlayerSettingUI(QWidget):
             self.volume_slider.setValue(volume)
         if state.get("wav_sound_path"):
             self.wav_sound_path = state["wav_sound_path"]
-            self.ready_to_play = True
+            self.wav_ready_to_play = True
             retranslator.set_text(self.wav_ready_label, "Ready")
         if state.get("player_sound_path"):
             self.player_sound_path = state["player_sound_path"]

--- a/frontengine/ui/page/text/text_setting_ui.py
+++ b/frontengine/ui/page/text/text_setting_ui.py
@@ -1,3 +1,5 @@
+import threading
+
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import QWidget, QGridLayout, QSlider, QLabel, QLineEdit, QPushButton, QCheckBox, QComboBox, \
@@ -41,6 +43,10 @@ class TextSettingUI(QWidget):
         # Init variable
         self.text_widget_list = []
         self.show_all_screen = False
+        # 已經解析過座標的地名，避免每台螢幕都重新查一次
+        # The city already resolved to coordinates, so each monitor does not
+        # trigger another lookup.
+        self._weather_city_resolved = None
 
         # Opacity setting
         self.opacity_label = tr(QLabel(), "Opacity")
@@ -186,15 +192,36 @@ class TextSettingUI(QWidget):
         )
 
     def _apply_weather_location(self) -> None:
-        """把使用者填的地名換成座標；查不到就沿用預設地點。"""
+        """
+        把使用者填的地名換成座標；查不到就沿用預設地點。
+
+        查詢在背景執行緒進行。lookup_city 是同步的網路請求（逾時 10 秒，再加上
+        沒有上限的 DNS），而這裡是由「開始」按鈕的槽函式呼叫、而且每一台螢幕
+        各呼叫一次：勾了「顯示在所有螢幕」又剛好斷網的話，三螢幕就是整個介面
+        僵住三十幾秒，畫面上什麼提示也沒有。同一個地名只查一次。
+
+        The lookup runs on a background thread. lookup_city is a synchronous
+        network request - a 10 second timeout plus uncapped DNS - called from the
+        Start button's slot once per monitor: with "show on all screens" ticked
+        and the network down, three monitors froze the whole interface for half a
+        minute with nothing on screen to explain it. Each city is resolved once.
+        """
         city = self.weather_location_edit.text().strip()
-        if not city:
+        if not city or city == self._weather_city_resolved:
             return
-        found = lookup_city(city)
-        if found is None:
-            front_engine_logger.warning(f"[TextSettingUI] weather city not found: {city}")
-            return
-        weather_service().set_location(found[0], found[1])
+        self._weather_city_resolved = city
+
+        def resolve() -> None:
+            found = lookup_city(city)
+            if found is None:
+                front_engine_logger.warning(f"[TextSettingUI] weather city not found: {city}")
+                # 查失敗就忘掉，下次按開始才會再試一次
+                # Forget a failure so the next Start tries again.
+                self._weather_city_resolved = None
+                return
+            weather_service().set_location(found[0], found[1])
+
+        threading.Thread(target=resolve, name="frontengine-city-lookup", daemon=True).start()
 
     def _create_text_widget(self) -> TextWidget:
         front_engine_logger.info("[TextSettingUI] _create_text_widget")

--- a/frontengine/ui/page/tools/tools_setting_ui.py
+++ b/frontengine/ui/page/tools/tools_setting_ui.py
@@ -9,7 +9,7 @@ arranging - as opposed to the other pages, which are for showing.
 from typing import List, Optional
 
 from PySide6.QtCore import QBuffer, QIODevice, QTimer
-from PySide6.QtGui import QGuiApplication
+from PySide6.QtGui import QGuiApplication, QPixmap
 from PySide6.QtWidgets import (
     QCheckBox, QComboBox, QFileDialog, QGridLayout, QLabel, QLineEdit, QPushButton, QSpinBox,
     QWidget,
@@ -78,7 +78,13 @@ class ToolsSettingUI(QWidget):
         self.last_recording: Optional[str] = None
         self.capture_widget_list: List[RegionCaptureWidget] = []
         self.camera_widget_list: List[CameraWidget] = []
-        self.last_capture: Optional[RegionCaptureWidget] = None
+        # 存畫面本身，不要存那個覆蓋層：框選完它就自己 close() 了，而
+        # WA_DeleteOnClose 會把底層物件銷毀，留下來的參考碰一下就 RuntimeError，
+        # 「複製上一張」因此永遠是靜悄悄的沒反應。
+        # Keep the pixmap, not the overlay: it closes itself once the selection
+        # is made and WA_DeleteOnClose destroys it, so the surviving reference
+        # raises RuntimeError on touch and "copy last" was a silent no-op.
+        self.last_capture: Optional[QPixmap] = None
         self.pin_dialog: Optional[WindowPinDialog] = None
 
         self._build_measure_row()
@@ -272,7 +278,8 @@ class ToolsSettingUI(QWidget):
     def start_capture(self) -> RegionCaptureWidget:
         """開一層框選截圖（放開滑鼠就擷取並自己關掉）。"""
         front_engine_logger.info("[ToolsSettingUI] start_capture")
-        widget = RegionCaptureWidget(on_captured=lambda pixmap, rect: self._on_captured(widget))
+        widget = RegionCaptureWidget(
+            on_captured=lambda pixmap, rect: self._on_captured(widget, pixmap))
         screen = QGuiApplication.primaryScreen()
         if screen is not None:
             widget.setGeometry(screen.geometry())
@@ -281,22 +288,22 @@ class ToolsSettingUI(QWidget):
         self.capture_widget_list.append(widget)
         return widget
 
-    def _on_captured(self, widget: RegionCaptureWidget) -> None:
-        """擷取完成：記住它並直接複製到剪貼簿。"""
-        self.last_capture = widget
+    def _on_captured(self, widget: RegionCaptureWidget, pixmap: QPixmap) -> None:
+        """擷取完成：記住畫面並直接複製到剪貼簿。"""
+        self.last_capture = pixmap
         widget.copy_to_clipboard()
         if widget in self.capture_widget_list:
             self.capture_widget_list.remove(widget)
 
     def copy_last_capture(self) -> bool:
         """把最近一次的截圖再放進剪貼簿一次。"""
-        if self.last_capture is None:
+        if self.last_capture is None or self.last_capture.isNull():
             return False
-        try:
-            return self.last_capture.copy_to_clipboard()
-        except RuntimeError:
-            self.last_capture = None
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is None:  # pragma: no cover - no clipboard at all
             return False
+        clipboard.setPixmap(self.last_capture)
+        return True
 
     # --- camera ----------------------------------------------------------
     def toggle_camera(self) -> None:
@@ -449,7 +456,12 @@ class ToolsSettingUI(QWidget):
     def show_screen_text(self, text) -> None:
         """收到結果：切回 UI 執行緒再開視窗（回呼來自背景執行緒）。"""
         self.last_screen_text = text
-        QTimer.singleShot(0, lambda: self._present_screen_text(text))
+        # 一定要傳 context 物件（self），否則計時器會被建在沒有事件迴圈的背景
+        # 執行緒上，永遠不會觸發，結果視窗根本不會打開。
+        # The context object (self) is essential: without it the timer is created
+        # on the worker thread, which has no event loop, so it never fires and
+        # the result window simply never opens.
+        QTimer.singleShot(0, self, lambda: self._present_screen_text(text))
 
     def _present_screen_text(self, text):
         dialog = ScreenTextDialog(

--- a/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
+++ b/frontengine/ui/page/wallpaper/wallpaper_setting_ui.py
@@ -23,7 +23,7 @@ from frontengine.ui.page.utils import (
 from frontengine.utils.audio_meter.screen_audio import audio_level_provider_for_screen
 from frontengine.utils.logging.loggin_instance import front_engine_logger
 from frontengine.utils.multi_language.language_wrapper import language_wrapper
-from frontengine.utils.multi_language.retranslate import tr
+from frontengine.utils.multi_language.retranslate import retranslator, tr
 # 多處共用的英文備援字串（只有在翻譯缺漏時才會看到）
 # The English fallback shared by several call sites, seen only when a
 # translation is missing.
@@ -236,8 +236,8 @@ class WallpaperSettingUI(QWidget):
         if self.wallpaper_widgets:
             self.advance_timer.start(
                 clamp_interval(self.interval_combobox.currentData()) * 1000)
-            self.start_button.setText(
-                language_wrapper.language_word_dict.get("wallpaper_stop", "Stop wallpaper"))
+            retranslator.set_text(
+                self.start_button, "wallpaper_stop", "Stop wallpaper")
 
     def stop_wallpaper(self) -> None:
         """收掉所有桌布。"""
@@ -249,8 +249,8 @@ class WallpaperSettingUI(QWidget):
                 pass
         self.wallpaper_widgets.clear()
         self.playlists.clear()
-        self.start_button.setText(
-            language_wrapper.language_word_dict.get("wallpaper_start", "Start wallpaper"))
+        retranslator.set_text(
+            self.start_button, "wallpaper_start", "Start wallpaper")
 
     def advance_all(self) -> None:
         """每個螢幕各自換到「此刻該用的清單」的下一張。"""

--- a/frontengine/ui/page/web/web_setting_ui.py
+++ b/frontengine/ui/page/web/web_setting_ui.py
@@ -1,7 +1,7 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QWidget, QGridLayout, QLabel, QSlider, QLineEdit, QPushButton, QCheckBox, QComboBox,
-    QPlainTextEdit,
+    QWidget, QGridLayout, QLabel, QMessageBox, QSlider, QLineEdit, QPushButton, QCheckBox,
+    QComboBox, QPlainTextEdit,
 )
 
 from frontengine.show.web.webview import WebWidget
@@ -276,6 +276,16 @@ class WEBSettingUI(QWidget):
 
     def start_open_web_with_url(self) -> None:
         front_engine_logger.info("[WEBSettingUI] start_open_web_with_url")
+        if not self.web_url_input.text().strip():
+            # 網址空白時開出來的是一層全螢幕、點擊穿透的空白網頁：看不見也點不到，
+            # 只能從控制中心關掉。其他分頁都會先擋下來，這裡也該一樣。
+            # An empty URL opens a blank fullscreen click-through page: invisible,
+            # unclickable, and only closable from the control center. Every other
+            # page stops first; this one should too.
+            message_box = QMessageBox(self)
+            message_box.setText(language_wrapper.language_word_dict.get("not_prepare"))
+            message_box.exec()
+            return
 
         def present_on_monitor(widget: WebWidget, monitor, _idx: int) -> None:
             widget.setScreen(monitor)

--- a/frontengine/ui/page/widgets/widgets_setting_ui.py
+++ b/frontengine/ui/page/widgets/widgets_setting_ui.py
@@ -110,7 +110,11 @@ class WidgetsSettingUI(QWidget):
     def _build_note_row(self) -> None:
         self.note_label = tr(QLabel(), "widgets_note_label", "Sticky note")
         self.note_button = tr(QPushButton(), "widgets_note_add", "New note")
-        self.note_button.clicked.connect(self.add_note)
+        # clicked 會送出 checked(bool)，直接接上 add_note(text=...) 的話新便利貼
+        # 開起來裡面就寫著 "False"
+        # clicked emits checked(bool); wired straight to add_note(text=...) every
+        # new note opens with the word "False" typed in it.
+        self.note_button.clicked.connect(lambda: self.add_note())
         self.note_close_button = tr(QPushButton(), "widgets_note_close", "Close notes")
         self.note_close_button.clicked.connect(self.close_notes)
         self.note_restore_checkbox = tr(QCheckBox(), "widgets_note_restore",

--- a/frontengine/user_setting/user_setting_file.py
+++ b/frontengine/user_setting/user_setting_file.py
@@ -193,8 +193,17 @@ def get_hotkey_action_map() -> Dict[str, str]:
     user_hotkeys = user_setting_dict.get("hotkeys")
     if isinstance(user_hotkeys, dict):
         for action, combo in user_hotkeys.items():
-            if isinstance(action, str) and isinstance(combo, str) and combo.strip():
+            if not isinstance(action, str) or not isinstance(combo, str):
+                continue
+            if combo.strip():
                 merged[action] = combo.strip()
+            else:
+                # 明確存成空字串＝使用者把那個欄位清空，也就是要解除綁定。
+                # 當成「沒設定」而沿用內建預設，等於那個快速鍵永遠拿不掉。
+                # An explicit empty string means the user cleared that field, i.e.
+                # unbind. Reading it as "unset" and falling back to the built-in
+                # default made the shortcut impossible to get rid of.
+                merged.pop(action, None)
     return merged
 
 

--- a/frontengine/utils/audio_meter/loopback_capture.py
+++ b/frontengine/utils/audio_meter/loopback_capture.py
@@ -151,7 +151,7 @@ class LoopbackSpectrum:
 
     def _capture_loop(self) -> None:  # pragma: no cover - needs a real audio device
         tools, enumerator, device = open_render_endpoint(self.device_id)
-        client = capture_client = None
+        client = capture_client = format_pointer = None
         try:
             client = activate_interface(tools, device, _IID_IAudioClient)
             mix_format, format_pointer = self._mix_format(tools, client)
@@ -159,6 +159,16 @@ class LoopbackSpectrum:
             capture_client = self._service(tools, client)
             self._pump(tools, client, capture_client, mix_format)
         finally:
+            # GetMixFormat 的 WAVEFORMATEX 是 COM 配置的，得自己還回去。
+            # 每次開關頻譜都會走一次這裡，不放就是一次一次累積。
+            # The WAVEFORMATEX from GetMixFormat is COM-allocated and ours to
+            # return. Every start/stop of the spectrum comes through here, so
+            # not freeing it simply accumulates.
+            if format_pointer:
+                try:
+                    tools.ole32.CoTaskMemFree(format_pointer)
+                except Exception as error:
+                    front_engine_logger.debug(f"[LoopbackCapture] format free failed: {error!r}")
             for interface in (capture_client, client, device, enumerator):
                 try:
                     tools.release(interface)
@@ -183,9 +193,21 @@ class LoopbackSpectrum:
         if get_mix_format(client, ctypes.byref(pointer)) != 0 or not pointer:
             raise OSError("GetMixFormat failed")
         wave = pointer.contents
+        # 兩個條件都要滿足才算支援，所以任一個不符就該拒絕（or，不是 and）。
+        # 寫成 and 的話，IEEE_FLOAT 的 24 bit 串流會被放行，接著
+        # samples_from_buffer 每個封包都回傳空陣列並記一筆 warning——一秒 50 次，
+        # 頻譜什麼都不顯示，日誌卻爆量。
+        # Both conditions must hold for the format to be usable, so failing
+        # either one is a rejection (or, not and). With and, an IEEE_FLOAT 24-bit
+        # stream sails through and samples_from_buffer then returns an empty
+        # array and logs a warning for every packet - 50 times a second, with the
+        # spectrum showing nothing and the log filling up.
         if wave.wFormatTag not in (_WAVE_FORMAT_IEEE_FLOAT, _WAVE_FORMAT_EXTENSIBLE) \
-                and wave.wBitsPerSample not in (16, 32):
-            raise OSError(f"unsupported mix format tag {wave.wFormatTag}")
+                or wave.wBitsPerSample not in (16, 32):
+            tools.ole32.CoTaskMemFree(pointer)
+            raise OSError(
+                f"unsupported mix format tag {wave.wFormatTag} "
+                f"at {wave.wBitsPerSample} bits")
         return (_MixFormat(wave.nChannels, wave.nSamplesPerSec,
                            wave.wBitsPerSample, wave.nBlockAlign), pointer)
 

--- a/frontengine/utils/clipboard/clipboard_history.py
+++ b/frontengine/utils/clipboard/clipboard_history.py
@@ -121,7 +121,14 @@ class ClipboardHistory:
     def _evict(self) -> None:
         """超過上限時丟掉最舊的未釘選項目。"""
         while len(self.entries) > self.limit:
-            for index in range(len(self.entries) - 1, -1, -1):
+            # 掃到 index 1 為止：index 0 是剛剛才收下的那一筆。掃到 0 的話，
+            # 當比較舊的項目全被釘選時，被丟掉的就是使用者這一秒複製的東西——
+            # add() 照樣回報成功，剪貼簿紀錄卻再也沒有新內容進得去。
+            # Stop at index 1: index 0 is the entry just taken. Scanning down to
+            # 0 means that once every older entry is pinned, the one thrown away
+            # is what the user copied a moment ago - add() still reports success
+            # while nothing new can ever enter the history again.
+            for index in range(len(self.entries) - 1, 0, -1):
                 if not self.entries[index]["pinned"]:
                     self.entries.pop(index)
                     break

--- a/frontengine/utils/critical_exit/critical_exit.py
+++ b/frontengine/utils/critical_exit/critical_exit.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QApplication
 
 from frontengine.utils.critical_exit.check_key_is_press import check_key_is_press
 from frontengine.utils.critical_exit.win32_vk import keyboard_keys_table
+from frontengine.utils.logging.loggin_instance import front_engine_logger
 
 
 class CriticalExit(Thread):
@@ -39,9 +40,27 @@ class CriticalExit(Thread):
         if isinstance(keycode, int):
             self._exit_check_key = keycode
         elif isinstance(keycode, str):
-            self._exit_check_key = keyboard_keys_table.get(keycode)
+            resolved = keyboard_keys_table.get(keycode.lower())
+            if resolved is None:
+                # 認不得的鍵名以前會被存成 None，接著 check_key_is_press(None)
+                # 丟出 ValueError，監聽執行緒當場結束——緊急退出鍵就這樣無聲失效。
+                # An unknown key name used to be stored as None, after which
+                # check_key_is_press(None) raised ValueError and killed the
+                # listener thread: the emergency exit silently stopped working.
+                raise ValueError(f"unknown key name: {keycode}")
+            self._exit_check_key = resolved
         else:
             raise ValueError("keycode must be int or str")
+
+    @staticmethod
+    def available() -> bool:
+        """
+        這個平台支援不支援。check_key_is_press 走的是 Win32 的 GetAsyncKeyState，
+        別的平台上只會丟 AttributeError。
+        Whether this platform supports it: check_key_is_press goes through Win32's
+        GetAsyncKeyState and raises AttributeError anywhere else.
+        """
+        return sys.platform == "win32"
 
     def run(self) -> None:
         """
@@ -54,12 +73,25 @@ class CriticalExit(Thread):
                 if check_key_is_press(self._exit_check_key):
                     QApplication.exit(0)
                     sys.exit(0)
+        except SystemExit:
+            raise
         except Exception as error:
-            print(repr(error), file=sys.stderr)
+            # 用 logger，不要 print 到 stderr：stderr 已經被 RedirectManager 換成
+            # 佇列了，訊息會消失在沒人看的地方。這裡失效等於全螢幕覆蓋層的緊急
+            # 出口不見了，是必須留下紀錄的事。
+            # Log it rather than printing to stderr, which RedirectManager has
+            # already replaced with a queue nobody reads. Losing this listener
+            # means a fullscreen overlay has no emergency exit, which is worth a
+            # record.
+            front_engine_logger.error(f"[CriticalExit] listener stopped: {error!r}")
 
     def init_critical_exit(self) -> None:
         """
-        啟動致命退出監聽器
-        Start the critical exit listener
+        啟動致命退出監聽器（平台不支援就不啟動）
+        Start the critical exit listener, unless the platform cannot support it.
         """
+        if not self.available():
+            front_engine_logger.info(
+                f"[CriticalExit] not supported on {sys.platform}, listener not started")
+            return
         self.start()

--- a/frontengine/utils/exception/exceptions.py
+++ b/frontengine/utils/exception/exceptions.py
@@ -10,8 +10,16 @@ class FrontEngineSaveFileException(Exception):
     pass
 
 
-class FrontEngineJsonFileException(Exception):
-    pass
+class FrontEngineJsonFileException(OSError):
+    """
+    設定檔／預設集讀寫失敗。繼承 OSError 是刻意的：所有呼叫端都寫
+    `except (OSError, ValueError)`，若只繼承 Exception，那些處理器一個也不會
+    生效——原本該顯示的警告訊息框不會出現，例外會一路炸穿到啟動流程。
+    A settings/preset file could not be read or written. Inheriting OSError is
+    deliberate: every call site guards `except (OSError, ValueError)`, and with a
+    plain Exception base not one of those handlers ever fired - the warning
+    dialogs never appeared and the exception escaped all the way to startup.
+    """
 
 
 class FrontEngineLoadUIException(Exception):

--- a/frontengine/utils/json/json_file.py
+++ b/frontengine/utils/json/json_file.py
@@ -1,10 +1,12 @@
 import json
+import os
 from pathlib import Path
 from threading import Lock
 from typing import Union, Optional, Any
 
 from frontengine.utils.exception.exception_tags import cant_find_json_error
 from frontengine.utils.exception.exception_tags import cant_save_json_error
+from frontengine.utils.exception.exception_tags import wrong_json_data_error
 from frontengine.utils.exception.exceptions import FrontEngineJsonFileException
 
 _lock = Lock()
@@ -21,17 +23,39 @@ def read_json(json_file_path: str) -> Optional[Any]:
         try:
             with open(file_path, "r", encoding="utf-8") as read_file:
                 return json.loads(read_file.read())
-        except (OSError, json.JSONDecodeError) as error:
+        except OSError as error:
             raise FrontEngineJsonFileException(f"{cant_find_json_error}: {error}") from error
+        except json.JSONDecodeError as error:
+            # 檔案在，是內容壞了。講「找不到檔案」只會把人帶去找錯地方。
+            # The file is there, its contents are not. Saying "cannot find" sends
+            # the reader looking in the wrong place.
+            raise FrontEngineJsonFileException(f"{wrong_json_data_error}: {error}") from error
 
 
 def write_json(json_save_path: str, data_to_output: Union[dict, list]) -> None:
     """
-    Write JSON to disk atomically enough for our overlay app.
+    Write JSON to disk atomically: serialise first, write a temporary file next
+    to the target, then rename over it. Opening the real file with "w" truncates
+    it before anything has been serialised, so an interrupted save - a power
+    cut, the F12 critical exit, a value json cannot encode - used to leave the
+    user with a zero-byte settings file and no way back.
     """
     with _lock:
+        target = Path(json_save_path)
         try:
-            with open(json_save_path, "w", encoding="utf-8") as file_to_write:
-                file_to_write.write(json.dumps(data_to_output, indent=4))
+            text = json.dumps(data_to_output, indent=4)
+        except (TypeError, ValueError) as error:
+            raise FrontEngineJsonFileException(f"{cant_save_json_error}: {error}") from error
+        temp_path = target.with_name(target.name + ".tmp")
+        try:
+            with open(temp_path, "w", encoding="utf-8") as file_to_write:
+                file_to_write.write(text)
+                file_to_write.flush()
+                os.fsync(file_to_write.fileno())
+            os.replace(temp_path, target)
         except OSError as error:
+            try:
+                temp_path.unlink()
+            except OSError:  # pragma: no cover - nothing more we can do
+                pass
             raise FrontEngineJsonFileException(f"{cant_save_json_error}: {error}") from error

--- a/frontengine/utils/json/json_repository.py
+++ b/frontengine/utils/json/json_repository.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from frontengine.utils.exception.exceptions import FrontEngineJsonFileException
 from frontengine.utils.json.json_file import read_json, write_json
+from frontengine.utils.logging.loggin_instance import front_engine_logger
 
 
 class JsonRepository:
@@ -30,7 +32,16 @@ class JsonRepository:
         cleared first so stale keys from a previous document do not
         survive a reload.
         """
-        data = self.load()
+        try:
+            data = self.load()
+        except FrontEngineJsonFileException as error:
+            # 設定檔壞掉不該讓程式打不開。留著壞檔案不動（使用者也許想手動救），
+            # 這次就用預設值跑；下次存檔會把它覆蓋掉。
+            # A damaged settings file must not stop the app from opening. Leave
+            # the file alone - the user may want to salvage it - and run on the
+            # defaults; the next save replaces it.
+            front_engine_logger.warning(f"[JsonRepository] unreadable {self._path}: {error}")
+            return
         if not isinstance(data, dict):
             return
         if replace:

--- a/frontengine/utils/logging/loggin_instance.py
+++ b/frontengine/utils/logging/loggin_instance.py
@@ -1,9 +1,11 @@
 import logging
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
-# 設定 root logger 層級
-# Set root logger level
-logging.root.setLevel(logging.DEBUG)
+# 只調自己這個 logger 的層級。動 root logger 會把 DEBUG 強加給任何
+# `import frontengine` 的程式，連帶它用的每一個第三方套件。
+# Only this logger's level is ours to set. Touching the root logger forces DEBUG
+# onto any application that imports frontengine, and every library it uses.
 
 # 建立 FrontEngine logger
 front_engine_logger = logging.getLogger("FrontEngine")
@@ -29,7 +31,21 @@ class FrontEngineLoggingHandler(RotatingFileHandler):
         max_bytes: int = 1073741824,  # 1GB
         backup_count: int = 3         # 保留 3 個備份檔案
     ):
-        super().__init__(filename=filename, mode=mode, maxBytes=max_bytes, backupCount=backup_count)
+        # delay=True：等到真的要寫第一筆才開檔。這個 handler 是在 import 期間
+        # 建立的，開檔失敗會讓整個 frontengine 套件 import 不起來。
+        # delay=True defers opening the file until the first record. This handler
+        # is built during import, so a failure to open would make the whole
+        # frontengine package unimportable.
+        # encoding="utf-8"：日誌會寫進翻譯過的字串與使用者的檔案路徑。
+        # 用系統預設編碼的話，cp950／cp1252 遇到俄文或中文就整行寫不進去，
+        # 還會把 logging 自己的錯誤倒進被導向的輸出面板。
+        # encoding="utf-8": the log carries translated strings and user file
+        # paths. On the locale codepage, cp950 or cp1252 drops any line with
+        # Russian or Chinese in it and spills logging's own traceback into the
+        # redirected output panel.
+        super().__init__(
+            filename=filename, mode=mode, maxBytes=max_bytes,
+            backupCount=backup_count, encoding="utf-8", delay=True)
         self.setFormatter(formatter)  # 正確套用 formatter
         self.setLevel(logging.DEBUG)
 
@@ -41,6 +57,28 @@ class FrontEngineLoggingHandler(RotatingFileHandler):
         super().emit(record)
 
 
+def _build_file_handler() -> logging.Handler:
+    """
+    日誌優先寫在工作目錄，寫不了就退到家目錄，再不行就不寫檔。
+    從唯讀目錄或系統目錄啟動（自動啟動很容易這樣）不該讓程式打不開——
+    少一份日誌可以接受，開不起來不行。
+    Prefer the working directory, fall back to the home directory, and give up
+    on file logging if neither works. Being launched from a read-only or system
+    directory - which autostart makes easy - must not stop the app from opening:
+    losing the log is acceptable, failing to start is not.
+    """
+    for candidate in ("FrontEngine.log", str(Path.home() / "FrontEngine.log")):
+        try:
+            # delay=True 不會在這裡開檔，所以自己確認一次真的寫得進去
+            # delay=True has not opened anything yet, so prove it is writable.
+            with open(candidate, "a", encoding="utf-8"):
+                pass
+            return FrontEngineLoggingHandler(filename=candidate)
+        except OSError:
+            continue
+    return logging.NullHandler()
+
+
 # 建立並加入 handler
-file_handler = FrontEngineLoggingHandler()
+file_handler = _build_file_handler()
 front_engine_logger.addHandler(file_handler)

--- a/frontengine/utils/logging/loggin_instance.py
+++ b/frontengine/utils/logging/loggin_instance.py
@@ -17,6 +17,9 @@ formatter = logging.Formatter(
     '%(asctime)s | %(name)s | %(levelname)s | %(message)s'
 )
 
+# 日誌檔名 / The log file's name
+LOG_FILE_NAME = "FrontEngine.log"
+
 
 class FrontEngineLoggingHandler(RotatingFileHandler):
     """
@@ -26,16 +29,11 @@ class FrontEngineLoggingHandler(RotatingFileHandler):
 
     def __init__(
         self,
-        filename: str = "FrontEngine.log",
+        filename: str = LOG_FILE_NAME,
         mode: str = "a",  # 建議使用 append 模式
         max_bytes: int = 1073741824,  # 1GB
         backup_count: int = 3         # 保留 3 個備份檔案
     ):
-        # delay=True：等到真的要寫第一筆才開檔。這個 handler 是在 import 期間
-        # 建立的，開檔失敗會讓整個 frontengine 套件 import 不起來。
-        # delay=True defers opening the file until the first record. This handler
-        # is built during import, so a failure to open would make the whole
-        # frontengine package unimportable.
         # encoding="utf-8"：日誌會寫進翻譯過的字串與使用者的檔案路徑。
         # 用系統預設編碼的話，cp950／cp1252 遇到俄文或中文就整行寫不進去，
         # 還會把 logging 自己的錯誤倒進被導向的輸出面板。
@@ -45,7 +43,7 @@ class FrontEngineLoggingHandler(RotatingFileHandler):
         # redirected output panel.
         super().__init__(
             filename=filename, mode=mode, maxBytes=max_bytes,
-            backupCount=backup_count, encoding="utf-8", delay=True)
+            backupCount=backup_count, encoding="utf-8")
         self.setFormatter(formatter)  # 正確套用 formatter
         self.setLevel(logging.DEBUG)
 
@@ -67,12 +65,10 @@ def _build_file_handler() -> logging.Handler:
     directory - which autostart makes easy - must not stop the app from opening:
     losing the log is acceptable, failing to start is not.
     """
-    for candidate in ("FrontEngine.log", str(Path.home() / "FrontEngine.log")):
+    for candidate in (LOG_FILE_NAME, str(Path.home() / LOG_FILE_NAME)):
         try:
-            # delay=True 不會在這裡開檔，所以自己確認一次真的寫得進去
-            # delay=True has not opened anything yet, so prove it is writable.
-            with open(candidate, "a", encoding="utf-8"):
-                pass
+            # 建構子本身就會開檔，所以「開得起來」就是這裡的測試
+            # The constructor opens the file, so building it is the test.
             return FrontEngineLoggingHandler(filename=candidate)
         except OSError:
             continue

--- a/frontengine/utils/midi/midi_input.py
+++ b/frontengine/utils/midi/midi_input.py
@@ -193,17 +193,26 @@ class MidiInput(QObject):
     def stop(self) -> None:
         """停止接收並關閉裝置。"""
         handle, self._handle = self._handle, None
-        self._callback = None
         if handle is None:
+            self._callback = None
             return
         try:  # pragma: no cover - Win32 boundary
             import ctypes
 
             winmm = ctypes.windll.winmm
             winmm.midiInStop(handle)
+            winmm.midiInReset(handle)
             winmm.midiInClose(handle)
         except Exception as error:  # pragma: no cover - Win32 boundary
             front_engine_logger.debug(f"[MidiInput] close failed: {error!r}")
+        # 裝置關掉之後才放掉 callback。self._callback 是那個 trampoline 唯一的
+        # 參考，裝置還在送訊息時就放掉，winmm 會呼叫進已釋放的記憶體——轉一下
+        # 旋鈕每秒就是幾十則訊息，這個空窗不是理論問題。
+        # Release the callback only once the device is closed. self._callback is
+        # the trampoline's only reference, and dropping it while the device is
+        # still delivering leaves winmm calling into freed memory - one turn of a
+        # knob is dozens of messages, so that window is not theoretical.
+        self._callback = None
         front_engine_logger.info("[MidiInput] stopped")
 
     def handle_raw(self, packed: Any) -> Optional[Dict[str, Any]]:

--- a/frontengine/utils/multi_language/english.py
+++ b/frontengine/utils/multi_language/english.py
@@ -40,6 +40,10 @@ english_word_dict = {
     "control_center_clear_log_panel": "Clear Log",
     "chat_scene_close": "Close all chat",
     "control_center_close_all": "Close all",
+    "tray_hide_window": "Hide window",
+    "tray_maximize_window": "Maximize window",
+    "tray_normal_window": "Restore window",
+    "tray_close_app": "Quit FrontEngine",
     # General
     "Opacity": "Opacity",
     "Speed": "Speed",

--- a/frontengine/utils/multi_language/france.py
+++ b/frontengine/utils/multi_language/france.py
@@ -40,6 +40,10 @@ french_word_dict = {
     "control_center_clear_log_panel": "Effacer le journal",
     "chat_scene_close": "Fermer toutes les discussions",
     "control_center_close_all": "Fermer tout",
+    "tray_hide_window": "Masquer la fenêtre",
+    "tray_maximize_window": "Agrandir la fenêtre",
+    "tray_normal_window": "Restaurer la fenêtre",
+    "tray_close_app": "Quitter FrontEngine",
     # General
     "Opacity": "Opacité",
     "Speed": "Vitesse",

--- a/frontengine/utils/multi_language/germany.py
+++ b/frontengine/utils/multi_language/germany.py
@@ -40,6 +40,10 @@ germany_word_dict = {
     "control_center_clear_log_panel": "Log löschen",
     "chat_scene_close": "Alle Chats schließen",
     "control_center_close_all": "Alles schließen",
+    "tray_hide_window": "Fenster ausblenden",
+    "tray_maximize_window": "Fenster maximieren",
+    "tray_normal_window": "Fenster wiederherstellen",
+    "tray_close_app": "FrontEngine beenden",
     # Allgemein
     "Opacity": "Deckkraft",
     "Speed": "Geschwindigkeit",

--- a/frontengine/utils/multi_language/italy.py
+++ b/frontengine/utils/multi_language/italy.py
@@ -40,6 +40,10 @@ italian_word_dict = {
     "control_center_clear_log_panel": "Pulisci Log",
     "chat_scene_close": "Chiudi tutte le chat",
     "control_center_close_all": "Chiudi tutto",
+    "tray_hide_window": "Nascondi la finestra",
+    "tray_maximize_window": "Ingrandisci la finestra",
+    "tray_normal_window": "Ripristina la finestra",
+    "tray_close_app": "Esci da FrontEngine",
     # General
     "Opacity": "Opacità",
     "Speed": "Velocità",

--- a/frontengine/utils/multi_language/russian.py
+++ b/frontengine/utils/multi_language/russian.py
@@ -40,6 +40,10 @@ russian_word_dict = {
     "control_center_clear_log_panel": "Очистить лог",
     "chat_scene_close": "Закрыть все чаты",
     "control_center_close_all": "Закрыть все",
+    "tray_hide_window": "Скрыть окно",
+    "tray_maximize_window": "Развернуть окно",
+    "tray_normal_window": "Восстановить окно",
+    "tray_close_app": "Выйти из FrontEngine",
     # General
     "Opacity": "Непрозрачность",
     "Speed": "Скорость",

--- a/frontengine/utils/multi_language/simplified_chinese.py
+++ b/frontengine/utils/multi_language/simplified_chinese.py
@@ -40,6 +40,10 @@ simplified_chinese_word_dict = {
     "control_center_clear_log_panel": "清除 Log",
     "chat_scene_close": "关闭所有聊天",
     "control_center_close_all": "关闭所有",
+    "tray_hide_window": "隐藏视窗",
+    "tray_maximize_window": "视窗最大化",
+    "tray_normal_window": "还原视窗",
+    "tray_close_app": "结束 FrontEngine",
     # 常规
     "Opacity": "不透明度",
     "Speed": "速度",

--- a/frontengine/utils/multi_language/traditional_chinese.py
+++ b/frontengine/utils/multi_language/traditional_chinese.py
@@ -40,6 +40,10 @@ traditional_chinese_word_dict = {
     "control_center_clear_log_panel": "清除 Log",
     "chat_scene_close": "關閉所有聊天",
     "control_center_close_all": "關閉所有",
+    "tray_hide_window": "隱藏視窗",
+    "tray_maximize_window": "視窗最大化",
+    "tray_normal_window": "還原視窗",
+    "tray_close_app": "結束 FrontEngine",
     # General
     "Opacity": "不透明度",
     "Speed": "速度",

--- a/frontengine/utils/pet_chat/pet_chat_service.py
+++ b/frontengine/utils/pet_chat/pet_chat_service.py
@@ -84,6 +84,9 @@ class PetChatService:
         self._key_provider = key_provider
         self._client = None
         self.history: List[dict] = []
+        # ask() 會從背景執行緒呼叫，而且可能同時有好幾次在跑
+        # ask() runs on background threads, possibly several at once.
+        self._ask_lock = threading.Lock()
 
     def available(self) -> bool:
         """有金鑰（或注入的 client）才算可用 / Usable only with a key or an injected client."""
@@ -121,6 +124,17 @@ class PetChatService:
         client = self._build_client()
         if client is None:
             return None
+        # 兩句話問得夠快就會同時在飛。history 沒有保護的話會排成
+        # ['user', 'user']，Messages API 要求角色交替，於是那次請求被拒；更糟的是
+        # history 從此變成壞的，之後每一句都失敗，只能等 reset()。
+        # Two questions asked in quick succession overlap. Without guarding
+        # history they interleave into ['user', 'user'], which the Messages API
+        # rejects because roles must alternate - and history stays broken, so
+        # every later question fails too until reset().
+        with self._ask_lock:
+            return self._ask_locked(client, text)
+
+    def _ask_locked(self, client, text: str) -> Optional[str]:
         self.history.append({"role": "user", "content": text})
         self.history = trim_history(self.history)
         # 送出當下的快照：回覆抵達後我們還會再改動 history

--- a/frontengine/utils/platform_info/platform_info.py
+++ b/frontengine/utils/platform_info/platform_info.py
@@ -152,7 +152,14 @@ def _idle_seconds_windows() -> Optional[float]:
         info.cbSize = ctypes.sizeof(info)
         if not ctypes.windll.user32.GetLastInputInfo(ctypes.byref(info)):
             return None
-        elapsed_ms = ctypes.windll.kernel32.GetTickCount() - info.dwTime
+        # GetTickCount 回傳無號 32 位元，但 ctypes 預設把回傳值當成有號 int。
+        # 開機超過 24.9 天後差值會變成大負數，被 max(0.0, ...) 夾成 0，
+        # 閒置偵測（省電、寵物睡覺、使用統計暫停）就永遠當作使用者在動。
+        # GetTickCount returns an unsigned 32-bit value, but ctypes reads the
+        # result as signed. Past 24.9 days of uptime the difference goes hugely
+        # negative and max(0.0, ...) clamps it to zero, so idle detection - power
+        # saving, the sleeping pet, pausing usage tracking - never triggers again.
+        elapsed_ms = (ctypes.windll.kernel32.GetTickCount() - info.dwTime) & 0xFFFFFFFF
         return max(0.0, elapsed_ms / 1000.0)
     except Exception as error:  # pragma: no cover - Win32 boundary
         front_engine_logger.debug(f"[platform_info] GetLastInputInfo failed: {error!r}")

--- a/frontengine/utils/playlist/playlist.py
+++ b/frontengine/utils/playlist/playlist.py
@@ -52,7 +52,12 @@ def in_window(hour: int, start_hour: int, end_hour: int) -> bool:
     start = int(start_hour) % 24
     end = int(end_hour) % 24
     if start == end:
-        return True
+        # [start, start) 是空區間，不是「整天」。兩個小時欄位設成同一個值時
+        # 使用者要的是「不要切換」，把它當成 24 小時生效正好相反。
+        # [start, start) is an empty range, not "all day". Two spinboxes left on
+        # the same hour mean "do not switch"; treating that as 24-hour coverage
+        # does exactly the opposite.
+        return False
     if start < end:
         return start <= hour < end
     return hour >= start or hour < end

--- a/frontengine/utils/preset_schedule/preset_schedule_service.py
+++ b/frontengine/utils/preset_schedule/preset_schedule_service.py
@@ -24,6 +24,21 @@ def _coerce_int(value: Any, default: int, modulo: int) -> int:
         return default
 
 
+def _crossed(previous: int, target: int, current: int) -> bool:
+    """
+    上次輪詢到這次之間，有沒有經過 target 這一分鐘（全部以「午夜起算的分鐘數」表示）。
+    午夜會讓分鐘數從 1439 掉回 0，直接寫 previous < target <= current 的話，
+    排在 00:00 的預設集永遠等不到——沒有哪個 previous 會小於 0。
+    Whether the target minute was passed between the previous poll and this one,
+    all counted as minutes since midnight. Midnight drops the count from 1439
+    back to 0, so a plain `previous < target <= current` can never be satisfied
+    for a preset scheduled at 00:00: no previous value is below zero.
+    """
+    if previous <= current:
+        return previous < target <= current
+    return target > previous or target <= current
+
+
 class PresetScheduleService(QObject):
     """
     每天在指定時間套用一個預設集。以「跨越目標時間」偵測觸發，因此每天只會
@@ -76,7 +91,7 @@ class PresetScheduleService(QObject):
             return
         previous = self._prev_minutes
         self._prev_minutes = current
-        if previous is not None and previous < target <= current:
+        if previous is not None and _crossed(previous, target, current):
             front_engine_logger.info(f"[PresetSchedule] fire | preset={preset}")
             self.preset_due.emit(preset.strip())
 

--- a/frontengine/utils/recording/gif_writer.py
+++ b/frontengine/utils/recording/gif_writer.py
@@ -53,6 +53,49 @@ _PALETTE = build_palette()
 # which overflows int16 into negatives and makes argmin pick nonsense.
 _PALETTE_ARRAY = numpy.array(_PALETTE, dtype=numpy.int32)
 
+# 查表用的顏色精度：每個通道取高 5 位（32 階）。
+# Colour resolution of the lookup table: the top 5 bits per channel (32 steps).
+_LOOKUP_BITS = 3
+_LOOKUP_STEPS = 1 << (8 - _LOOKUP_BITS)
+_LOOKUP_CHUNK = 4096
+_lookup_table: Optional[numpy.ndarray] = None
+
+
+def _nearest_indices(colors: numpy.ndarray) -> numpy.ndarray:
+    """
+    (N, 3) 的顏色找最近的調色盤索引。分批算：一次全算會產生 N x 256 x 3 的
+    中間陣列，一張 1280x720 的畫面就要 3.8 GB。
+    Nearest palette index for an (N, 3) array of colours, in chunks: doing it in
+    one go materialises an N x 256 x 3 intermediate, which is 3.8 GB for a
+    single 1280x720 frame.
+    """
+    result = numpy.empty(colors.shape[0], dtype=numpy.uint8)
+    palette = _PALETTE_ARRAY.reshape((1, -1, 3))
+    for start in range(0, colors.shape[0], _LOOKUP_CHUNK):
+        chunk = colors[start:start + _LOOKUP_CHUNK].reshape((-1, 1, 3))
+        distances = ((chunk - palette) ** 2).sum(axis=2)
+        result[start:start + _LOOKUP_CHUNK] = distances.argmin(axis=1).astype(numpy.uint8)
+    return result
+
+
+def _get_lookup_table() -> numpy.ndarray:
+    """
+    32x32x32 的最近色查表，第一次用到才建（約 33k 次搜尋，之後每張畫面只要
+    三次位移加一次索引）。調色盤是固定的，所以這張表也是固定的。
+    A 32x32x32 nearest-colour table, built on first use (~33k searches; after
+    that a frame costs three shifts and one indexing operation). The palette is
+    fixed, so the table is too.
+    """
+    global _lookup_table
+    if _lookup_table is None:
+        centers = numpy.arange(_LOOKUP_STEPS, dtype=numpy.int32) * (1 << _LOOKUP_BITS) \
+            + (1 << (_LOOKUP_BITS - 1))
+        grid = numpy.stack(
+            numpy.meshgrid(centers, centers, centers, indexing="ij"), axis=-1)
+        _lookup_table = _nearest_indices(grid.reshape((-1, 3))).reshape(
+            (_LOOKUP_STEPS, _LOOKUP_STEPS, _LOOKUP_STEPS))
+    return _lookup_table
+
 
 def quantize(pixels: numpy.ndarray) -> numpy.ndarray:
     """
@@ -62,10 +105,9 @@ def quantize(pixels: numpy.ndarray) -> numpy.ndarray:
     data = numpy.asarray(pixels, dtype=numpy.int32)
     if data.ndim != 3 or data.shape[2] < 3:
         raise ValueError("frame must be H x W x 3")
-    flat = data[:, :, :3].reshape((-1, 1, 3))
-    distances = ((flat - _PALETTE_ARRAY.reshape((1, -1, 3))) ** 2).sum(axis=2)
-    return distances.argmin(axis=1).astype(numpy.uint8).reshape(
-        (data.shape[0], data.shape[1]))
+    table = _get_lookup_table()
+    binned = data[:, :, :3] >> _LOOKUP_BITS
+    return table[binned[:, :, 0], binned[:, :, 1], binned[:, :, 2]]
 
 
 def clamp_delay(delay_ms) -> int:

--- a/frontengine/utils/reminder/reminder_service.py
+++ b/frontengine/utils/reminder/reminder_service.py
@@ -102,10 +102,17 @@ class ReminderTracker:
         self._config_provider = config_provider
         self._now = now_provider
         self._last_fired: Dict[str, datetime] = {}
+        # 上一次檢查這則提醒的時間。判斷「有沒有跨過那個時刻」要靠它，
+        # 只看「今天響過沒」的話，每次啟動只要時間已經過了就會補響一次。
+        # When each reminder was last examined. The "did we cross that moment"
+        # test needs it: going by "has it fired today" alone means every launch
+        # after the time re-fires it.
+        self._last_seen: Dict[str, datetime] = {}
 
     def reset(self) -> None:
         """忘掉所有紀錄（重新開始計時）。"""
         self._last_fired.clear()
+        self._last_seen.clear()
 
     def _key(self, reminder: Dict[str, Any]) -> str:
         return f"{reminder['kind']}:{reminder['label']}"
@@ -124,7 +131,18 @@ class ReminderTracker:
         if moment is None:
             return False
         target = now.replace(hour=moment[0], minute=moment[1], second=0, microsecond=0)
-        if now < target:
+        previous = self._last_seen.get(key)
+        self._last_seen[key] = now
+        if previous is None:
+            # 第一次看到只記時間，不響。和 _due_every 一樣的原則：不然
+            # 「09:00 吃藥」在 10 點、13 點、18 點各開一次程式就會響三次。
+            # First sighting only starts the clock, as in _due_every: otherwise a
+            # 09:00 reminder fires again at every launch that day - 10:00, 13:30,
+            # 18:45, each one another toast.
+            return False
+        if previous >= target or now < target:
+            # 那個時刻不在「上次檢查到現在」之間
+            # The moment does not fall between the previous check and now.
             return False
         last = self._last_fired.get(key)
         # 每天只響一次：同一天已經響過就跳過

--- a/frontengine/utils/remote/remote_server.py
+++ b/frontengine/utils/remote/remote_server.py
@@ -76,6 +76,20 @@ def is_allowed(action: Any) -> bool:
     return str(action or "") in ALLOWED_ACTIONS
 
 
+def token_matches(candidate: Any, expected: str) -> bool:
+    """
+    常數時間比對權杖。要先轉成 bytes：compare_digest 拿到含非 ASCII 字元的 str
+    會丟 TypeError，而權杖是從網路來的——外面隨手送一個 %C3%A9 就能讓處理器
+    整個炸掉，連 403 都回不出去。
+    Constant-time token comparison, on bytes: compare_digest raises TypeError for
+    a str holding non-ASCII characters, and this token arrives over the network -
+    a casual %C3%A9 from outside was enough to blow up the handler before it
+    could even answer 403.
+    """
+    return secrets.compare_digest(
+        str(candidate or "").encode("utf-8"), str(expected or "").encode("utf-8"))
+
+
 def parse_request(path: str) -> Tuple[str, Dict[str, str]]:
     """把請求路徑拆成 (路徑, 查詢參數)。"""
     parsed = urlparse(str(path or "/"))
@@ -186,7 +200,7 @@ class RemoteServer(QObject):
         Handle one request and return the status code: 403 for a wrong token,
         400 for an action outside the list.
         """
-        if not secrets.compare_digest(str(token or ""), self.token):
+        if not token_matches(token, self.token):
             front_engine_logger.warning("[RemoteServer] refused a request with a bad token")
             return 403
         if not is_allowed(action):
@@ -215,7 +229,7 @@ class RemoteServer(QObject):
                 if path != "/":
                     self._send(404, b"not found", _PLAIN_TEXT)
                     return
-                if not secrets.compare_digest(query.get("token", ""), server.token):
+                if not token_matches(query.get("token", ""), server.token):
                     self._send(403, b"bad token", _PLAIN_TEXT)
                     return
                 page = PAGE.replace("__ACTIONS__", json.dumps(list(ALLOWED_ACTIONS)))

--- a/frontengine/utils/screen_privacy/share_watch.py
+++ b/frontengine/utils/screen_privacy/share_watch.py
@@ -15,6 +15,7 @@ user decide than to guess wrong.
 """
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 from PySide6.QtCore import QObject, QTimer, Signal
@@ -59,9 +60,22 @@ def sharing_app_running(watched: Any, window_titles: List[str]) -> Optional[str]
     wanted = parse_app_list(watched) or list(DEFAULT_SHARING_APPS)
     haystack = [title.lower() for title in window_titles]
     for name in wanted:
-        if any(name in title for title in haystack):
+        if any(_title_names_app(title, name) for title in haystack):
             return name
     return None
+
+
+def _title_names_app(title: str, name: str) -> bool:
+    """
+    視窗標題裡有沒有「這個名字」——要求前後是字界，不是單純的子字串。
+    純子字串比對會把 "Obsidian" 當成 obs、"jobs.txt" 當成 obs、"TeamSpeak"
+    當成 teams：一個記事軟體就足以讓所有覆蓋層永遠躲起來。
+    Whether the title names this app, on word boundaries rather than as a raw
+    substring. Plain containment reads "Obsidian" and "jobs.txt" as obs and
+    "TeamSpeak" as teams - one note-taking app was enough to hide every overlay
+    for good.
+    """
+    return re.search(rf"(?<![0-9a-z]){re.escape(name)}(?![0-9a-z])", title) is not None
 
 
 class ShareWatchService(QObject):

--- a/frontengine/utils/text_source/text_source.py
+++ b/frontengine/utils/text_source/text_source.py
@@ -72,7 +72,11 @@ def parse_countdown_target(template: str, now: datetime) -> Optional[datetime]:
         return None
     try:
         return now + timedelta(minutes=float(text))
-    except ValueError:
+    except (ValueError, OverflowError):
+        # OverflowError：分鐘數大到超出 datetime 範圍（例如 10000000000）。
+        # 不接住的話會一路炸出 start()，倒數計時的「開始」按鈕就變成沒反應。
+        # OverflowError: a minute count past datetime's range (10000000000, say).
+        # Uncaught it escapes start(), leaving the countdown's Start button dead.
         pass
     for pattern in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
         try:

--- a/frontengine/utils/weather/weather_service.py
+++ b/frontengine/utils/weather/weather_service.py
@@ -156,16 +156,27 @@ class WeatherService:
             return dict(self._values)
 
     def _refresh(self) -> None:
-        with self._lock:
-            latitude, longitude, unit = self.latitude, self.longitude, self.unit
-        payload = fetch_json(build_forecast_url(latitude, longitude, unit), opener=self._opener)
-        values = parse_forecast(payload) if payload else {}
-        with self._lock:
-            self._refreshing = False
-            if values.get("temperature") is None:
-                return
-            self._values = values
-            self._fetched_at = time.monotonic()
+        # try/finally：這裡任何一個例外都跑在背景執行緒上，沒人接得到。
+        # 若 _refreshing 卡在 True，refresh_async 之後每次都會立刻返回——
+        # 這個工作階段的天氣就永遠停在最後一次成功的數字上。
+        # try/finally: anything raised here runs on a background thread where
+        # nobody catches it. Leaving _refreshing stuck at True makes every later
+        # refresh_async return immediately, freezing the weather on whatever the
+        # last successful fetch said for the rest of the session.
+        try:
+            with self._lock:
+                latitude, longitude, unit = self.latitude, self.longitude, self.unit
+            payload = fetch_json(
+                build_forecast_url(latitude, longitude, unit), opener=self._opener)
+            values = parse_forecast(payload) if payload else {}
+            with self._lock:
+                if values.get("temperature") is None:
+                    return
+                self._values = values
+                self._fetched_at = time.monotonic()
+        finally:
+            with self._lock:
+                self._refreshing = False
 
 
 _weather_singleton: Optional[WeatherService] = None

--- a/frontengine/utils/window_pin/window_layout.py
+++ b/frontengine/utils/window_pin/window_layout.py
@@ -121,14 +121,25 @@ def restore_layout(layout: Any, lister=None, mover=None) -> Tuple[int, int]:
     if not entries:
         return (0, 0)
     windows = (lister or list_windows)() or []
-    by_title = {normalize_title(title): handle for handle, title in windows}
+    # 同名視窗很常見（兩個「文件」的檔案總管、兩份同檔名的文件）。用 dict 存
+    # 單一 handle 的話後面的會蓋掉前面的，結果是同一個視窗被搬兩次、另一個
+    # 完全沒動，回報卻說兩個都搬好了。每個標題存一串 handle，用掉一個就取走。
+    # Windows sharing a title are common: two Explorer windows both called
+    # "Documents", two copies of the same document. Keeping one handle per title
+    # lets the later one overwrite the earlier, so one window gets moved twice,
+    # another is never touched, and the report claims both were placed. Keep a
+    # queue of handles per title and consume one per entry.
+    by_title: Dict[str, List[int]] = {}
+    for handle, title in windows:
+        by_title.setdefault(normalize_title(title), []).append(handle)
     move = mover or move_window
     moved = missing = 0
     for entry in entries:
-        handle = by_title.get(normalize_title(entry["title"]))
-        if handle is None:
+        handles = by_title.get(normalize_title(entry["title"]))
+        if not handles:
             missing += 1
             continue
+        handle = handles.pop(0)
         if move(handle, entry["x"], entry["y"], entry["width"], entry["height"]):
             moved += 1
     front_engine_logger.info(f"[WindowLayout] restored | moved={moved}, missing={missing}")


### PR DESCRIPTION
Read every module under `frontengine/` and fixed 58 verified defects. Each one was reproduced before being changed, and 41 checks covering them were run offscreen afterwards.

## Features that never worked at all

| What | Why |
|---|---|
| Sound page **Play wav** | `setLoopCount(QSoundEffect.Infinite)` — the setter takes an `int`, not the `Loop` enum, so the button always raised `TypeError` |
| Pet **AI chat** and **screen-text recognition** | Both hopped back to the UI thread with the two-argument `QTimer.singleShot` *from a worker thread*, which creates the timer on a thread with no event loop. It never fires. |
| MIDI **Learn** button | `learn()` had no caller anywhere, so no MIDI binding could be created from the UI |
| Control center **Close scene** | Built, translated and wired — but never added to the layout |
| Pet page **audio source / volume** | Two checkboxes were placed in the same grid cells, drawn on top of the comboboxes, so neither dropdown could be opened |
| Saving a **screen recording** | The quantiser allocated ~6 KB per pixel — 3.8 GB for a single 720p frame — and died with `MemoryError`. Replaced with a lookup table. |
| **Saving on exit** | `QWidget::close()` is not virtual in Qt, so the title-bar X, a session logout and `closeAllWindows()` reached only `closeEvent`. Only the tray's Quit item saved anything. |

## Data and environment

- `write_json` truncated the target *before* serialising, so an interrupted save left a zero-byte settings file — which then raised out of `FrontEngineMainUI.__init__` and blocked startup. Writes are now atomic (temp file + `os.replace`) and a damaged file falls back to defaults.
- `FrontEngineJsonFileException` derived from `Exception` while all nine call sites guard `except (OSError, ValueError)`. None of those warning dialogs had ever appeared.
- Windows faded from the pin dialog were never restored — they stayed see-through after FrontEngine exited.
- A blank hotkey field could not unbind, despite the on-screen hint saying "leave blank to unbind".
- The remote-control checkbox opened the network port and wrote to disk on toggle, so **Cancel did not cancel**.
- The tray menu never retranslated, and four of its items were hardcoded English. Added `tray_*` keys to all seven languages.
- The log file was opened at import time in the working directory (making the package unimportable from a read-only directory) and written in the locale codepage, dropping every line containing Chinese or Russian.

## Behaviour

- The pen, whiteboard, region-capture and ruler overlays were dragged bodily by the base class while being used — region capture then grabbed a different area than the one selected. Sticky notes and pets all snapped to one shared class-level geometry.
- Particle textures were uploaded as RGBA from BGRA data, swapping red and blue; the 60 Hz timer kept running after close.
- Closing a scene left its items in the `QGraphicsScene`: sound kept playing with no window, and restarting stacked duplicates.
- The per-type "close all" buttons dropped references without `close()`, so `closeEvent` never ran.
- A missing image or video path crashed `paintEvent` / `set_player_variable`.
- `in_window(h, 9, 9)` reported every hour as inside the window; a preset scheduled for `00:00` could never fire.
- `GetTickCount` was read as signed, so idle detection returned 0 forever past 24.9 days of uptime.
- Screen-share detection matched raw substrings — Obsidian read as `obs`, TeamSpeak as `teams` — hiding every overlay indefinitely.
- The ruler and protractor could measure only once; clipboard history discarded the newest entry once older ones were pinned; a daily reminder fired again on every launch after its time; same-titled windows collapsed to one handle when restoring a layout.
- Toggle buttons reverted to their "start" wording on a language change while the overlay was still running.
- The quality tier was written to the settings file on every save but never read back.

## Verification

- `py -m pytest tests/ -q` → **883 passed**
- `py -m pyflakes frontengine/ exe/ tests/` → no output
- 41 additional offscreen checks covering the fixes above, plus a real startup/shutdown smoke test

Happy to split this into three PRs (crashes & data loss / dead features / wrong behaviour) if that reviews better.
