### PR TITLE
Record how the Steam announcement is written

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,29 @@ frontengine/
 - **PR rules**: One feature per PR. All CI checks must pass.
 - **Version updates**: `pyproject.toml` = dev version, `stable.toml` = stable version.
 
+## Release Announcements
+
+`Update Note.txt` is the announcement posted to Steam. It is **BBCode, not
+Markdown** — Steam renders no Markdown, so `**bold**` and `### heading` would
+appear literally in the announcement.
+
+- `[h2]…[/h2]`, `[b]…[/b]`, `[list]` / `[*]` / `[/list]`, `[hr][/hr]`.
+- There is no inline code. Write variable names and formats as plain prose, or
+  leave them out — for a reader on Steam they are noise either way.
+- **One paragraph per line, however long.** Steam turns a single newline into a
+  hard line break, so text wrapped at 80 columns arrives broken mid-sentence.
+- The file is `.txt` on purpose: BBCode in a `.md` renders as noise on GitHub.
+- No title inside the file — Steam has its own title field.
+- **Do not pin a version number in it.** The file lives in this repository, so
+  correcting the number is a merge, and every merge to `main` bumps the version;
+  whatever number is written is wrong the moment it lands. State the window the
+  announcement covers instead — the start of that window does not move.
+- Screenshots have to be uploaded to Steam first and referenced by the URL it
+  returns, so `[img]` tags are added by whoever posts it, not here.
+
+Announce what a user can see. A change that only affects the repository —
+workflow fixes, lint debt, tracked files — does not belong in it.
+
 ## Build & Run
 
 ```bash


### PR DESCRIPTION
`Update Note.txt` carries two conventions that are not guessable from looking at
it, and both were learned by getting them wrong first.

**It is BBCode, not Markdown.** Steam renders no Markdown, so the notes as
originally written would have shown `**bold**` and `### heading` literally in the
announcement.

**Each paragraph is one line, however long.** Steam turns a single newline into a
hard line break. Wrapped at 80 columns — the obvious thing to do to a text file
in a repository — every paragraph arrives broken mid-sentence.

Also recorded, for the same reason:

- No version number in the file. It lives in this repository, so correcting the
  number is a merge, and every merge to `main` bumps the version; whatever number
  is written is wrong the moment it lands. This already happened once.
- `.txt` rather than `.md`, since BBCode in a `.md` renders as noise on GitHub.
- No title in the file — Steam has its own title field.
- `[img]` tags are added by whoever posts it, because screenshots have to be
  uploaded to Steam first and referenced by the URL it returns.
- Announce what a user can see. Workflow fixes and lint debt do not belong in it.

Documentation only; no code touched. 901 tests still pass.