### PR TITLE
Correct the progress-log description now that .claude/ is tracked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,17 @@
 
 ## Session Progress Log (check first)
 
-At the start of every session, check `.claude/PROGRESS.md` — a local, git-ignored
-scratch record of in-flight / unfinished work. Read it before planning so you can
-resume where the last session left off.
+At the start of every session, check `.claude/PROGRESS.md` — a scratch record of
+in-flight / unfinished work. Read it before planning so you can resume where the
+last session left off.
 
 - While working: record in-progress and pending items there.
 - When **all** listed items are done (merged/verified), **clear the file** — reset it
   to just its header/instructions, leaving no stale entries.
-- It is local-only (ignored via `/.claude/`); never rely on it being committed.
+- It is tracked, so it survives a fresh clone and reaches other machines. Commit
+  changes to it like any other file, and keep it free of anything that should not
+  be public. Only `.claude/settings.local.json` stays ignored — that one holds
+  machine-local permissions.
 
 ## Project Overview
 


### PR DESCRIPTION
`CLAUDE.md` describes `.claude/PROGRESS.md` as "a local, git-ignored scratch
record" and says to "never rely on it being committed". #195 tracks the
directory, so both statements become wrong the moment it lands — and a rule that
does not match the repository is worse than no rule, because it is followed.

Replaces them with what will actually be true: the file is tracked, commit it
like any other, keep it free of anything that should not be public, and only
`.claude/settings.local.json` stays ignored.

**Merge after #195.** On its own this PR would make `CLAUDE.md` wrong in the
other direction. It touches only `CLAUDE.md`, so it will not conflict with
anything in flight.