### PR TITLE
Add update notes covering everything since the 8 February release

### DIFF
--- a/Update Note.md
+++ b/Update Note.md
@@ -1,0 +1,152 @@
+# Update Notes
+
+## 31 July 2026 — Seven new tabs, and a lot of automation
+
+*Covers everything since the 8 February 2026 release. Current version: 1.0.56.*
+
+FrontEngine started out as a way to put a video, an image or a web page on top of
+your screen and leave it there. It still does that, and nothing about the way you
+do it has changed. What has changed is how much else it can put on screen, and how
+much of it can now happen without you.
+
+This is the largest update the project has had. Seven new tabs, a preset system
+that travels between machines, automation that reacts to what you are doing, and a
+full pass over privacy for anyone who shares their screen for a living.
+
+---
+
+### A pet that lives on your desktop
+
+The **Pet** tab is the headline. Point it at a single image for something simple,
+or at a folder of walk / idle / sleep / climb / fall / drag frames for a pet that
+animates properly.
+
+It walks the floor, wanders freely, or chases your cursor. It climbs window edges
+and sits on the top edge of your windows. Spawn it more than once and two or more
+pets will play tag with each other. Drop a file onto it to feed it; drop an image
+or a pet pack onto it to change how it looks.
+
+It talks, too — short remarks as the day goes on, when it is fed, and so on — and
+it can read those aloud. It can move in time with your speakers or your
+microphone, and it will keep a focus timer for you, with breaks. If you supply
+your own Anthropic API key, you can hold a conversation with it.
+
+### Six more tabs
+
+**Eye Care** — a warm, amber, rose, yellow, green, blue or grey wash over the
+screen with adjustable strength; a reading ruler that follows the cursor; eye
+breaks that dim the screen after so many minutes; and colour-vision simulation
+(protanopia, deuteranopia, tritanopia, achromatopsia) for checking that a design
+still reads.
+
+**Presenting** — draw over whatever is on screen with a pen, highlighter and
+eraser, with undo. Ring the pointer, ripple your clicks, or spotlight everything
+but the cursor. Show the keys you press for recordings. A magnifier from 1.5x to
+6x. And an endless whiteboard you can pan and zoom, which saves an image of the
+area you actually drew on.
+
+**Wallpaper** — a rotating wallpaper that sits below every window, per monitor,
+from 30 seconds to an hour per image, with shuffle and nested folders. It can
+react to what your speakers are playing, and switch to a calmer folder during the
+quiet hours you set.
+
+**Focus** — dim every window except the one you are working in, or cover a single
+distraction: the taskbar strip, a corner, an edge, or the whole screen.
+
+**Widgets** — an audio spectrum as bars or a ring, a CPU / memory / disk / network
+panel, the track your media player is on, and sticky notes that can come back the
+next time FrontEngine starts.
+
+**Tools** — measure things and have the answer land on your clipboard: a colour
+picker that copies as `#rrggbb`, `rgb()`, `hsl()` or a CSS custom property, a pixel
+ruler, and a protractor. Capture a region. Record part of the screen, optionally
+with the camera in the corner. Show any video input — including capture cards — as
+a circle, rounded rectangle or rectangle. Pin another application's window on top
+and change how see-through it is. Save where your windows are and put them back
+later. Read the text in a region to copy, translate or ask a question about it.
+And send an area of your screen, overlays and all, as a webcam that Zoom, Teams or
+Discord can pick as their video source.
+
+---
+
+### Presets that travel
+
+Save everything the pages are set to under a name, and load it back later. Export
+one as a json file to move it between machines, or export a package with the
+images, videos and sounds it refers to as a zip. Pick one to apply automatically
+at startup. Content you subscribe to on Steam can be imported directly.
+
+### It can now run itself
+
+* **Hotkeys** — global shortcuts for hide all, show all, close all, mute all,
+  opacity up and down, next dashboard page, and lock.
+* **App profiles** — apply a preset automatically when a given application comes
+  to the front.
+* **Smart pause** — put the overlays away while a fullscreen application is
+  running, while on battery, or while named applications have focus.
+* **Signage mode** — rotate through a list of presets on a timer, for a machine
+  left running as a display.
+* **Scheduled day/night theme**, **start with the system**, **restore last
+  session**, and **reminders** on an interval or at a time of day.
+* **Remote control** — drive FrontEngine from a phone on the same network, and
+  bind a MIDI controller.
+
+### A Control Center that reaches everything
+
+One page that reaches every overlay, whichever tab opened it: close by kind or
+close all, hide and show, mute, lock and unlock, reset positions, and chroma key
+for keying in OBS. Unlocked overlays can be dragged into place and remember where
+you dropped them. Low power and a High / Balanced / Saver quality setting cut
+refresh rate and render resolution when the battery matters.
+
+### Privacy, taken seriously
+
+* **Hide from capture** keeps overlays on your own screen but leaves them out of
+  what a screen share records.
+* **Screen-sharing privacy** does that automatically while a meeting application
+  is open, matched on window titles so a meeting held in a browser tab is caught
+  too.
+* **Screen time** stays on your machine and is never sent anywhere.
+* **Clipboard history** is kept in memory unless you explicitly ask for it to
+  persist, because clipboards so often hold passwords.
+* Audio-reactive features read a **level** — a single number — and never capture
+  what is being said. The audio spectrum does capture audio to compute
+  frequencies, in memory only; nothing is recorded or sent, and capture stops when
+  you stop the spectrum.
+* The features that use Anthropic's API ask for consent first and use your own
+  `ANTHROPIC_API_KEY`, which is never stored.
+* The phone remote carries a one-time token that changes at every start, and only
+  the buttons on the page can be triggered. It is plain HTTP — leave it off on
+  networks you do not trust.
+
+### Seven languages, switched live
+
+English, Traditional Chinese, Simplified Chinese, German, Russian, French and
+Italian. Changing language no longer needs a restart — the whole interface
+re-labels itself in place.
+
+### A guide inside the application
+
+**Help → How to use...** now explains your first overlay, the settings every page
+shares, and how to clear the screen again, without sending you to a website.
+
+---
+
+### Notes
+
+* Clicks still pass straight through an overlay, so the window underneath keeps
+  working. The two exceptions are the pet and the drawing layer on the Presenting
+  page while drawing is switched on.
+* Some features depend on Windows APIs and are marked as such in the application:
+  audio-reactive overlays, the audio spectrum, pinning another window, hiding
+  overlays from capture, and screen-sharing privacy.
+* The virtual camera needs the optional `pyvirtualcam` package and a virtual
+  camera driver. Without either, the button tells you so.
+* **F12 closes FrontEngine at once**, from anywhere.
+
+### Under the hood
+
+Upgraded to PySide6 6.11.1. The static-analysis debt is cleared and the test suite
+now runs headless in CI, which builds and installs a package from the checked-out
+source so the start-up tests exercise the code in front of them rather than the
+one already published.


### PR DESCRIPTION
The last release was 8 February 2026 (PR #130). Since then 262 commits and
PRs #131-#193 have landed with no announcement. This adds `Update Note.md`
covering that window.

## How the content was established

Not from commit subjects:

- The seven new tabs were confirmed with `git log --diff-filter=A` over
  `frontengine/ui/page/`, so pages that already existed in 2024-2025 are not
  presented as new.
- Feature descriptions come from the English documentation under
  `docs/source/docs/Eng/`, not from paraphrasing branch names.
- The list was checked against `_add_tabs()` in `main_ui.py`, so the note
  describes what a user actually sees.

## Two deliberate omissions

- **The Stream tab is not mentioned.** It was added in #175 and removed in #186
  on the same day, entirely inside this window, so no user ever had it.
  Announcing an addition-and-removal would only confuse.
- **No version range is claimed.** `git show 21d0ed6:stable.toml` reads `1.0.0`
  at the February release, which does not match the 1.0.39/1.0.40 releases
  recorded on PyPI at that time. Rather than assert a range I could not verify,
  the note states only the current version, 1.0.56.

Privacy is given its own section: the audio-reactive features read a level
rather than content, screen time stays local, clipboard history is in memory by
default, and the AI features ask for consent and use the user's own key. Those
facts were scattered across the individual pages and are worth stating together.