### PR TITLE
Stop the release from racing concurrent merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,14 +111,47 @@ jobs:
             exit 1
           fi
 
+      # 推版本號會和「同時被合併的其他 PR」搶 main。之前五個 PR 在 36 秒內合併，
+      # 這一步就被 `cannot lock ref 'refs/heads/main'` 打掉、整個發佈失敗。
+      # main 被推走不是錯誤，是正常情況，rebase 後重試即可；rebase 真的衝突才算失敗。
+      # Pushing the bump races with any PR merged at the same time. Five PRs
+      # merged inside 36 seconds once killed this step with
+      # `cannot lock ref 'refs/heads/main'` and failed the whole release.
+      # main moving is normal, not an error: rebase and retry. Only a genuine
+      # rebase conflict is a failure.
       - name: Commit version bump to main
+        id: commit
         shell: bash
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add stable.toml pyproject.toml
           git commit -m "Bump version to ${{ steps.bump.outputs.version }} [skip ci]"
-          git push origin main
+
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then
+              echo "Pushed the version bump on attempt ${attempt}."
+              break
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Could not push the version bump after 5 attempts."
+              exit 1
+            fi
+            echo "::notice::Push rejected - main moved. Rebasing and retrying."
+            if ! git pull --rebase origin main; then
+              git rebase --abort || true
+              echo "::error::Rebasing the version bump onto main conflicted."
+              exit 1
+            fi
+            sleep 5
+          done
+
+          # 建置與打標籤都要用這個 SHA。rebase 之後 HEAD 會換，而且此時的工作目錄
+          # 已包含期間合併進來的內容——產出的套件與標籤因此指向同一份程式碼。
+          # The build and the tag both use this SHA. HEAD changes after a rebase,
+          # and the tree now carries whatever was merged in the meantime, so the
+          # published distribution and the tag describe the same code.
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Swap in stable project metadata for build
         run: cp stable.toml pyproject.toml
@@ -155,6 +188,12 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: python -m twine upload --non-interactive dist/*
 
+      # 標籤要綁在剛才推上去的那個 commit，不能綁 main。綁 main 的話，發佈期間又有
+      # PR 合併進來，標籤就會落在後來的 commit 上——v1.0.58 就是這樣指到一個
+      # 「不是 1.0.58 實際發佈內容」的 commit。
+      # Tag the commit that was just pushed, not main. With `--target main`, a PR
+      # merged while the release runs moves the tag onto a later commit: that is
+      # how v1.0.58 ended up on a commit that is not what 1.0.58 shipped.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,4 +202,4 @@ jobs:
             dist/* \
             --title "${{ steps.meta.outputs.name }} ${{ steps.bump.outputs.version }}" \
             --generate-notes \
-            --target main
+            --target "${{ steps.commit.outputs.sha }}"


### PR DESCRIPTION
Merging five PRs inside 36 seconds broke the release in two ways. Both are
reproducible races, not one-off bad luck, and either will happen again the next
time two PRs land close together.

## 1. The version-bump push had no retry

The step checks out `main`, bumps, commits and pushes. A PR merged in the
meantime moves `main`, and the push dies:

```
! [remote rejected] main -> main (cannot lock ref 'refs/heads/main':
  is at 79331d3 but expected 31e6426)
```

That failed the entire release before it built or published anything.

`main` moving is normal, not an error. The push now retries up to five times,
rebasing between attempts, and fails only when the rebase genuinely conflicts —
in which case it aborts the rebase and exits with a clear `::error::` rather
than looping.

## 2. The GitHub release was tagged against a moving branch

`gh release create ... --target main` puts the tag on whatever `main` is at that
moment. A merge landing during the run moves it onto a later commit.

This already happened: **`v1.0.58` points at the merge commit for #198**, but the
1.0.58 wheel on PyPI does not contain the UI redesign — verified by downloading
it and checking the archive:

```
1.0.58: ABSENT  frontengine/ui/nav/sidebar.py
1.0.59: present frontengine/ui/nav/sidebar.py
```

The tag now targets the SHA that was just pushed. After a rebase that commit also
carries whatever was merged in the meantime, so the built distribution and the
tag describe the same code.

## Verification

The workflow cannot be run to test this, so the changed step was extracted from
`release.yml` and executed against two throwaway repositories that reproduce the
race — a "runner" about to push its bump while another clone pushes a merge
first:

```
Push rejected - main moved. Rebasing and retrying.
Successfully rebased and updated refs/heads/main.
Pushed the version bump on attempt 2.

sha output:     93ff93f...
that commit:    Bump version to 1.0.1 [skip ci]
version there:  1.0.1
file.txt there: base/merged PR/     <- carries the other PR too
remote main:    93ff93f...          <- the sha IS main's head
RESULT: PASS
```

The conflict path was exercised too: a genuine rebase conflict aborts and exits
1 with the error message rather than retrying blindly.

Every `run:` block in the file was also checked with `bash -n`, and the file
parses as YAML.

## Not changed

`concurrency: group: release` with `cancel-in-progress: false` keeps only the
most recent *queued* run, so rapid merges still cancel intermediate releases —
which is why #196 and #197 produced no release of their own. That is batching
rather than breakage: with these two fixes the run that does win carries
everything merged before it. Worth deciding separately whether every merge
should produce its own version.